### PR TITLE
refactor: tighten tool exposure levels

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -5,6 +5,12 @@
 from enum import Enum, auto
 
 
+class ExposureLevel(str, Enum):
+    NONE = "none"
+    FILE_ONLY = "file_only"
+    DOCUMENT_FULL = "document_full"
+
+
 class OfficeType(Enum):
     WORD = auto()
     EXCEL = auto()
@@ -91,6 +97,20 @@ FILE_TOOLS = (
     "export_document",
     "convert_to_pdf",
     "convert_from_pdf",
+)
+
+FILE_ONLY_TOOLS = (
+    "read_file",
+    "convert_to_pdf",
+    "convert_from_pdf",
+)
+
+DOCUMENT_FULL_TOOLS = (
+    *FILE_ONLY_TOOLS,
+    "create_document",
+    "add_blocks",
+    "finalize_document",
+    "export_document",
 )
 
 EXPLICIT_FILE_TOOL_EVENT_KEY = "office_assistant_explicit_file_tool_name"

--- a/constants.py
+++ b/constants.py
@@ -107,6 +107,7 @@ FILE_ONLY_TOOLS = (
 
 DOCUMENT_FULL_TOOLS = (
     *FILE_ONLY_TOOLS,
+    "create_office_file",
     "create_document",
     "add_blocks",
     "finalize_document",

--- a/constants.py
+++ b/constants.py
@@ -11,6 +11,13 @@ class ExposureLevel(str, Enum):
     DOCUMENT_FULL = "document_full"
 
 
+class ExposureDeniedReason(str, Enum):
+    GROUP_FEATURE_DISABLED = "group_feature_disabled"
+    MISSING_PERMISSION = "missing_permission"
+    MISSING_GROUP_TRIGGER = "missing_group_trigger"
+    NO_RELEVANT_INTENT = "no_relevant_intent"
+
+
 class OfficeType(Enum):
     WORD = auto()
     EXCEL = auto()

--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -601,6 +601,28 @@ class DocumentSessionStore:
             document = self.require_document(document_id)
             return self._build_prompt_summary_locked(document)
 
+    def build_latest_prompt_summary_for_session(
+        self, session_id: str
+    ) -> dict[str, object] | None:
+        normalized_session_id = str(session_id or "").strip()
+        if not normalized_session_id:
+            return None
+        with self._lock:
+            self._evict_expired_locked()
+            candidates = [
+                document
+                for document in self._documents.values()
+                if document.session_id == normalized_session_id
+                and document.status != DocumentStatus.EXPORTED
+            ]
+            if not candidates:
+                return None
+            latest_document = max(
+                candidates,
+                key=lambda document: document.metadata.updated_at,
+            )
+            return self._build_prompt_summary_locked(latest_document)
+
     @staticmethod
     def _build_prompt_summary_locked(document: DocumentModel) -> dict[str, object]:
         latest_block_types = [

--- a/internal_hooks.py
+++ b/internal_hooks.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from inspect import isawaitable
 from typing import Any
 
+from .constants import ExposureLevel
 from .domain.document.hooks import (
     AfterExportContext,
     AfterExportHook,
@@ -43,6 +44,8 @@ class NoticeBuildContext:
     should_expose: bool
     can_process_upload: bool
     explicit_tool_name: str | None
+    exposure_level: ExposureLevel = ExposureLevel.NONE
+    allowed_tool_names: tuple[str, ...] = ()
     notices: list[str] = field(default_factory=list)
     section_names: list[str] = field(default_factory=list)
 
@@ -54,6 +57,8 @@ class ToolExposureContext:
     should_expose: bool
     can_process_upload: bool
     explicit_tool_name: str | None
+    exposure_level: ExposureLevel = ExposureLevel.NONE
+    allowed_tool_names: tuple[str, ...] = ()
 
 
 NoticeBuildHook = Callable[

--- a/prompts/scenes/uploaded_file.py
+++ b/prompts/scenes/uploaded_file.py
@@ -45,18 +45,24 @@ def build_uploaded_file_scene_notice(
     *,
     file_count: int,
     allow_external_input_files: bool,
+    document_workflow: bool = False,
 ) -> str:
     file_requirement = (
         "MUST 先调用 `read_file` 读取此文件"
         if file_count == 1
         else "MUST 先调用 `read_file` 依次读取这些文件"
     )
+    follow_up_rule = (
+        "2. 如果用户目标明确是整理成文档、报告、汇报或 Word，读取成功后必须直接调用 `create_document`，随后继续完成直到 `export_document` 成功，不要停下来只回复过渡说明。\n"
+        if document_workflow
+        else "2. 如果用户意图明确，读取后按需处理；如果意图不清楚，读取后用中文追问用户。\n"
+    )
     return (
         "\n[操作要求]\n"
         f"1. {file_requirement}，不要自行猜测文件名，也不要列目录或调用 shell。"
         f"{_build_relative_path_rule(allow_external_input_files=allow_external_input_files)}"
         "在读取前 NEVER 创建新文档。\n"
-        "2. 如果用户意图明确，读取后按需处理；如果意图不清楚，读取后用中文追问用户。\n"
+        f"{follow_up_rule}"
         "3. 所有面向用户的回复 MUST 使用中文。\n"
     )
 
@@ -130,7 +136,7 @@ def build_buffered_upload_prompt(
             + "1. 优先围绕这些上传文件完成用户请求。\n"
             + "2. 先调用 `read_file` 读取文件，不要自行猜测文件名，也不要列目录或调用 shell。\n"
             + relative_path_guidance
-            + "4. 如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取后继续调用相应工具完成结果，不要停下来只回复过渡说明。\n"
+            + "4. 如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取成功后必须直接调用 `create_document`，随后继续完成直到 `export_document` 成功，不要停下来只回复过渡说明。\n"
             + "5. 所有面向用户的回复 MUST 使用中文。"
         )
 

--- a/prompts/static/__init__.py
+++ b/prompts/static/__init__.py
@@ -1,4 +1,4 @@
-from .access import build_tools_denied_notice
+from .access import build_file_only_notice, build_tools_denied_notice
 from .document_tools import (
     build_document_tools_core_notice,
     build_document_tools_detail_notice,
@@ -9,5 +9,6 @@ __all__ = [
     "build_document_tools_core_notice",
     "build_document_tools_detail_notice",
     "build_document_tools_guide_notice",
+    "build_file_only_notice",
     "build_tools_denied_notice",
 ]

--- a/prompts/static/access.py
+++ b/prompts/static/access.py
@@ -7,3 +7,13 @@ def build_tools_denied_notice() -> str:
         " 或 `astrbot_execute_ipython` 绕过限制。\n"
         "4. NEVER 尝试任何变通方案来绕过以上限制。"
     )
+
+
+def build_file_only_notice() -> str:
+    return (
+        "\n[System Notice] 文件处理规则\n"
+        "1. 需要读取内容时，先调用 `read_file`。\n"
+        "2. 不要猜测文件名，不要列目录，也不要调用 shell。\n"
+        "3. 只做文件读取或 PDF 转换时，不要擅自进入 Word 文档工具链。\n"
+        "4. 所有面向用户的回复 MUST 使用中文。"
+    )

--- a/prompts/static/document_tools.py
+++ b/prompts/static/document_tools.py
@@ -24,7 +24,7 @@ def build_document_tools_core_notice() -> str:
         "- `export_document` 会直接发送文件给用户\n"
         "\n"
         "[约束规则]\n"
-        "1. 如果用户请求依赖上传文件，MUST 先调用 `read_file` 读取内容，再创建文档。\n"
+        "1. 如果用户请求依赖上传文件且目标是文档、报告、汇报或 Word，MUST 先调用 `read_file` 读取内容；读取成功后立刻调用 `create_document`，不要停下来只发过渡说明。\n"
         "2. 如果 `read_file` 返回文件不存在或路径非法，NEVER 调用网络搜索；直接请用户重新上传。\n"
         "3. 如果用户显式指定了某个工具名和参数，MUST 先按该工具调用；即使预期会报错，也不要擅自改调其他工具，也不要自行修改参数后重试。\n"
         "4. 一旦开始使用文档工具链，MUST 持续调用直到 `export_document` 成功，中途不要停下来发自然语言回复。\n"

--- a/services/intent_patterns.py
+++ b/services/intent_patterns.py
@@ -26,16 +26,16 @@ FILE_INTENT_RE = re.compile(
     r"(read_file|convert_to_pdf|convert_from_pdf|"
     r"读取.*文件|查看.*文件|看看.*文件|读取内容|读取这个|"
     r"\bpdf\b|转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
-    r"pdf转word|pdf转excel)",
+    r"pdf\s*转\s*word|pdf\s*转\s*excel|word\s*转\s*pdf|excel\s*转\s*pdf)",
     flags=re.IGNORECASE,
 )
 
 PDF_CONVERSION_INTENT_RE = re.compile(
     r"(convert_to_pdf|convert_from_pdf|"
-    r"pdf转word|pdf转excel|"
+    r"pdf\s*转\s*word|pdf\s*转\s*excel|word\s*转\s*pdf|excel\s*转\s*pdf|"
     r"转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
-    r"\bpdf\b.*(?:转word|转excel|导出|转换)|"
-    r"(?:转word|转excel).*\bpdf\b)",
+    r"pdf.*(?:转\s*word|转\s*excel|导出|转换)|"
+    r"(?:转\s*word|转\s*excel).*pdf)",
     flags=re.IGNORECASE,
 )
 

--- a/services/intent_patterns.py
+++ b/services/intent_patterns.py
@@ -1,0 +1,160 @@
+import re
+from collections.abc import Iterable
+
+
+NEGATIVE_TOOL_PREFIX_RE = re.compile(
+    r"(?:不要|别|勿|不用|无需|do\s+not|don't|not)\s*(?:调用|使用|call|use|invoke)?\s*$",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_ID_RE = re.compile(
+    r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_INTENT_RE = re.compile(
+    r"(create_document|add_blocks|finalize_document|export_document|"
+    r"document_id\b|整理成\s*(?:文档|报告|汇报|word|docx)|"
+    r"导出成\s*word|导出为\s*word|生成\s*(?:文档|报告|汇报|word|docx)|"
+    r"生成\s*(?:excel|xlsx|表格|powerpoint|ppt|幻灯片)|"
+    r"\bword\b|\bdocx\b|\bexcel\b|\bxlsx\b|\bpowerpoint\b|\bppt\b|"
+    r"文档|报告|汇报|表格|幻灯片)",
+    flags=re.IGNORECASE,
+)
+
+FILE_INTENT_RE = re.compile(
+    r"(read_file|convert_to_pdf|convert_from_pdf|"
+    r"读取.*文件|查看.*文件|看看.*文件|读取内容|读取这个|"
+    r"\bpdf\b|转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
+    r"pdf转word|pdf转excel)",
+    flags=re.IGNORECASE,
+)
+
+PDF_CONVERSION_INTENT_RE = re.compile(
+    r"(convert_to_pdf|convert_from_pdf|"
+    r"pdf转word|pdf转excel|"
+    r"转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
+    r"\bpdf\b.*(?:转word|转excel|导出|转换)|"
+    r"(?:转word|转excel).*\bpdf\b)",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_FOLLOWUP_RE = re.compile(
+    r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_FOLLOWUP_ACTION_RE = re.compile(
+    r"(导出|发给我|加一章|加一节|补充|再加)",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_FOLLOWUP_SHORT_RE = re.compile(
+    r"^(继续|接着|继续写|继续补充|继续完善|补充|完善|导出|发给我)$",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_FOLLOWUP_TOPICAL_RE = re.compile(
+    r"(文档|报告|汇报|正文|内容|段落|章节|小节|标题|表格|草稿|这一章|这一节|上一段|下一段|上一版)",
+    flags=re.IGNORECASE,
+)
+
+DOCUMENT_DETAIL_HINT_RE = re.compile(
+    r"(create_document|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
+    r"\bword\b|\bdocx\b|汇报|报告|"
+    r"生成\s*(?:word|docx|报告|汇报)|整理成\s*(?:word|docx|报告|汇报)|"
+    r"business_report|project_review|executive_brief|accent_color|document_style)",
+    flags=re.IGNORECASE,
+)
+
+
+def extract_document_id(text: str) -> str | None:
+    if not text:
+        return None
+    match = DOCUMENT_ID_RE.search(text)
+    if not match:
+        return None
+    return match.group("document_id")
+
+
+def detect_explicit_file_tool(text: str, file_tools: Iterable[str]) -> str | None:
+    if not text:
+        return None
+
+    explicit_matches: set[str] = set()
+    tool_invocation_prefix = (
+        r"(?:调用|使用|请求(?:调用|使用)?|请(?!问)(?:调用|使用)?|"
+        r"\b(?:call|use|invoke)\b|\bplease\s+(?:call|use|invoke)\b)"
+    )
+
+    for tool_name in sorted(file_tools, key=len, reverse=True):
+        patterns = (
+            rf"(?P<tool>{tool_invocation_prefix}\s*`?{re.escape(tool_name)}`?)",
+            rf"(?P<tool>`{re.escape(tool_name)}`)",
+            rf"(?P<tool>{re.escape(tool_name)}\s*\()",
+            rf"(?P<tool>{re.escape(tool_name)}\s*[,，]\s*[a-zA-Z_]\w*\s*=)",
+        )
+        for pattern in patterns:
+            for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+                tool_start = match.start("tool")
+                prefix = text[max(0, tool_start - 20) : tool_start]
+                if NEGATIVE_TOOL_PREFIX_RE.search(prefix):
+                    continue
+                explicit_matches.add(tool_name)
+                break
+
+    if len(explicit_matches) == 1:
+        return next(iter(explicit_matches))
+    return None
+
+
+def has_document_intent(text: str) -> bool:
+    return bool(extract_document_id(text) or DOCUMENT_INTENT_RE.search(text or ""))
+
+
+def has_file_intent(text: str) -> bool:
+    return bool(FILE_INTENT_RE.search(text or ""))
+
+
+def has_pdf_conversion_intent(text: str) -> bool:
+    return bool(PDF_CONVERSION_INTENT_RE.search(text or ""))
+
+
+def looks_like_document_followup(text: str) -> bool:
+    normalized_text = str(text or "").strip()
+    if not normalized_text:
+        return False
+    if DOCUMENT_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
+        return True
+    if not DOCUMENT_FOLLOWUP_RE.search(normalized_text):
+        return False
+    if DOCUMENT_FOLLOWUP_TOPICAL_RE.search(normalized_text):
+        return True
+    return bool(DOCUMENT_FOLLOWUP_ACTION_RE.search(normalized_text))
+
+
+def should_use_active_document_summary(text: str) -> bool:
+    normalized_text = str(text or "").strip()
+    if not normalized_text:
+        return False
+    if DOCUMENT_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
+        return True
+    return bool(
+        DOCUMENT_FOLLOWUP_RE.search(normalized_text)
+        and (
+            DOCUMENT_FOLLOWUP_TOPICAL_RE.search(normalized_text)
+            or DOCUMENT_FOLLOWUP_ACTION_RE.search(normalized_text)
+        )
+    )
+
+
+def should_inject_document_tool_detail(
+    *,
+    request_text: str,
+    document_id: str | None,
+) -> bool:
+    if not request_text:
+        return False
+    if document_id and not DOCUMENT_DETAIL_HINT_RE.search(request_text):
+        return False
+    return bool(DOCUMENT_DETAIL_HINT_RE.search(request_text))

--- a/services/intent_patterns.py
+++ b/services/intent_patterns.py
@@ -26,13 +26,17 @@ FILE_INTENT_RE = re.compile(
     r"(read_file|convert_to_pdf|convert_from_pdf|"
     r"读取.*文件|查看.*文件|看看.*文件|读取内容|读取这个|"
     r"\bpdf\b|转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
-    r"pdf\s*转\s*word|pdf\s*转\s*excel|word\s*转\s*pdf|excel\s*转\s*pdf)",
+    r"pdf.*转(?:成)?\s*word|pdf.*转(?:成)?\s*excel|"
+    r"word\s*转\s*pdf|word\s*转成\s*pdf|"
+    r"excel\s*转\s*pdf|excel\s*转成\s*pdf)",
     flags=re.IGNORECASE,
 )
 
 PDF_CONVERSION_INTENT_RE = re.compile(
     r"(convert_to_pdf|convert_from_pdf|"
-    r"pdf\s*转\s*word|pdf\s*转\s*excel|word\s*转\s*pdf|excel\s*转\s*pdf|"
+    r"pdf.*转(?:成)?\s*word|pdf.*转(?:成)?\s*excel|"
+    r"word\s*转\s*pdf|word\s*转成\s*pdf|"
+    r"excel\s*转\s*pdf|excel\s*转成\s*pdf|"
     r"转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
     r"pdf.*(?:转\s*word|转\s*excel|导出|转换)|"
     r"(?:转\s*word|转\s*excel).*pdf)",

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -185,6 +185,11 @@ class LLMRequestPolicy:
             return None
         return self._request_hook_service.get_active_document_prompt_summary(event)
 
+    def _has_session_upload_infos(self, event: AstrMessageEvent) -> bool:
+        if self._request_hook_service is None:
+            return False
+        return bool(self._request_hook_service.get_session_upload_infos(event))
+
     @staticmethod
     def _should_append_denied_notice(
         denied_reason: ExposureDeniedReason | None,
@@ -289,7 +294,9 @@ class LLMRequestPolicy:
 
         has_uploaded_files = self._has_uploaded_file_component(event)
         has_buffered_upload = bool(getattr(event, "_buffered", False))
+        has_cached_uploads = self._has_session_upload_infos(event)
         has_current_upload = has_uploaded_files or has_buffered_upload
+        has_upload_context = has_current_upload or has_cached_uploads
         active_document_summary = self._get_active_document_summary(event)
         has_active_document = bool(active_document_summary)
         has_document_id = bool(extract_document_id_from_text(request_text))
@@ -312,11 +319,11 @@ class LLMRequestPolicy:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_pdf_conversion_intent:
             exposure_level = ExposureLevel.FILE_ONLY
-        elif has_current_upload and has_document_intent:
+        elif has_upload_context and has_document_intent:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_document_intent:
             exposure_level = ExposureLevel.DOCUMENT_FULL
-        elif has_current_upload or has_file_intent:
+        elif has_upload_context or has_file_intent:
             exposure_level = ExposureLevel.FILE_ONLY
         else:
             exposure_level = ExposureLevel.NONE

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass
 
+import astrbot.api.message_components as Comp
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from astrbot.core.platform.message_type import MessageType
@@ -9,9 +10,12 @@ from astrbot.core.provider.entities import ProviderRequest
 
 from ..constants import (
     DOC_COMMAND_TRIGGER_EVENT_KEY,
+    DOCUMENT_FULL_TOOLS,
     EXECUTION_TOOLS,
     EXPLICIT_FILE_TOOL_EVENT_KEY,
+    ExposureLevel,
     FILE_TOOLS,
+    FILE_ONLY_TOOLS,
 )
 from ..internal_hooks import (
     NoticeBuildContext,
@@ -30,6 +34,32 @@ class LLMRequestPolicy:
         r"(?:不要|别|勿|不用|无需|do\s+not|don't|not)\s*(?:调用|使用|call|use|invoke)?\s*$",
         flags=re.IGNORECASE,
     )
+    _DOCUMENT_ID_RE = re.compile(
+        r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_INTENT_RE = re.compile(
+        r"(create_document|add_blocks|finalize_document|export_document|"
+        r"document_id\b|整理成\s*(?:文档|报告|汇报|word|docx)|"
+        r"导出成\s*word|导出为\s*word|生成\s*(?:文档|报告|汇报|word|docx)|"
+        r"\bword\b|\bdocx\b|文档|报告|汇报)",
+        flags=re.IGNORECASE,
+    )
+    _FILE_INTENT_RE = re.compile(
+        r"(read_file|convert_to_pdf|convert_from_pdf|"
+        r"读取.*文件|查看.*文件|看看.*文件|读取内容|读取这个|"
+        r"\bpdf\b|转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
+        r"pdf转word|pdf转excel)",
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_FOLLOWUP_RE = re.compile(
+        r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_FOLLOWUP_ACTION_RE = re.compile(
+        r"(导出|发给我|加一章|加一节|补充|再加)",
+        flags=re.IGNORECASE,
+    )
     _BUFFERED_USER_INSTRUCTION_RE = re.compile(
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
@@ -41,6 +71,10 @@ class LLMRequestPolicy:
         has_permission: bool
         can_process_upload: bool
         should_expose: bool
+        exposure_level: ExposureLevel
+        allowed_tool_names: tuple[str, ...]
+        active_document_summary: dict[str, object] | None
+        denied_reason: str | None
 
     def __init__(
         self,
@@ -187,6 +221,76 @@ class LLMRequestPolicy:
             ),
         )
 
+    @staticmethod
+    def _extract_document_id(text: str) -> str | None:
+        if not text:
+            return None
+        match = LLMRequestPolicy._DOCUMENT_ID_RE.search(text)
+        if not match:
+            return None
+        return match.group("document_id")
+
+    @staticmethod
+    def _has_uploaded_file_component(event: AstrMessageEvent) -> bool:
+        return any(
+            isinstance(component, Comp.File)
+            for component in (getattr(event.message_obj, "message", None) or [])
+        )
+
+    def _get_cached_upload_infos(self, event: AstrMessageEvent) -> list[dict[str, object]]:
+        if self._request_hook_service is None:
+            return []
+        return self._request_hook_service.get_cached_upload_infos(event)
+
+    def _get_active_document_summary(
+        self, event: AstrMessageEvent
+    ) -> dict[str, object] | None:
+        if self._request_hook_service is None:
+            return None
+        return self._request_hook_service.get_active_document_prompt_summary(event)
+
+    @classmethod
+    def _looks_like_document_followup(cls, text: str) -> bool:
+        normalized_text = str(text or "").strip()
+        if not normalized_text:
+            return False
+        if not cls._DOCUMENT_FOLLOWUP_RE.search(normalized_text):
+            return False
+        if len(normalized_text) <= 24:
+            return True
+        return bool(cls._DOCUMENT_FOLLOWUP_ACTION_RE.search(normalized_text))
+
+    @staticmethod
+    def _allowed_tool_names_for_level(
+        exposure_level: ExposureLevel,
+    ) -> tuple[str, ...]:
+        if exposure_level == ExposureLevel.FILE_ONLY:
+            return tuple(FILE_ONLY_TOOLS)
+        if exposure_level == ExposureLevel.DOCUMENT_FULL:
+            return tuple(DOCUMENT_FULL_TOOLS)
+        return ()
+
+    def _apply_allowed_file_tools(
+        self,
+        req: ProviderRequest,
+        *,
+        exposure_level: ExposureLevel,
+    ) -> tuple[str, ...]:
+        if not req.func_tool:
+            return ()
+
+        allowed_tool_names = self._allowed_tool_names_for_level(exposure_level)
+        if exposure_level == ExposureLevel.DOCUMENT_FULL:
+            for tool in self._document_toolset.tools:
+                if tool.name in allowed_tool_names:
+                    req.func_tool.add_tool(tool)
+
+        allowed_tool_set = set(allowed_tool_names)
+        for tool_name in FILE_TOOLS:
+            if tool_name not in allowed_tool_set:
+                req.func_tool.remove_tool(tool_name)
+        return allowed_tool_names
+
     def _resolve_exposure_decision(
         self,
         event: AstrMessageEvent,
@@ -195,9 +299,8 @@ class LLMRequestPolicy:
         is_group: bool,
         is_friend: bool,
     ) -> ExposureDecision:
-        explicit_tool_name = self._detect_explicit_file_tool(
-            self._extract_explicit_tool_text(event, req)
-        )
+        request_text = self._extract_explicit_tool_text(event, req)
+        explicit_tool_name = self._detect_explicit_file_tool(request_text)
         has_permission = self._check_permission(event)
         can_process_upload = has_permission or event.is_admin()
         get_extra = getattr(event, "get_extra", None)
@@ -212,14 +315,74 @@ class LLMRequestPolicy:
             or self._is_bot_mentioned(event)
             or doc_command_triggered
         )
-        should_expose = (is_friend and event.is_admin()) or (
-            has_permission and meets_group_trigger
+        if not self._is_group_feature_enabled(event):
+            return self.ExposureDecision(
+                explicit_tool_name=explicit_tool_name,
+                has_permission=has_permission,
+                can_process_upload=can_process_upload,
+                should_expose=False,
+                exposure_level=ExposureLevel.NONE,
+                allowed_tool_names=(),
+                active_document_summary=None,
+                denied_reason="group_feature_disabled",
+            )
+        if not ((is_friend and event.is_admin()) or has_permission):
+            return self.ExposureDecision(
+                explicit_tool_name=explicit_tool_name,
+                has_permission=has_permission,
+                can_process_upload=can_process_upload,
+                should_expose=False,
+                exposure_level=ExposureLevel.NONE,
+                allowed_tool_names=(),
+                active_document_summary=None,
+                denied_reason="missing_permission",
+            )
+        if not ((is_friend and event.is_admin()) or meets_group_trigger):
+            return self.ExposureDecision(
+                explicit_tool_name=explicit_tool_name,
+                has_permission=has_permission,
+                can_process_upload=can_process_upload,
+                should_expose=False,
+                exposure_level=ExposureLevel.NONE,
+                allowed_tool_names=(),
+                active_document_summary=None,
+                denied_reason="missing_group_trigger",
+            )
+
+        has_uploaded_files = self._has_uploaded_file_component(event)
+        has_cached_uploads = bool(self._get_cached_upload_infos(event))
+        active_document_summary = self._get_active_document_summary(event)
+        has_active_document = bool(active_document_summary)
+        has_document_id = bool(self._extract_document_id(request_text))
+        has_document_intent = bool(
+            has_document_id or self._DOCUMENT_INTENT_RE.search(request_text)
         )
+        has_file_intent = bool(self._FILE_INTENT_RE.search(request_text))
+
+        if has_document_id:
+            exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif has_active_document and self._looks_like_document_followup(request_text):
+            exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif (has_uploaded_files or has_cached_uploads) and has_document_intent:
+            exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif has_document_intent:
+            exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif has_uploaded_files or has_cached_uploads or has_file_intent:
+            exposure_level = ExposureLevel.FILE_ONLY
+        else:
+            exposure_level = ExposureLevel.NONE
+
+        allowed_tool_names = self._allowed_tool_names_for_level(exposure_level)
+        should_expose = exposure_level != ExposureLevel.NONE
         return self.ExposureDecision(
             explicit_tool_name=explicit_tool_name,
             has_permission=has_permission,
             can_process_upload=can_process_upload,
             should_expose=should_expose,
+            exposure_level=exposure_level,
+            allowed_tool_names=allowed_tool_names,
+            active_document_summary=active_document_summary,
+            denied_reason=None if should_expose else "no_relevant_intent",
         )
 
     async def apply(self, event: AstrMessageEvent, req: ProviderRequest) -> None:
@@ -237,18 +400,15 @@ class LLMRequestPolicy:
             decision.explicit_tool_name,
         )
 
-        if not self._is_group_feature_enabled(event):
-            self._remove_file_tools(req)
-            self._remove_execution_tools(req)
-            self._append_tools_denied_notice(req)
-            logger.debug("[文件管理] 群聊总开关关闭，已隐藏全部文件工具")
-            return
-
         if not decision.should_expose:
-            if not decision.has_permission:
+            if decision.denied_reason == "group_feature_disabled":
+                logger.debug("[文件管理] 群聊总开关关闭，已隐藏全部文件工具")
+            elif decision.denied_reason == "missing_permission":
                 logger.debug(
                     f"[文件管理] 用户 {event.get_sender_id()} 无文件权限，已隐藏文件工具"
                 )
+            elif decision.denied_reason == "no_relevant_intent":
+                logger.debug("[文件管理] 当前请求无文件相关意图，已隐藏文件工具")
             else:
                 logger.debug(
                     f"[文件管理] 用户 {event.get_sender_id()} 未满足群聊触发条件，已隐藏文件工具"
@@ -258,9 +418,15 @@ class LLMRequestPolicy:
             self._append_tools_denied_notice(req)
             return
 
-        if decision.should_expose and req.func_tool:
-            for tool in self._document_toolset.tools:
-                req.func_tool.add_tool(tool)
+        allowed_tool_names = self._apply_allowed_file_tools(
+            req,
+            exposure_level=decision.exposure_level,
+        )
+        logger.debug(
+            "[文件管理] exposure_level=%s | allowed_tools=%s",
+            decision.exposure_level.value,
+            ",".join(allowed_tool_names) or "none",
+        )
 
         await self._run_before_expose_tools(
             ToolExposureContext(
@@ -269,6 +435,8 @@ class LLMRequestPolicy:
                 should_expose=decision.should_expose,
                 can_process_upload=decision.can_process_upload,
                 explicit_tool_name=decision.explicit_tool_name,
+                exposure_level=decision.exposure_level,
+                allowed_tool_names=allowed_tool_names,
             )
         )
 
@@ -279,6 +447,8 @@ class LLMRequestPolicy:
                 should_expose=decision.should_expose,
                 can_process_upload=decision.can_process_upload,
                 explicit_tool_name=decision.explicit_tool_name,
+                exposure_level=decision.exposure_level,
+                allowed_tool_names=allowed_tool_names,
             )
         )
         if notice_context.notices:
@@ -291,8 +461,12 @@ class LLMRequestPolicy:
             req.system_prompt = (req.system_prompt or "") + "".join(ordered_notices)
             logger.debug(
                 "[文件管理] Prompt sections: %s",
-                self._prompt_context_service.build_section_trace(
-                    section_names=ordered_names,
-                    notices=ordered_notices,
+                (
+                    self._prompt_context_service.build_section_trace(
+                        section_names=ordered_names,
+                        notices=ordered_notices,
+                    )
+                    + f" | exposure_level={decision.exposure_level.value}"
+                    + f" | allowed_tools={','.join(allowed_tool_names) or 'none'}"
                 ),
             )

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -13,6 +13,7 @@ from ..constants import (
     DOCUMENT_FULL_TOOLS,
     EXECUTION_TOOLS,
     EXPLICIT_FILE_TOOL_EVENT_KEY,
+    ExposureDeniedReason,
     ExposureLevel,
     FILE_TOOLS,
     FILE_ONLY_TOOLS,
@@ -52,7 +53,7 @@ class LLMRequestPolicy:
         exposure_level: ExposureLevel
         allowed_tool_names: tuple[str, ...]
         active_document_summary: dict[str, object] | None
-        denied_reason: str | None
+        denied_reason: ExposureDeniedReason | None
 
     def __init__(
         self,
@@ -185,11 +186,13 @@ class LLMRequestPolicy:
         return self._request_hook_service.get_active_document_prompt_summary(event)
 
     @staticmethod
-    def _should_append_denied_notice(denied_reason: str | None) -> bool:
+    def _should_append_denied_notice(
+        denied_reason: ExposureDeniedReason | None,
+    ) -> bool:
         return denied_reason in {
-            "group_feature_disabled",
-            "missing_permission",
-            "missing_group_trigger",
+            ExposureDeniedReason.GROUP_FEATURE_DISABLED,
+            ExposureDeniedReason.MISSING_PERMISSION,
+            ExposureDeniedReason.MISSING_GROUP_TRIGGER,
         }
 
     @staticmethod
@@ -259,7 +262,7 @@ class LLMRequestPolicy:
                 exposure_level=ExposureLevel.NONE,
                 allowed_tool_names=(),
                 active_document_summary=None,
-                denied_reason="group_feature_disabled",
+                denied_reason=ExposureDeniedReason.GROUP_FEATURE_DISABLED,
             )
         if not ((is_friend and event.is_admin()) or has_permission):
             return self.ExposureDecision(
@@ -270,7 +273,7 @@ class LLMRequestPolicy:
                 exposure_level=ExposureLevel.NONE,
                 allowed_tool_names=(),
                 active_document_summary=None,
-                denied_reason="missing_permission",
+                denied_reason=ExposureDeniedReason.MISSING_PERMISSION,
             )
         if not ((is_friend and event.is_admin()) or meets_group_trigger):
             return self.ExposureDecision(
@@ -281,7 +284,7 @@ class LLMRequestPolicy:
                 exposure_level=ExposureLevel.NONE,
                 allowed_tool_names=(),
                 active_document_summary=None,
-                denied_reason="missing_group_trigger",
+                denied_reason=ExposureDeniedReason.MISSING_GROUP_TRIGGER,
             )
 
         has_uploaded_files = self._has_uploaded_file_component(event)
@@ -328,7 +331,11 @@ class LLMRequestPolicy:
             exposure_level=exposure_level,
             allowed_tool_names=allowed_tool_names,
             active_document_summary=active_document_summary,
-            denied_reason=None if should_expose else "no_relevant_intent",
+            denied_reason=(
+                None
+                if should_expose
+                else ExposureDeniedReason.NO_RELEVANT_INTENT
+            ),
         )
 
     async def apply(self, event: AstrMessageEvent, req: ProviderRequest) -> None:
@@ -347,20 +354,31 @@ class LLMRequestPolicy:
         )
 
         if not decision.should_expose:
-            if decision.denied_reason == "group_feature_disabled":
+            if (
+                decision.denied_reason
+                == ExposureDeniedReason.GROUP_FEATURE_DISABLED
+            ):
                 logger.debug("[文件管理] 群聊总开关关闭，已隐藏全部文件工具")
-            elif decision.denied_reason == "missing_permission":
+            elif (
+                decision.denied_reason == ExposureDeniedReason.MISSING_PERMISSION
+            ):
                 logger.debug(
                     f"[文件管理] 用户 {event.get_sender_id()} 无文件权限，已隐藏文件工具"
                 )
-            elif decision.denied_reason == "no_relevant_intent":
+            elif (
+                decision.denied_reason
+                == ExposureDeniedReason.NO_RELEVANT_INTENT
+            ):
                 logger.debug("[文件管理] 当前请求无文件相关意图，已隐藏文件工具")
             else:
                 logger.debug(
                     f"[文件管理] 用户 {event.get_sender_id()} 未满足群聊触发条件，已隐藏文件工具"
                 )
             self._remove_file_tools(req)
-            if decision.denied_reason == "no_relevant_intent":
+            if (
+                decision.denied_reason
+                == ExposureDeniedReason.NO_RELEVANT_INTENT
+            ):
                 await self._run_before_expose_tools(
                     ToolExposureContext(
                         event=event,

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -42,7 +42,9 @@ class LLMRequestPolicy:
         r"(create_document|add_blocks|finalize_document|export_document|"
         r"document_id\b|整理成\s*(?:文档|报告|汇报|word|docx)|"
         r"导出成\s*word|导出为\s*word|生成\s*(?:文档|报告|汇报|word|docx)|"
-        r"\bword\b|\bdocx\b|文档|报告|汇报)",
+        r"生成\s*(?:excel|xlsx|表格|powerpoint|ppt|幻灯片)|"
+        r"\bword\b|\bdocx\b|\bexcel\b|\bxlsx\b|\bpowerpoint\b|\bppt\b|"
+        r"文档|报告|汇报|表格|幻灯片)",
         flags=re.IGNORECASE,
     )
     _FILE_INTENT_RE = re.compile(
@@ -237,11 +239,6 @@ class LLMRequestPolicy:
             for component in (getattr(event.message_obj, "message", None) or [])
         )
 
-    def _get_cached_upload_infos(self, event: AstrMessageEvent) -> list[dict[str, object]]:
-        if self._request_hook_service is None:
-            return []
-        return self._request_hook_service.get_cached_upload_infos(event)
-
     def _get_active_document_summary(
         self, event: AstrMessageEvent
     ) -> dict[str, object] | None:
@@ -350,7 +347,8 @@ class LLMRequestPolicy:
             )
 
         has_uploaded_files = self._has_uploaded_file_component(event)
-        has_cached_uploads = bool(self._get_cached_upload_infos(event))
+        has_buffered_upload = bool(getattr(event, "_buffered", False))
+        has_current_upload = has_uploaded_files or has_buffered_upload
         active_document_summary = self._get_active_document_summary(event)
         has_active_document = bool(active_document_summary)
         has_document_id = bool(self._extract_document_id(request_text))
@@ -358,16 +356,25 @@ class LLMRequestPolicy:
             has_document_id or self._DOCUMENT_INTENT_RE.search(request_text)
         )
         has_file_intent = bool(self._FILE_INTENT_RE.search(request_text))
+        has_explicit_document_tool = explicit_tool_name in {
+            "create_office_file",
+            "create_document",
+            "add_blocks",
+            "finalize_document",
+            "export_document",
+        }
 
         if has_document_id:
             exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif has_explicit_document_tool:
+            exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_active_document and self._looks_like_document_followup(request_text):
             exposure_level = ExposureLevel.DOCUMENT_FULL
-        elif (has_uploaded_files or has_cached_uploads) and has_document_intent:
+        elif has_current_upload and has_document_intent:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_document_intent:
             exposure_level = ExposureLevel.DOCUMENT_FULL
-        elif has_uploaded_files or has_cached_uploads or has_file_intent:
+        elif has_current_upload or has_file_intent:
             exposure_level = ExposureLevel.FILE_ONLY
         else:
             exposure_level = ExposureLevel.NONE
@@ -414,7 +421,20 @@ class LLMRequestPolicy:
                     f"[文件管理] 用户 {event.get_sender_id()} 未满足群聊触发条件，已隐藏文件工具"
                 )
             self._remove_file_tools(req)
-            self._remove_execution_tools(req)
+            if decision.denied_reason == "no_relevant_intent":
+                await self._run_before_expose_tools(
+                    ToolExposureContext(
+                        event=event,
+                        request=req,
+                        should_expose=False,
+                        can_process_upload=decision.can_process_upload,
+                        explicit_tool_name=decision.explicit_tool_name,
+                        exposure_level=decision.exposure_level,
+                        allowed_tool_names=decision.allowed_tool_names,
+                    )
+                )
+            else:
+                self._remove_execution_tools(req)
             self._append_tools_denied_notice(req)
             return
 

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -62,6 +62,14 @@ class LLMRequestPolicy:
         r"(导出|发给我|加一章|加一节|补充|再加)",
         flags=re.IGNORECASE,
     )
+    _DOCUMENT_FOLLOWUP_SHORT_RE = re.compile(
+        r"^(继续|接着|继续写|继续补充|继续完善|补充|完善|导出|发给我)$",
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_FOLLOWUP_TOPICAL_RE = re.compile(
+        r"(文档|报告|汇报|正文|内容|段落|章节|小节|标题|表格|草稿|这一章|这一节|上一段|下一段)",
+        flags=re.IGNORECASE,
+    )
     _BUFFERED_USER_INSTRUCTION_RE = re.compile(
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
@@ -251,11 +259,21 @@ class LLMRequestPolicy:
         normalized_text = str(text or "").strip()
         if not normalized_text:
             return False
+        if cls._DOCUMENT_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
+            return True
         if not cls._DOCUMENT_FOLLOWUP_RE.search(normalized_text):
             return False
-        if len(normalized_text) <= 24:
+        if cls._DOCUMENT_FOLLOWUP_TOPICAL_RE.search(normalized_text):
             return True
         return bool(cls._DOCUMENT_FOLLOWUP_ACTION_RE.search(normalized_text))
+
+    @staticmethod
+    def _should_append_denied_notice(denied_reason: str | None) -> bool:
+        return denied_reason in {
+            "group_feature_disabled",
+            "missing_permission",
+            "missing_group_trigger",
+        }
 
     @staticmethod
     def _allowed_tool_names_for_level(
@@ -435,7 +453,8 @@ class LLMRequestPolicy:
                 )
             else:
                 self._remove_execution_tools(req)
-            self._append_tools_denied_notice(req)
+            if self._should_append_denied_notice(decision.denied_reason):
+                self._append_tools_denied_notice(req)
             return
 
         allowed_tool_names = self._apply_allowed_file_tools(

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -25,59 +25,19 @@ from ..internal_hooks import (
     run_notice_hooks,
     run_tool_exposure_hooks,
 )
+from .intent_patterns import (
+    detect_explicit_file_tool as detect_explicit_file_tool_by_text,
+    extract_document_id as extract_document_id_from_text,
+    has_document_intent as text_has_document_intent,
+    has_file_intent as text_has_file_intent,
+    has_pdf_conversion_intent as text_has_pdf_conversion_intent,
+    looks_like_document_followup as text_looks_like_document_followup,
+)
 from .prompt_context_service import PromptContextService
 from .request_hook_service import RequestHookService
 
 
 class LLMRequestPolicy:
-    _NEGATIVE_TOOL_PREFIX_RE = re.compile(
-        r"(?:不要|别|勿|不用|无需|do\s+not|don't|not)\s*(?:调用|使用|call|use|invoke)?\s*$",
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_ID_RE = re.compile(
-        r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_INTENT_RE = re.compile(
-        r"(create_document|add_blocks|finalize_document|export_document|"
-        r"document_id\b|整理成\s*(?:文档|报告|汇报|word|docx)|"
-        r"导出成\s*word|导出为\s*word|生成\s*(?:文档|报告|汇报|word|docx)|"
-        r"生成\s*(?:excel|xlsx|表格|powerpoint|ppt|幻灯片)|"
-        r"\bword\b|\bdocx\b|\bexcel\b|\bxlsx\b|\bpowerpoint\b|\bppt\b|"
-        r"文档|报告|汇报|表格|幻灯片)",
-        flags=re.IGNORECASE,
-    )
-    _FILE_INTENT_RE = re.compile(
-        r"(read_file|convert_to_pdf|convert_from_pdf|"
-        r"读取.*文件|查看.*文件|看看.*文件|读取内容|读取这个|"
-        r"\bpdf\b|转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
-        r"pdf转word|pdf转excel)",
-        flags=re.IGNORECASE,
-    )
-    _PDF_CONVERSION_INTENT_RE = re.compile(
-        r"(convert_to_pdf|convert_from_pdf|"
-        r"pdf转word|pdf转excel|"
-        r"转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
-        r"\bpdf\b.*(?:转word|转excel|导出|转换)|"
-        r"(?:转word|转excel).*\bpdf\b)",
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_FOLLOWUP_RE = re.compile(
-        r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_FOLLOWUP_ACTION_RE = re.compile(
-        r"(导出|发给我|加一章|加一节|补充|再加)",
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_FOLLOWUP_SHORT_RE = re.compile(
-        r"^(继续|接着|继续写|继续补充|继续完善|补充|完善|导出|发给我)$",
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_FOLLOWUP_TOPICAL_RE = re.compile(
-        r"(文档|报告|汇报|正文|内容|段落|章节|小节|标题|表格|草稿|这一章|这一节|上一段|下一段)",
-        flags=re.IGNORECASE,
-    )
     _BUFFERED_USER_INSTRUCTION_RE = re.compile(
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
@@ -138,35 +98,6 @@ class LLMRequestPolicy:
             self._notice_hooks = None
             self._tool_exposure_hooks = None
             self._request_hook_service = request_hook_service
-
-    def _detect_explicit_file_tool(self, text: str) -> str | None:
-        if not text:
-            return None
-
-        explicit_matches: set[str] = set()
-        tool_invocation_prefix = (
-            r"(?:调用|使用|请求(?:调用|使用)?|请(?!问)(?:调用|使用)?|"
-            r"\b(?:call|use|invoke)\b|\bplease\s+(?:call|use|invoke)\b)"
-        )
-        for tool_name in sorted(FILE_TOOLS, key=len, reverse=True):
-            patterns = (
-                rf"(?P<tool>{tool_invocation_prefix}\s*`?{re.escape(tool_name)}`?)",
-                rf"(?P<tool>`{re.escape(tool_name)}`)",
-                rf"(?P<tool>{re.escape(tool_name)}\s*\()",
-                rf"(?P<tool>{re.escape(tool_name)}\s*[,，]\s*[a-zA-Z_]\w*\s*=)",
-            )
-            for pattern in patterns:
-                for match in re.finditer(pattern, text, flags=re.IGNORECASE):
-                    tool_start = match.start("tool")
-                    prefix = text[max(0, tool_start - 20) : tool_start]
-                    if self._NEGATIVE_TOOL_PREFIX_RE.search(prefix):
-                        continue
-                    explicit_matches.add(tool_name)
-                    break
-
-        if len(explicit_matches) == 1:
-            return next(iter(explicit_matches))
-        return None
 
     def _extract_explicit_tool_text(
         self,
@@ -240,15 +171,6 @@ class LLMRequestPolicy:
         )
 
     @staticmethod
-    def _extract_document_id(text: str) -> str | None:
-        if not text:
-            return None
-        match = LLMRequestPolicy._DOCUMENT_ID_RE.search(text)
-        if not match:
-            return None
-        return match.group("document_id")
-
-    @staticmethod
     def _has_uploaded_file_component(event: AstrMessageEvent) -> bool:
         return any(
             isinstance(component, Comp.File)
@@ -261,19 +183,6 @@ class LLMRequestPolicy:
         if self._request_hook_service is None:
             return None
         return self._request_hook_service.get_active_document_prompt_summary(event)
-
-    @classmethod
-    def _looks_like_document_followup(cls, text: str) -> bool:
-        normalized_text = str(text or "").strip()
-        if not normalized_text:
-            return False
-        if cls._DOCUMENT_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
-            return True
-        if not cls._DOCUMENT_FOLLOWUP_RE.search(normalized_text):
-            return False
-        if cls._DOCUMENT_FOLLOWUP_TOPICAL_RE.search(normalized_text):
-            return True
-        return bool(cls._DOCUMENT_FOLLOWUP_ACTION_RE.search(normalized_text))
 
     @staticmethod
     def _should_append_denied_notice(denied_reason: str | None) -> bool:
@@ -323,7 +232,10 @@ class LLMRequestPolicy:
         is_friend: bool,
     ) -> ExposureDecision:
         request_text = self._extract_explicit_tool_text(event, req)
-        explicit_tool_name = self._detect_explicit_file_tool(request_text)
+        explicit_tool_name = detect_explicit_file_tool_by_text(
+            request_text,
+            FILE_TOOLS,
+        )
         has_permission = self._check_permission(event)
         can_process_upload = has_permission or event.is_admin()
         get_extra = getattr(event, "get_extra", None)
@@ -377,14 +289,10 @@ class LLMRequestPolicy:
         has_current_upload = has_uploaded_files or has_buffered_upload
         active_document_summary = self._get_active_document_summary(event)
         has_active_document = bool(active_document_summary)
-        has_document_id = bool(self._extract_document_id(request_text))
-        has_document_intent = bool(
-            has_document_id or self._DOCUMENT_INTENT_RE.search(request_text)
-        )
-        has_file_intent = bool(self._FILE_INTENT_RE.search(request_text))
-        has_pdf_conversion_intent = bool(
-            self._PDF_CONVERSION_INTENT_RE.search(request_text)
-        )
+        has_document_id = bool(extract_document_id_from_text(request_text))
+        has_document_intent = text_has_document_intent(request_text)
+        has_file_intent = text_has_file_intent(request_text)
+        has_pdf_conversion_intent = text_has_pdf_conversion_intent(request_text)
         has_explicit_document_tool = explicit_tool_name in {
             "create_office_file",
             "create_document",
@@ -397,7 +305,7 @@ class LLMRequestPolicy:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_explicit_document_tool:
             exposure_level = ExposureLevel.DOCUMENT_FULL
-        elif has_active_document and self._looks_like_document_followup(request_text):
+        elif has_active_document and text_looks_like_document_followup(request_text):
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_pdf_conversion_intent:
             exposure_level = ExposureLevel.FILE_ONLY

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -54,6 +54,14 @@ class LLMRequestPolicy:
         r"pdf转word|pdf转excel)",
         flags=re.IGNORECASE,
     )
+    _PDF_CONVERSION_INTENT_RE = re.compile(
+        r"(convert_to_pdf|convert_from_pdf|"
+        r"pdf转word|pdf转excel|"
+        r"转成\s*pdf|转换成\s*pdf|导出成\s*pdf|导出为\s*pdf|"
+        r"\bpdf\b.*(?:转word|转excel|导出|转换)|"
+        r"(?:转word|转excel).*\bpdf\b)",
+        flags=re.IGNORECASE,
+    )
     _DOCUMENT_FOLLOWUP_RE = re.compile(
         r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
         flags=re.IGNORECASE,
@@ -290,11 +298,11 @@ class LLMRequestPolicy:
         req: ProviderRequest,
         *,
         exposure_level: ExposureLevel,
+        allowed_tool_names: tuple[str, ...],
     ) -> tuple[str, ...]:
         if not req.func_tool:
             return ()
 
-        allowed_tool_names = self._allowed_tool_names_for_level(exposure_level)
         if exposure_level == ExposureLevel.DOCUMENT_FULL:
             for tool in self._document_toolset.tools:
                 if tool.name in allowed_tool_names:
@@ -374,6 +382,9 @@ class LLMRequestPolicy:
             has_document_id or self._DOCUMENT_INTENT_RE.search(request_text)
         )
         has_file_intent = bool(self._FILE_INTENT_RE.search(request_text))
+        has_pdf_conversion_intent = bool(
+            self._PDF_CONVERSION_INTENT_RE.search(request_text)
+        )
         has_explicit_document_tool = explicit_tool_name in {
             "create_office_file",
             "create_document",
@@ -388,6 +399,8 @@ class LLMRequestPolicy:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_active_document and self._looks_like_document_followup(request_text):
             exposure_level = ExposureLevel.DOCUMENT_FULL
+        elif has_pdf_conversion_intent:
+            exposure_level = ExposureLevel.FILE_ONLY
         elif has_current_upload and has_document_intent:
             exposure_level = ExposureLevel.DOCUMENT_FULL
         elif has_document_intent:
@@ -460,6 +473,7 @@ class LLMRequestPolicy:
         allowed_tool_names = self._apply_allowed_file_tools(
             req,
             exposure_level=decision.exposure_level,
+            allowed_tool_names=decision.allowed_tool_names,
         )
         logger.debug(
             "[文件管理] exposure_level=%s | allowed_tools=%s",

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -10,6 +10,7 @@ from ..prompts.scenes.uploaded_file import (
     build_uploaded_file_summary_notice,
 )
 from ..prompts.static import (
+    build_file_only_notice,
     build_document_tools_core_notice,
     build_document_tools_detail_notice,
     build_tools_denied_notice,
@@ -17,6 +18,7 @@ from ..prompts.static import (
 from .upload_types import UploadInfo
 
 SECTION_STATIC_ACCESS = "static_access"
+SECTION_STATIC_FILE_ONLY = "static_file_only"
 SECTION_STATIC_DOCUMENT_TOOLS = "static_document_tools"
 SECTION_STATIC_DOCUMENT_TOOLS_DETAIL = "static_document_tools_detail"
 SECTION_SCENE_UPLOADED_FILE = "scene_uploaded_file"
@@ -130,6 +132,15 @@ class PromptContextService:
     def build_tools_denied_notice(self) -> str:
         return self.render_sections(self.build_tools_denied_section())
 
+    def build_file_only_notice_section(self) -> PromptSection:
+        return PromptSection(
+            name=SECTION_STATIC_FILE_ONLY,
+            content=build_file_only_notice(),
+        )
+
+    def build_file_only_notice(self) -> str:
+        return self.render_sections(self.build_file_only_notice_section())
+
     def build_document_tool_guide_section(self) -> PromptSection:
         return PromptSection(
             name=SECTION_STATIC_DOCUMENT_TOOLS,
@@ -209,12 +220,14 @@ class PromptContextService:
         self,
         *,
         file_count: int,
+        document_workflow: bool = False,
     ) -> PromptSection:
         return PromptSection(
             name=SECTION_SCENE_UPLOADED_FILE,
             content=build_uploaded_file_scene_notice(
                 file_count=file_count,
                 allow_external_input_files=self._allow_external_input_files,
+                document_workflow=document_workflow,
             ),
         )
 

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -201,6 +201,7 @@ class RequestHookService:
             summary = self._get_document_prompt_summary(document_id)
             if summary:
                 return summary
+            return None
         return self.get_active_document_prompt_summary(event)
 
     @staticmethod
@@ -358,11 +359,7 @@ class RequestHookService:
         self,
         context: ToolExposureContext,
     ) -> ToolExposureContext:
-        if (
-            context.should_expose
-            and context.request.func_tool
-            and self._auto_block_execution_tools
-        ):
+        if context.request.func_tool and self._auto_block_execution_tools:
             for tool_name in EXECUTION_TOOLS:
                 context.request.func_tool.remove_tool(tool_name)
             logger.debug("[文件管理] 已自动屏蔽 shell/python 执行类工具")

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -9,6 +9,7 @@ from astrbot.api.event import AstrMessageEvent
 from ..constants import (
     ALL_OFFICE_SUFFIXES,
     EXECUTION_TOOLS,
+    ExposureLevel,
     FILE_TOOLS,
     PDF_SUFFIX,
     TEXT_SUFFIXES,
@@ -34,13 +35,6 @@ class RequestHookService:
         r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
         flags=re.IGNORECASE,
     )
-    _DOCUMENT_WORKFLOW_HINT_RE = re.compile(
-        r"(create_document|add_blocks|finalize_document|export_document|"
-        r"document_id\b|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
-        r"\bword\b|\bdocx\b|汇报|报告|"
-        r"生成\s*(?:word|docx|报告|汇报)|整理成\s*(?:word|docx|报告|汇报))",
-        flags=re.IGNORECASE,
-    )
     _DOCUMENT_DETAIL_HINT_RE = re.compile(
         r"(create_document|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
         r"\bword\b|\bdocx\b|汇报|报告|"
@@ -62,6 +56,9 @@ class RequestHookService:
         get_document_prompt_summary: (
             Callable[[str], dict[str, object] | None] | None
         ) = None,
+        get_active_document_prompt_summary: (
+            Callable[[str], dict[str, object] | None] | None
+        ) = None,
         prompt_context_service: PromptContextService | None = None,
     ) -> None:
         self._auto_block_execution_tools = auto_block_execution_tools
@@ -69,6 +66,9 @@ class RequestHookService:
         self._extract_upload_source = extract_upload_source
         self._store_uploaded_file = store_uploaded_file
         self._get_document_prompt_summary = get_document_prompt_summary
+        self._get_active_document_prompt_summary = (
+            get_active_document_prompt_summary
+        )
         self.prompt_context_service = prompt_context_service or PromptContextService(
             allow_external_input_files=allow_external_input_files
         )
@@ -106,13 +106,22 @@ class RequestHookService:
         if not (context.should_expose and context.request.func_tool):
             return context
 
+        exposure_level = getattr(context, "exposure_level", ExposureLevel.NONE)
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
-        document_id = self._extract_document_id(request_text)
-        should_inject = self._should_inject_document_tool_guide(
+        document_summary = self._resolve_document_summary(
+            event=context.event,
             request_text=request_text,
-            document_id=document_id,
         )
-        if not should_inject:
+        document_id = str((document_summary or {}).get("document_id") or "").strip()
+
+        if exposure_level == ExposureLevel.NONE:
+            return context
+
+        if exposure_level == ExposureLevel.FILE_ONLY:
+            self._append_prompt_section(
+                context,
+                self.prompt_context_service.build_file_only_notice_section(),
+            )
             return context
 
         self._append_prompt_section(
@@ -121,21 +130,17 @@ class RequestHookService:
         )
         if self._should_inject_document_tool_detail(
             request_text=request_text,
-            document_id=document_id,
+            document_id=document_id or None,
         ):
             self._append_prompt_section(
                 context,
                 self.prompt_context_service.build_document_tool_detail_section(),
             )
-        if not (document_id and self._get_document_prompt_summary):
-            return context
-
-        summary = self._get_document_prompt_summary(document_id)
-        if summary:
+        if document_summary:
             self._append_prompt_section(
                 context,
                 self.prompt_context_service.build_document_summary_section(
-                    summary=summary
+                    summary=document_summary
                 ),
             )
         return context
@@ -158,19 +163,6 @@ class RequestHookService:
         return match.group("document_id")
 
     @classmethod
-    def _should_inject_document_tool_guide(
-        cls,
-        *,
-        request_text: str,
-        document_id: str | None,
-    ) -> bool:
-        if document_id:
-            return True
-        if not request_text:
-            return False
-        return bool(cls._DOCUMENT_WORKFLOW_HINT_RE.search(request_text))
-
-    @classmethod
     def _should_inject_document_tool_detail(
         cls,
         *,
@@ -182,6 +174,34 @@ class RequestHookService:
         if document_id and not cls._DOCUMENT_DETAIL_HINT_RE.search(request_text):
             return False
         return bool(cls._DOCUMENT_DETAIL_HINT_RE.search(request_text))
+
+    def get_cached_upload_infos(
+        self, event: AstrMessageEvent
+    ) -> list[UploadInfo]:
+        return list(self._get_cached_upload_infos(event))
+
+    def get_active_document_prompt_summary(
+        self, event: AstrMessageEvent
+    ) -> dict[str, object] | None:
+        if self._get_active_document_prompt_summary is None:
+            return None
+        session_id = str(getattr(event, "unified_msg_origin", "") or "").strip()
+        if not session_id:
+            return None
+        return self._get_active_document_prompt_summary(session_id)
+
+    def _resolve_document_summary(
+        self,
+        *,
+        event: AstrMessageEvent,
+        request_text: str,
+    ) -> dict[str, object] | None:
+        document_id = self._extract_document_id(request_text)
+        if document_id and self._get_document_prompt_summary:
+            summary = self._get_document_prompt_summary(document_id)
+            if summary:
+                return summary
+        return self.get_active_document_prompt_summary(event)
 
     @staticmethod
     def _append_prompt_section(
@@ -293,7 +313,11 @@ class RequestHookService:
             self._append_prompt_section(
                 context,
                 self.prompt_context_service.build_uploaded_file_scene_section(
-                    file_count=len(readable_upload_infos)
+                    file_count=len(readable_upload_infos),
+                    document_workflow=(
+                        getattr(context, "exposure_level", ExposureLevel.NONE)
+                        == ExposureLevel.DOCUMENT_FULL
+                    ),
                 ),
             )
 
@@ -352,8 +376,10 @@ class RequestHookService:
             context.should_expose
             and context.request.func_tool
             and context.explicit_tool_name
+            and context.explicit_tool_name
+            in set(getattr(context, "allowed_tool_names", ()))
         ):
-            for tool_name in FILE_TOOLS:
+            for tool_name in tuple(getattr(context, "allowed_tool_names", ())):
                 if tool_name != context.explicit_tool_name:
                     context.request.func_tool.remove_tool(tool_name)
             logger.info(

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -41,6 +41,7 @@ class RequestHookService:
         *,
         auto_block_execution_tools: bool,
         get_cached_upload_infos: Callable[[AstrMessageEvent], list[UploadInfo]],
+        list_session_upload_infos: Callable[[AstrMessageEvent], list[UploadInfo]] | None = None,
         extract_upload_source: Callable[
             [Comp.File], Awaitable[tuple[Path | None, str]]
         ],
@@ -56,6 +57,9 @@ class RequestHookService:
     ) -> None:
         self._auto_block_execution_tools = auto_block_execution_tools
         self._get_cached_upload_infos = get_cached_upload_infos
+        self._list_session_upload_infos = (
+            list_session_upload_infos or get_cached_upload_infos
+        )
         self._extract_upload_source = extract_upload_source
         self._store_uploaded_file = store_uploaded_file
         self._get_document_prompt_summary = get_document_prompt_summary
@@ -153,6 +157,31 @@ class RequestHookService:
     ) -> list[UploadInfo]:
         return list(self._get_cached_upload_infos(event))
 
+    def get_session_upload_infos(
+        self, event: AstrMessageEvent
+    ) -> list[UploadInfo]:
+        return list(self._list_session_upload_infos(event))
+
+    def _get_readable_cached_upload_infos(
+        self,
+        event: AstrMessageEvent,
+    ) -> list[UploadInfo]:
+        readable_infos: list[UploadInfo] = []
+        for cached_info in self.get_session_upload_infos(event):
+            if not cached_info.get("is_supported", False):
+                continue
+            readable_infos.append(
+                {
+                    "original_name": str(cached_info.get("original_name", "") or ""),
+                    "file_suffix": str(cached_info.get("file_suffix", "") or ""),
+                    "type_desc": str(cached_info.get("type_desc", "") or ""),
+                    "is_supported": True,
+                    "stored_name": str(cached_info.get("stored_name", "") or ""),
+                    "source_path": str(cached_info.get("source_path", "") or ""),
+                }
+            )
+        return readable_infos
+
     def get_active_document_prompt_summary(
         self, event: AstrMessageEvent
     ) -> dict[str, object] | None:
@@ -200,11 +229,13 @@ class RequestHookService:
 
         event = context.event
         req = context.request
+        has_current_file_component = False
         cached_upload_infos = iter(self._get_cached_upload_infos(event))
         readable_upload_infos: list[UploadInfo] = []
         for component in getattr(event.message_obj, "message", None) or []:
             if not isinstance(component, Comp.File):
                 continue
+            has_current_file_component = True
 
             try:
                 cached_info = next(cached_upload_infos, None)
@@ -280,9 +311,11 @@ class RequestHookService:
                 logger.error(f"[文件管理] 处理上传文件失败: {exc}")
 
         if not readable_upload_infos:
-            return context
+            readable_upload_infos = self._get_readable_cached_upload_infos(event)
+            if not readable_upload_infos:
+                return context
 
-        if self._should_append_uploaded_file_scene_notice(
+        if has_current_file_component and self._should_append_uploaded_file_scene_notice(
             event=event,
             prompt=str(req.prompt or ""),
         ):

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -42,6 +42,22 @@ class RequestHookService:
         r"business_report|project_review|executive_brief|accent_color|document_style)",
         flags=re.IGNORECASE,
     )
+    _ACTIVE_SUMMARY_FOLLOWUP_SHORT_RE = re.compile(
+        r"^(继续|接着|继续写|继续补充|继续完善|补充|完善|导出|发给我)$",
+        flags=re.IGNORECASE,
+    )
+    _ACTIVE_SUMMARY_FOLLOWUP_RE = re.compile(
+        r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
+        flags=re.IGNORECASE,
+    )
+    _ACTIVE_SUMMARY_FOLLOWUP_ACTION_RE = re.compile(
+        r"(导出|发给我|加一章|加一节|补充|再加)",
+        flags=re.IGNORECASE,
+    )
+    _ACTIVE_SUMMARY_TOPICAL_RE = re.compile(
+        r"(文档|报告|汇报|正文|内容|段落|章节|小节|标题|表格|草稿|这一章|这一节|上一段|下一段|上一版)",
+        flags=re.IGNORECASE,
+    )
 
     def __init__(
         self,
@@ -202,7 +218,24 @@ class RequestHookService:
             if summary:
                 return summary
             return None
+        if not self._should_use_active_document_summary(request_text):
+            return None
         return self.get_active_document_prompt_summary(event)
+
+    @classmethod
+    def _should_use_active_document_summary(cls, request_text: str) -> bool:
+        normalized_text = str(request_text or "").strip()
+        if not normalized_text:
+            return False
+        if cls._ACTIVE_SUMMARY_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
+            return True
+        return bool(
+            cls._ACTIVE_SUMMARY_FOLLOWUP_RE.search(normalized_text)
+            and (
+                cls._ACTIVE_SUMMARY_TOPICAL_RE.search(normalized_text)
+                or cls._ACTIVE_SUMMARY_FOLLOWUP_ACTION_RE.search(normalized_text)
+            )
+        )
 
     @staticmethod
     def _append_prompt_section(

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -10,7 +10,6 @@ from ..constants import (
     ALL_OFFICE_SUFFIXES,
     EXECUTION_TOOLS,
     ExposureLevel,
-    FILE_TOOLS,
     PDF_SUFFIX,
     TEXT_SUFFIXES,
 )
@@ -22,6 +21,11 @@ from ..internal_hooks import (
     run_notice_hooks,
     run_tool_exposure_hooks,
 )
+from .intent_patterns import (
+    extract_document_id,
+    should_inject_document_tool_detail,
+    should_use_active_document_summary,
+)
 from .prompt_context_service import PromptContextService
 from .upload_types import UploadInfo
 
@@ -30,33 +34,6 @@ class RequestHookService:
     _BUFFERED_USER_INSTRUCTION_RE = re.compile(
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
-    )
-    _DOCUMENT_ID_RE = re.compile(
-        r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
-        flags=re.IGNORECASE,
-    )
-    _DOCUMENT_DETAIL_HINT_RE = re.compile(
-        r"(create_document|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
-        r"\bword\b|\bdocx\b|汇报|报告|"
-        r"生成\s*(?:word|docx|报告|汇报)|整理成\s*(?:word|docx|报告|汇报)|"
-        r"business_report|project_review|executive_brief|accent_color|document_style)",
-        flags=re.IGNORECASE,
-    )
-    _ACTIVE_SUMMARY_FOLLOWUP_SHORT_RE = re.compile(
-        r"^(继续|接着|继续写|继续补充|继续完善|补充|完善|导出|发给我)$",
-        flags=re.IGNORECASE,
-    )
-    _ACTIVE_SUMMARY_FOLLOWUP_RE = re.compile(
-        r"(继续|接着|再加|加一章|加一节|补充|完善|导出|发给我)",
-        flags=re.IGNORECASE,
-    )
-    _ACTIVE_SUMMARY_FOLLOWUP_ACTION_RE = re.compile(
-        r"(导出|发给我|加一章|加一节|补充|再加)",
-        flags=re.IGNORECASE,
-    )
-    _ACTIVE_SUMMARY_TOPICAL_RE = re.compile(
-        r"(文档|报告|汇报|正文|内容|段落|章节|小节|标题|表格|草稿|这一章|这一节|上一段|下一段|上一版)",
-        flags=re.IGNORECASE,
     )
 
     def __init__(
@@ -144,7 +121,7 @@ class RequestHookService:
             context,
             self.prompt_context_service.build_document_tool_guide_section(),
         )
-        if self._should_inject_document_tool_detail(
+        if should_inject_document_tool_detail(
             request_text=request_text,
             document_id=document_id or None,
         ):
@@ -171,26 +148,6 @@ class RequestHookService:
             return match.group("instruction").strip()
         return stripped_prompt
 
-    @classmethod
-    def _extract_document_id(cls, prompt: str) -> str | None:
-        match = cls._DOCUMENT_ID_RE.search(prompt)
-        if not match:
-            return None
-        return match.group("document_id")
-
-    @classmethod
-    def _should_inject_document_tool_detail(
-        cls,
-        *,
-        request_text: str,
-        document_id: str | None,
-    ) -> bool:
-        if not request_text:
-            return False
-        if document_id and not cls._DOCUMENT_DETAIL_HINT_RE.search(request_text):
-            return False
-        return bool(cls._DOCUMENT_DETAIL_HINT_RE.search(request_text))
-
     def get_cached_upload_infos(
         self, event: AstrMessageEvent
     ) -> list[UploadInfo]:
@@ -212,30 +169,15 @@ class RequestHookService:
         event: AstrMessageEvent,
         request_text: str,
     ) -> dict[str, object] | None:
-        document_id = self._extract_document_id(request_text)
+        document_id = extract_document_id(request_text)
         if document_id and self._get_document_prompt_summary:
             summary = self._get_document_prompt_summary(document_id)
             if summary:
                 return summary
             return None
-        if not self._should_use_active_document_summary(request_text):
+        if not should_use_active_document_summary(request_text):
             return None
         return self.get_active_document_prompt_summary(event)
-
-    @classmethod
-    def _should_use_active_document_summary(cls, request_text: str) -> bool:
-        normalized_text = str(request_text or "").strip()
-        if not normalized_text:
-            return False
-        if cls._ACTIVE_SUMMARY_FOLLOWUP_SHORT_RE.fullmatch(normalized_text):
-            return True
-        return bool(
-            cls._ACTIVE_SUMMARY_FOLLOWUP_RE.search(normalized_text)
-            and (
-                cls._ACTIVE_SUMMARY_TOPICAL_RE.search(normalized_text)
-                or cls._ACTIVE_SUMMARY_FOLLOWUP_ACTION_RE.search(normalized_text)
-            )
-        )
 
     @staticmethod
     def _append_prompt_section(

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -219,6 +219,7 @@ def _build_request_pipeline_services(
     request_hook_service = RequestHookService(
         auto_block_execution_tools=settings.auto_block_execution_tools,
         get_cached_upload_infos=upload_session_service.get_cached_upload_infos,
+        list_session_upload_infos=upload_session_service.list_session_upload_infos,
         extract_upload_source=extract_upload_source,
         store_uploaded_file=store_uploaded_file,
         allow_external_input_files=settings.allow_external_input_files,

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -209,6 +209,13 @@ def _build_request_pipeline_services(
         except KeyError:
             return None
 
+    def _get_active_document_prompt_summary(
+        session_id: str,
+    ) -> dict[str, object] | None:
+        if document_store is None:
+            return None
+        return document_store.build_latest_prompt_summary_for_session(session_id)
+
     request_hook_service = RequestHookService(
         auto_block_execution_tools=settings.auto_block_execution_tools,
         get_cached_upload_infos=upload_session_service.get_cached_upload_infos,
@@ -216,6 +223,7 @@ def _build_request_pipeline_services(
         store_uploaded_file=store_uploaded_file,
         allow_external_input_files=settings.allow_external_input_files,
         get_document_prompt_summary=_get_document_prompt_summary,
+        get_active_document_prompt_summary=_get_active_document_prompt_summary,
         prompt_context_service=prompt_context_service,
     )
     llm_request_policy = LLMRequestPolicy(

--- a/tests/test_intent_patterns.py
+++ b/tests/test_intent_patterns.py
@@ -49,6 +49,15 @@ def test_pdf_conversion_intent_matches_spaced_chinese_phrasing():
     assert has_file_intent("把PDF 转 WORD") is True
 
 
+def test_pdf_conversion_intent_matches_turn_into_word_or_excel_phrasing():
+    assert has_pdf_conversion_intent("pdf转成word") is True
+    assert has_pdf_conversion_intent("把这个pdf文件转成word") is True
+    assert has_pdf_conversion_intent("pdf转成excel") is True
+    assert has_pdf_conversion_intent("把这个pdf文件转成excel") is True
+    assert has_file_intent("pdf转成word") is True
+    assert has_file_intent("把这个pdf文件转成word") is True
+
+
 def test_document_followup_requires_document_semantics_for_topic_switch():
     assert looks_like_document_followup("继续") is True
     assert looks_like_document_followup("再加一章关于销售的") is True

--- a/tests/test_intent_patterns.py
+++ b/tests/test_intent_patterns.py
@@ -1,0 +1,71 @@
+from astrbot_plugin_office_assistant.services.intent_patterns import (
+    detect_explicit_file_tool,
+    extract_document_id,
+    has_document_intent,
+    has_file_intent,
+    has_pdf_conversion_intent,
+    looks_like_document_followup,
+    should_inject_document_tool_detail,
+    should_use_active_document_summary,
+)
+
+
+def test_extract_document_id_returns_expected_value():
+    assert extract_document_id('继续完善 document_id="doc-123" 的内容') == "doc-123"
+    assert extract_document_id("hello") is None
+
+
+def test_detect_explicit_file_tool_respects_negative_prefix():
+    file_tools = ("read_file", "create_document", "create_office_file")
+
+    assert (
+        detect_explicit_file_tool(
+            "请调用 create_document，title=季度复盘",
+            file_tools,
+        )
+        == "create_document"
+    )
+    assert (
+        detect_explicit_file_tool(
+            "不要调用 create_document，先告诉我可用工具。",
+            file_tools,
+        )
+        is None
+    )
+
+
+def test_pdf_conversion_intent_stays_distinct_from_generic_document_intent():
+    text = "先导出为pdf再转word"
+
+    assert has_pdf_conversion_intent(text) is True
+    assert has_file_intent(text) is True
+    assert has_document_intent(text) is False
+
+
+def test_document_followup_requires_document_semantics_for_topic_switch():
+    assert looks_like_document_followup("继续") is True
+    assert looks_like_document_followup("再加一章关于销售的") is True
+    assert looks_like_document_followup("继续讲个笑话") is False
+
+
+def test_active_document_summary_only_applies_to_followup_requests():
+    assert should_use_active_document_summary("继续完善上一版报告") is True
+    assert should_use_active_document_summary("再加一章关于销售的") is True
+    assert should_use_active_document_summary("请生成一份新的报告") is False
+
+
+def test_document_tool_detail_hint_matches_detail_request_only():
+    assert (
+        should_inject_document_tool_detail(
+            request_text="请生成一份 Word 报告，accent_color=112233",
+            document_id=None,
+        )
+        is True
+    )
+    assert (
+        should_inject_document_tool_detail(
+            request_text='继续完善 document_id="doc-1" 的内容',
+            document_id="doc-1",
+        )
+        is False
+    )

--- a/tests/test_intent_patterns.py
+++ b/tests/test_intent_patterns.py
@@ -42,6 +42,13 @@ def test_pdf_conversion_intent_stays_distinct_from_generic_document_intent():
     assert has_document_intent(text) is False
 
 
+def test_pdf_conversion_intent_matches_spaced_chinese_phrasing():
+    assert has_pdf_conversion_intent("pdf 转 word") is True
+    assert has_pdf_conversion_intent("把PDF 转 WORD") is True
+    assert has_file_intent("pdf 转 word") is True
+    assert has_file_intent("把PDF 转 WORD") is True
+
+
 def test_document_followup_requires_document_semantics_for_topic_switch():
     assert looks_like_document_followup("继续") is True
     assert looks_like_document_followup("再加一章关于销售的") is True

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -1192,7 +1192,7 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
 
 
 @pytest.mark.asyncio
-async def test_llm_request_policy_does_not_upgrade_plain_chat_from_cached_uploads():
+async def test_llm_request_policy_uses_file_only_for_cached_upload_context():
     request_hook_service = RequestHookService(
         auto_block_execution_tools=True,
         get_cached_upload_infos=lambda _event: [
@@ -1220,7 +1220,7 @@ async def test_llm_request_policy_does_not_upgrade_plain_chat_from_cached_upload
     )
     event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2")
     req = ProviderRequest(
-        prompt="今天天气怎么样",
+        prompt="读取看看",
         system_prompt="base",
         func_tool=ToolSet(
             [
@@ -1237,11 +1237,70 @@ async def test_llm_request_policy_does_not_upgrade_plain_chat_from_cached_upload
 
     tool_names = set(req.func_tool.names())
     assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
-    assert "read_file" not in tool_names
+    assert "read_file" in tool_names
     assert "create_office_file" not in tool_names
     assert "create_document" not in tool_names
     assert "astrbot_execute_shell" not in tool_names
     assert "existing_tool" in tool_names
+    assert "文件处理规则" in req.system_prompt
+    assert "report_1.docx" in req.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_uses_session_upload_context_for_follow_up_text():
+    request_hook_service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        list_session_upload_infos=lambda _event: [
+            {
+                "original_name": "empty_1.txt",
+                "file_suffix": ".txt",
+                "stored_name": "empty_1.txt",
+                "source_path": "/tmp/empty_1.txt",
+                "type_desc": "文本/代码文件",
+                "is_supported": True,
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    policy = LLMRequestPolicy(
+        document_toolset=SimpleNamespace(
+            tools=[_tool("create_office_file"), _tool("create_document")]
+        ),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: False,
+        request_hook_service=request_hook_service,
+    )
+    event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2")
+    req = ProviderRequest(
+        prompt="你看一下",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_file"),
+                _tool("create_office_file"),
+                _tool("create_document"),
+                _tool("existing_tool"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+
+    await policy.apply(event, req)
+
+    tool_names = set(req.func_tool.names())
+    assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
+    assert "read_file" in tool_names
+    assert "create_office_file" not in tool_names
+    assert "create_document" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+    assert "existing_tool" in tool_names
+    assert "文件处理规则" in req.system_prompt
+    assert "empty_1.txt" in req.system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -587,12 +587,50 @@ async def test_before_llm_chat_restricts_file_tools_for_explicit_tool_call(
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
-        assert "create_office_file" not in tool_names
+        assert "create_office_file" in tool_names
+        assert "create_document" not in tool_names
+        assert "add_blocks" not in tool_names
+        assert "finalize_document" not in tool_names
+        assert "export_document" not in tool_names
+        assert "read_file" not in tool_names
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_keeps_create_office_file_for_excel_intent():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        req = ProviderRequest(
+            prompt="帮我创建一个 Excel 表格",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("create_office_file"),
+                    _tool("create_document"),
+                    _tool("add_blocks"),
+                    _tool("finalize_document"),
+                    _tool("export_document"),
+                    _tool("read_file"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "create_office_file" in tool_names
         assert "create_document" in tool_names
         assert "add_blocks" in tool_names
-        assert "finalize_document" in tool_names
         assert "export_document" in tool_names
-        assert "read_file" in tool_names
+        assert "文件工具使用指南" in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -1062,6 +1100,98 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
     assert "existing_tool" in set(req.func_tool.names())
     assert "read_file" not in set(req.func_tool.names())
     assert "astrbot_execute_shell" not in set(req.func_tool.names())
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_does_not_upgrade_plain_chat_from_cached_uploads():
+    request_hook_service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [
+            {
+                "original_name": "report.docx",
+                "file_suffix": ".docx",
+                "stored_name": "report_1.docx",
+                "source_path": "/tmp/report.docx",
+                "is_supported": True,
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    policy = LLMRequestPolicy(
+        document_toolset=SimpleNamespace(
+            tools=[_tool("create_office_file"), _tool("create_document")]
+        ),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: False,
+        request_hook_service=request_hook_service,
+    )
+    event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2")
+    req = ProviderRequest(
+        prompt="今天天气怎么样",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_file"),
+                _tool("create_office_file"),
+                _tool("create_document"),
+                _tool("existing_tool"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+
+    await policy.apply(event, req)
+
+    tool_names = set(req.func_tool.names())
+    assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+    assert "read_file" not in tool_names
+    assert "create_office_file" not in tool_names
+    assert "create_document" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+    assert "existing_tool" in tool_names
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_keeps_execution_tools_when_no_file_intent_and_auto_block_disabled():
+    request_hook_service = RequestHookService(
+        auto_block_execution_tools=False,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    policy = LLMRequestPolicy(
+        document_toolset=SimpleNamespace(tools=[_tool("create_document")]),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: False,
+        request_hook_service=request_hook_service,
+    )
+    event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2")
+    req = ProviderRequest(
+        prompt="hello",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_file"),
+                _tool("existing_tool"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+
+    await policy.apply(event, req)
+
+    tool_names = set(req.func_tool.names())
+    assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+    assert "read_file" not in tool_names
+    assert "existing_tool" in tool_names
+    assert "astrbot_execute_shell" in tool_names
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -223,7 +223,7 @@ async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
         assert "astrbot_execute_shell" not in tool_names
         assert "create_document" not in tool_names
         assert "read_file" not in tool_names
-        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
         assert "文件工具使用指南" not in req.system_prompt
     finally:
         await plugin.terminate()
@@ -342,8 +342,49 @@ async def test_before_llm_chat_downgrades_active_document_session_for_unrelated_
         assert "create_document" not in tool_names
         assert "add_blocks" not in tool_names
         assert "read_file" not in tool_names
-        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
         assert "当前文档状态摘要" not in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_downgrades_active_document_session_for_short_topic_switch():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        document_store = plugin._runtime.document_toolset.document_store
+        document_store.create_document(
+            CreateDocumentRequest(
+                session_id=event.unified_msg_origin,
+                title="季度经营复盘",
+            )
+        )
+        req = ProviderRequest(
+            prompt="继续讲个笑话",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("read_file"),
+                    _tool("create_document"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "read_file" not in tool_names
+        assert "create_document" not in tool_names
+        assert "文件工具使用指南" not in req.system_prompt
+        assert "当前文档状态摘要" not in req.system_prompt
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -699,7 +740,7 @@ async def test_before_llm_chat_does_not_restrict_for_question_style_tool_mention
         assert "create_office_file" not in tool_names
         assert "create_document" not in tool_names
         assert "read_file" not in tool_names
-        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -742,7 +783,7 @@ async def test_before_llm_chat_does_not_restrict_for_non_explicit_tool_mentions(
         assert "create_office_file" not in tool_names
         assert "create_document" not in tool_names
         assert "read_file" not in tool_names
-        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -1147,7 +1188,7 @@ async def test_llm_request_policy_does_not_upgrade_plain_chat_from_cached_upload
     await policy.apply(event, req)
 
     tool_names = set(req.func_tool.names())
-    assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+    assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
     assert "read_file" not in tool_names
     assert "create_office_file" not in tool_names
     assert "create_document" not in tool_names
@@ -1188,7 +1229,7 @@ async def test_llm_request_policy_keeps_execution_tools_when_no_file_intent_and_
     await policy.apply(event, req)
 
     tool_names = set(req.func_tool.names())
-    assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+    assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
     assert "read_file" not in tool_names
     assert "existing_tool" in tool_names
     assert "astrbot_execute_shell" in tool_names

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -430,6 +430,54 @@ async def test_before_llm_chat_uses_file_only_for_uploaded_file_without_document
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "把这个 pdf转word",
+        "先导出为pdf再转word",
+    ],
+)
+async def test_before_llm_chat_keeps_pdf_conversion_on_file_only_path(prompt: str):
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        req = ProviderRequest(
+            prompt=prompt,
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("read_file"),
+                    _tool("convert_to_pdf"),
+                    _tool("convert_from_pdf"),
+                    _tool("create_document"),
+                    _tool("add_blocks"),
+                    _tool("export_document"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "read_file" in tool_names
+        assert "convert_to_pdf" in tool_names
+        assert "convert_from_pdf" in tool_names
+        assert "create_document" not in tool_names
+        assert "add_blocks" not in tool_names
+        assert "export_document" not in tool_names
+        assert "文件处理规则" in req.system_prompt
+        assert "文件工具使用指南" not in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
 async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruction():
     context = MagicMock()
     plugin = FileOperationPlugin(context=context, config=_build_config())

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -73,6 +73,7 @@ def _build_event(
     event.unified_msg_origin = "session-1"
     event.message_str = ""
     event._buffer_reentry_count = 0
+    event._buffered = False
     event.set_extra.side_effect = lambda key, value: extras.__setitem__(key, value)
     event.get_extra.side_effect = lambda key=None, default=None: (
         dict(extras) if key is None else extras.get(key, default)
@@ -220,13 +221,169 @@ async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "astrbot_execute_shell" not in tool_names
-        assert {
-            "create_document",
-            "add_blocks",
-            "finalize_document",
-            "export_document",
-        }.issubset(tool_names)
+        assert "create_document" not in tool_names
+        assert "read_file" not in tool_names
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
         assert "文件工具使用指南" not in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_keeps_document_full_for_active_document_session_short_follow_up():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        document_store = plugin._runtime.document_toolset.document_store
+        document_store.create_document(
+            CreateDocumentRequest(
+                session_id=event.unified_msg_origin,
+                title="季度经营复盘",
+            )
+        )
+        req = ProviderRequest(
+            prompt="继续",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("read_file"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "create_document" in tool_names
+        assert "add_blocks" in tool_names
+        assert "export_document" in tool_names
+        assert "当前文档状态摘要" in req.system_prompt
+        assert "文件工具使用指南" in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_keeps_document_full_for_active_document_session_add_section():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        document_store = plugin._runtime.document_toolset.document_store
+        document_store.create_document(
+            CreateDocumentRequest(
+                session_id=event.unified_msg_origin,
+                title="季度经营复盘",
+            )
+        )
+        req = ProviderRequest(
+            prompt="再加一章关于销售的",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("read_file"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "create_document" in tool_names
+        assert "add_blocks" in tool_names
+        assert "export_document" in tool_names
+        assert "当前文档状态摘要" in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_downgrades_active_document_session_for_unrelated_chat():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        document_store = plugin._runtime.document_toolset.document_store
+        document_store.create_document(
+            CreateDocumentRequest(
+                session_id=event.unified_msg_origin,
+                title="季度经营复盘",
+            )
+        )
+        req = ProviderRequest(
+            prompt="今天天气怎么样",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("read_file"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "create_document" not in tool_names
+        assert "add_blocks" not in tool_names
+        assert "read_file" not in tool_names
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
+        assert "当前文档状态摘要" not in req.system_prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_uses_file_only_for_uploaded_file_without_document_intent():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        source_path = Path(__file__).resolve()
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE,
+            sender_id="user-1",
+        )
+        event.message_obj.message = [
+            Comp.File(name="source.txt", file=str(source_path)),
+        ]
+
+        async def _fake_extract_upload_source(_component):
+            return source_path, "source.txt"
+
+        plugin._extract_upload_source = _fake_extract_upload_source
+        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.txt")
+
+        req = ProviderRequest(
+            prompt="先看看里面写了什么",
+            system_prompt="base",
+            func_tool=ToolSet([_tool("existing_tool"), _tool("read_file")]),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "read_file" in tool_names
+        assert "create_document" not in tool_names
+        assert "add_blocks" not in tool_names
+        assert "文件处理规则" in req.system_prompt
+        assert "文件工具使用指南" not in req.system_prompt
+        assert "工作区文件名：source_1.txt" in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -376,7 +533,10 @@ async def test_before_llm_chat_requires_read_before_document_tools_for_uploaded_
 
         await plugin.before_llm_chat(event, req)
 
-        assert "MUST 先调用 `read_file` 读取内容，再创建文档" in req.system_prompt
+        assert (
+            "MUST 先调用 `read_file` 读取内容；读取成功后立刻调用 `create_document`"
+            in req.system_prompt
+        )
         assert "MUST 先调用 `read_file` 读取此文件" in req.system_prompt
         assert "原始文件名：source.docx" in req.system_prompt
         assert "工作区文件名：source_1.docx" in req.system_prompt
@@ -390,25 +550,15 @@ async def test_before_llm_chat_requires_read_before_document_tools_for_uploaded_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("prompt", "expected_tool"),
+    "prompt",
     [
-        (
-            "调用 create_office_file，filename=report，content=hello，file_type=word",
-            "create_office_file",
-        ),
-        (
-            "reviewpr请求create_office_file，filename=report，content=hello，file_type=word",
-            "create_office_file",
-        ),
-        (
-            "please call `create_office_file` with filename=report, content=hello, file_type=word",
-            "create_office_file",
-        ),
+        "调用 create_office_file，filename=report，content=hello，file_type=word",
+        "reviewpr请求create_office_file，filename=report，content=hello，file_type=word",
+        "please call `create_office_file` with filename=report, content=hello, file_type=word",
     ],
 )
 async def test_before_llm_chat_restricts_file_tools_for_explicit_tool_call(
     prompt: str,
-    expected_tool: str,
 ):
     context = MagicMock()
     plugin = FileOperationPlugin(context=context, config=_build_config())
@@ -437,12 +587,12 @@ async def test_before_llm_chat_restricts_file_tools_for_explicit_tool_call(
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
-        assert expected_tool in tool_names
-        assert "create_document" not in tool_names
-        assert "add_blocks" not in tool_names
-        assert "finalize_document" not in tool_names
-        assert "export_document" not in tool_names
-        assert "read_file" not in tool_names
+        assert "create_office_file" not in tool_names
+        assert "create_document" in tool_names
+        assert "add_blocks" in tool_names
+        assert "finalize_document" in tool_names
+        assert "export_document" in tool_names
+        assert "read_file" in tool_names
     finally:
         await plugin.terminate()
 
@@ -508,9 +658,10 @@ async def test_before_llm_chat_does_not_restrict_for_question_style_tool_mention
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
-        assert "create_office_file" in tool_names
-        assert "create_document" in tool_names
-        assert "read_file" in tool_names
+        assert "create_office_file" not in tool_names
+        assert "create_document" not in tool_names
+        assert "read_file" not in tool_names
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -550,9 +701,10 @@ async def test_before_llm_chat_does_not_restrict_for_non_explicit_tool_mentions(
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
-        assert "create_office_file" in tool_names
-        assert "create_document" in tool_names
-        assert "read_file" in tool_names
+        assert "create_office_file" not in tool_names
+        assert "create_document" not in tool_names
+        assert "read_file" not in tool_names
+        assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -568,7 +720,7 @@ async def test_before_llm_chat_does_not_treat_system_notice_as_explicit_tool_cal
         )
         event.message_str = "[System Notice] 用户上传了文件，请先调用 `read_file` 读取内容，再继续处理。"
         req = ProviderRequest(
-            prompt="",
+            prompt="请根据文件整理成 Word 报告",
             system_prompt="base",
             func_tool=ToolSet(
                 [
@@ -738,7 +890,7 @@ async def test_llm_request_policy_runs_internal_notice_and_tool_hooks():
     )
     event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1")
     req = ProviderRequest(
-        prompt="hello",
+        prompt="请生成一份 Word 报告",
         system_prompt="base",
         func_tool=ToolSet([_tool("create_document"), _tool("existing_tool")]),
     )
@@ -1213,7 +1365,7 @@ async def test_buffered_upload_with_prompt_uses_structured_notice_and_follow_thr
     assert "先调用 `read_file` 读取文件" in prompt_text
     assert "不要自行猜测文件名，也不要列目录或调用 shell" in prompt_text
     assert (
-        "如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取后继续调用相应工具完成结果"
+        "如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取成功后必须直接调用 `create_document`"
         in prompt_text
     )
     assert not queued_event.message_str.startswith("/")

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -44,6 +44,7 @@ from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_UPLOAD_SUMMARY,
     SECTION_SCENE_UPLOADED_FILE,
     SECTION_STATIC_DOCUMENT_TOOLS,
+    SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
     PromptContextService,
 )
 from astrbot_plugin_office_assistant.utils import (
@@ -1391,6 +1392,96 @@ async def test_request_hook_service_does_not_fallback_to_active_document_when_do
     assert "文件工具使用指南" in context.notices[0]
     assert "当前文档状态摘要" not in context.notices[0]
     assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_does_not_append_active_document_summary_for_new_document_intent():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+        get_active_document_prompt_summary=lambda _session_id: {
+            "document_id": "doc-active",
+            "title": "当前活动草稿",
+            "status": "draft",
+            "block_count": 2,
+            "latest_block_types": ["paragraph"],
+            "next_allowed_actions": ["add_blocks", "finalize_document"],
+        },
+    )
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt="请生成一份新的报告",
+            system_prompt="base",
+            func_tool=ToolSet([_tool("create_document")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        exposure_level=ExposureLevel.DOCUMENT_FULL,
+        notices=[],
+        section_names=[],
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert len(context.notices) == 2
+    assert "文件工具使用指南" in context.notices[0]
+    assert "文件工具细节指南" in context.notices[1]
+    assert all("当前文档状态摘要" not in notice for notice in context.notices)
+    assert context.section_names == [
+        SECTION_STATIC_DOCUMENT_TOOLS,
+        SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_appends_active_document_summary_for_followup_without_document_id():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+        get_active_document_prompt_summary=lambda _session_id: {
+            "document_id": "doc-active",
+            "title": "当前活动草稿",
+            "status": "draft",
+            "block_count": 2,
+            "latest_block_types": ["paragraph"],
+            "next_allowed_actions": ["add_blocks", "finalize_document"],
+        },
+    )
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt="继续完善上一版报告",
+            system_prompt="base",
+            func_tool=ToolSet([_tool("create_document")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        exposure_level=ExposureLevel.DOCUMENT_FULL,
+        notices=[],
+        section_names=[],
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert len(context.notices) == 3
+    assert "文件工具使用指南" in context.notices[0]
+    assert "文件工具细节指南" in context.notices[1]
+    assert "当前文档状态摘要" in context.notices[2]
+    assert "document_id: doc-active" in context.notices[2]
+    assert context.section_names == [
+        SECTION_STATIC_DOCUMENT_TOOLS,
+        SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
+        SECTION_DYNAMIC_DOCUMENT_SUMMARY,
+    ]
 
 
 def test_prompt_context_service_orders_notice_sections_by_stability():

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1352,6 +1352,47 @@ async def test_request_hook_service_appends_document_summary_for_existing_docume
     ]
 
 
+@pytest.mark.asyncio
+async def test_request_hook_service_does_not_fallback_to_active_document_when_document_id_missing():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+        get_document_prompt_summary=lambda _document_id: None,
+        get_active_document_prompt_summary=lambda _session_id: {
+            "document_id": "doc-active",
+            "title": "当前活动草稿",
+            "status": "draft",
+            "block_count": 2,
+            "latest_block_types": ["paragraph"],
+            "next_allowed_actions": ["add_blocks", "finalize_document"],
+        },
+    )
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt='继续完善 document_id="doc-missing" 的内容',
+            system_prompt="base",
+            func_tool=ToolSet([_tool("create_document")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        exposure_level=ExposureLevel.DOCUMENT_FULL,
+        notices=[],
+        section_names=[],
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert len(context.notices) == 1
+    assert "文件工具使用指南" in context.notices[0]
+    assert "当前文档状态摘要" not in context.notices[0]
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+
+
 def test_prompt_context_service_orders_notice_sections_by_stability():
     service = PromptContextService(allow_external_input_files=False)
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1173,6 +1173,101 @@ async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_pr
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_reuses_cached_upload_summary_without_current_file_components():
+    request = ProviderRequest(
+        prompt="读取看看",
+        system_prompt="base",
+        func_tool=ToolSet([_tool("read_file")]),
+    )
+    event = _build_event()
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [
+            {
+                "original_name": "empty_1.txt",
+                "file_suffix": ".txt",
+                "type_desc": "文本/代码文件",
+                "is_supported": True,
+                "stored_name": "empty_1.txt",
+                "source_path": "",
+            },
+            {
+                "original_name": "empty_2.txt",
+                "file_suffix": ".txt",
+                "type_desc": "文本/代码文件",
+                "is_supported": True,
+                "stored_name": "empty_2.txt",
+                "source_path": "",
+            },
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=event,
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        notices=[],
+        section_names=[],
+    )
+
+    context = await service.append_uploaded_file_notices(context)
+
+    assert len(context.notices) == 1
+    assert context.section_names == [SECTION_DYNAMIC_UPLOAD_SUMMARY]
+    assert "文件数量：2" in context.notices[0]
+    assert "empty_1.txt" in context.notices[0]
+    assert "empty_2.txt" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_uses_session_upload_infos_when_event_cache_is_empty():
+    request = ProviderRequest(
+        prompt="你看一下",
+        system_prompt="base",
+        func_tool=ToolSet([_tool("read_file")]),
+    )
+    event = _build_event()
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        list_session_upload_infos=lambda _event: [
+            {
+                "original_name": "empty_1.txt",
+                "file_suffix": ".txt",
+                "type_desc": "文本/代码文件",
+                "is_supported": True,
+                "stored_name": "empty_1.txt",
+                "source_path": "",
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=event,
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        notices=[],
+        section_names=[],
+    )
+
+    context = await service.append_uploaded_file_notices(context)
+
+    assert len(context.notices) == 1
+    assert context.section_names == [SECTION_DYNAMIC_UPLOAD_SUMMARY]
+    assert "原始文件名：empty_1.txt" in context.notices[0]
+    assert "工作区文件名：empty_1.txt" in context.notices[0]
+    assert "empty_1.txt" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_keeps_scene_notice_for_buffered_prompt_with_instruction():
     request = ProviderRequest(
         prompt=(

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -15,6 +15,7 @@ from astrbot_plugin_office_assistant.constants import (
     DEFAULT_MAX_INLINE_DOCX_IMAGE_MB,
     DOC_COMMAND_TRIGGER_EVENT_KEY,
     EXPLICIT_FILE_TOOL_EVENT_KEY,
+    ExposureLevel,
     OfficeType,
 )
 from astrbot_plugin_office_assistant.internal_hooks import NoticeBuildContext
@@ -1013,6 +1014,7 @@ async def test_request_hook_service_builds_default_tool_hooks():
         should_expose=True,
         can_process_upload=True,
         explicit_tool_name="read_file",
+        allowed_tool_names=("read_file", "create_document"),
     )
 
     for hook in service.build_tool_exposure_hooks():
@@ -1329,6 +1331,7 @@ async def test_request_hook_service_appends_document_summary_for_existing_docume
         should_expose=True,
         can_process_upload=True,
         explicit_tool_name=None,
+        exposure_level=ExposureLevel.DOCUMENT_FULL,
         notices=[],
     )
 


### PR DESCRIPTION
## Summary

这个 PR 把插件工具暴露从原来的布尔判断改成按意图分级，重点减少普通聊天和 file-only 场景里不必要的文档工具注入，同时保留文档工作流需要的完整链路。

## 这次改了什么

- 新增 `ExposureLevel`，统一为 `NONE`、`FILE_ONLY`、`DOCUMENT_FULL` 三个级别
- `LLMRequestPolicy` 改为集中判断暴露级别，并按级别直接保留允许工具
- 普通聊天默认降到 `NONE`，不再暴露文件/Office/PDF 相关工具
- 上传文件但没有文档目标时，改为 `FILE_ONLY`，只保留 `read_file` 和 PDF 转换工具
- 明确要求整理成文档、报告、Word，或带有 `document_id` 时，保留完整文档工具链
- 活动草稿不再一直保持文档链，只有“继续”“再加”“导出”这类延续短句才维持 `DOCUMENT_FULL`
- `RequestHookService` 和 `PromptContextService` 改为按 `exposure_level` 分层注入 prompt
- 新增 file-only 极简提示，避免在非文档场景注入整套文档指南
- 上传文件且目标明确为文档时，统一要求 `read_file` 成功后直接进入 `create_document`
- 新增按 session 读取最近活动文档摘要的能力，并接入请求阶段复用
- 补充日志字段，输出 `exposure_level`、允许工具集合和命中的 prompt sections`

## 为什么要改

之前的行为里，只要进入文件处理路径，就会把整套文档工具和相关提示一起带进请求。这样会让两类场景都变重：

- 普通聊天其实不需要任何插件工具，但仍然可能带入文件相关能力
- 只需要读文件或处理 PDF 的场景，也会额外注入整套文档工具 schema 和文档指南

这次调整之后，行为会更符合预期：

- 普通聊天不再暴露插件工具
- 只读文件或处理 PDF 时，只进入 file-only 路径
- 明确生成文档时，仍然保留完整文档工具链
- 活动草稿场景下，延续性输入可以继续文档链，闲聊则会自动降级

## 预期收益

- 普通聊天场景：不再暴露任何插件工具，文档/文件工具 schema 增量为 `0`；当前实现仍保留一小段限制提示，因此总 token 增量不是绝对 `0`，但相对原先会显著下降
- file-only 场景：不再注入文档工具链和文档指南，只保留 `read_file` 与 PDF 相关工具，预计相对当前 `master` 下降约 `85% ~ 95%`
- 明确文档生成场景：仍然保留完整文档工具链，这类场景的 token 下降不会太大，主要收益来自 prompt 分层和减少误注入，预计下降约 `0% ~ 15%`
- 活动草稿但用户转入闲聊的场景：现在会自动降回 `NONE`，预计可接近普通聊天场景的下降幅度

## 测试

执行了：

```bash
PYTHONPATH="D:\aobo\open_source;D:\aobo\open_source\AstrBot" python -m pytest astrbot_plugin_office_assistant/tests -q
```

结果：
```
297 passed, 6 warnings
```

## 变更范围

本次修改了这 13 个文件：

- constants.py
- domain/document/session_store.py
- internal_hooks.py
- prompts/scenes/uploaded_file.py
- prompts/static/__init__.py
- prompts/static/access.py
- prompts/static/document_tools.py
- services/llm_request_policy.py
- services/prompt_context_service.py
- services/request_hook_service.py
- services/runtime_builder.py
- tests/test_office_assistant_before_llm_chat.py
- tests/test_office_assistant_services.py

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

</details>

增强内容：
- 添加 ExposureLevel 等级（none、file-only、document-full），用于驱动在每个请求中暴露哪些文件/文档工具。
- 优化 LLMRequestPolicy 和 RequestHookService，以推断文件 vs 文档意图、推导 exposure_level，并据此过滤允许使用的工具。
- 注入更轻量的、仅针对文件的系统提示，并基于 exposure_level 有条件地包含完整文档工作流指引和摘要。
- 按会话暴露最近的活动文档摘要，用于构造提示词，同时避免错误的回退行为。
- 更新已上传文件处理的提示，引导在目标是文档工作流时强制立即调用 create_document，并在仅文件流程中避免不必要地进入 document-chain。

测试：
- 扩展和调整 office assistant 的测试，以覆盖曝光等级、后续行为、缓存上传、执行工具阻断以及新的提示文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

</details>

增强内容：
- 添加 ExposureLevel 等级（none、file-only、document-full），用于驱动在每个请求中暴露哪些文件/文档工具。
- 优化 LLMRequestPolicy 和 RequestHookService，以推断文件 vs 文档意图、推导 exposure_level，并据此过滤允许使用的工具。
- 注入更轻量的、仅针对文件的系统提示，并基于 exposure_level 有条件地包含完整文档工作流指引和摘要。
- 按会话暴露最近的活动文档摘要，用于构造提示词，同时避免错误的回退行为。
- 更新已上传文件处理的提示，引导在目标是文档工作流时强制立即调用 create_document，并在仅文件流程中避免不必要地进入 document-chain。

测试：
- 扩展和调整 office assistant 的测试，以覆盖曝光等级、后续行为、缓存上传、执行工具阻断以及新的提示文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

增强内容：
- 新增 `ExposureLevel` 枚举，并在 `LLMRequestPolicy` 中集中实现逻辑，用于推断文件 vs 文档意图、计算 `exposure_level`，并据此过滤允许的工具。
- 优化 `RequestHookService` 和 `PromptContextService`，根据 `exposure_level` 分层组织提示段落，包括轻量级的“仅文件”提示，以及有条件地注入文档工作流指引和摘要。
- 通过文档会话存储对外提供每个会话的最近活跃文档摘要，并在文档 `document_id` 解析失败时，利用这些摘要增强提示，而不会错误回退到不相关文档。
- 更新上传文件处理相关提示，以区分“仅文件”流程和“文档工作流”，并在目标是文档时，要求在成功读取后立即调用 `create_document`。
- 扩展内部 hook 上下文以携带曝光元数据，并在工具曝光和提示/通知构建流水线中传递 `allowed_tool_names`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、“仅文件” vs “完整文档”行为、缓存上传、执行工具阻塞以及新的提示文案。
- 为 `RequestHookService` 的文档摘要行为添加测试，包括在请求的 `document_id` 没有摘要时，避免回退到当前活跃文档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入「曝光级别」（exposure levels）来控制何时展示文件和文档工具，将纯聊天、仅文件和完整文档工作流区分开来，并相应调整提示词和策略。

增强内容：
- 新增 `ExposureLevel` enum，并在 `LLMRequestPolicy` 中集中处理意图检测和工具曝光逻辑，包括按曝光级别划分的允许工具集以及更丰富的日志记录。
- 优化 `RequestHookService` 和 `PromptContextService`，根据曝光级别构建分层提示片段，包括轻量的仅文件提示说明，以及有条件地加入文档说明和文档摘要。
- 从文档会话存储中暴露每个会话最近的活动文档摘要，并在请求阶段将其接入提示构建，避免出现错误的回退行为。
- 更新上传文件场景的提示以及静态文档工具指引，使仅文件流程保持简洁，而文档流程则要求先执行 `read_file`，再执行 `create_document`。

测试：
- 扩展 office assistant 的 `before_llm_chat` 和策略测试，以覆盖曝光级别、活动文档的追问 vs 话题切换、仅文件 vs 完整文档行为、缓冲上传、显式工具限制以及执行工具阻断等场景。
- 为新的 `intent_patterns` 辅助函数以及 `RequestHookService` 的文档摘要行为新增单元测试，包括缺失 `document_id` 以及新文档意图等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce exposure levels to control when file and document tools are surfaced, separating plain chat, file-only, and full document workflows, and adjust prompts and policies accordingly.

Enhancements:
- Add an ExposureLevel enum and centralize intent detection and tool exposure logic in LLMRequestPolicy, including per-level allowed tool sets and richer logging.
- Refine RequestHookService and PromptContextService to build layered prompt sections based on exposure level, including a lightweight file-only notice and conditional document guides and summaries.
- Expose per-session latest active document summaries from the document session store and wire them into request-time prompt construction without incorrect fallbacks.
- Update uploaded-file scene prompts and static document tool guidance so that file-only flows stay minimal while document flows require read_file followed by create_document.

Tests:
- Expand office assistant before_llm_chat and policy tests to cover exposure levels, active-document follow-ups vs topic switches, file-only vs full-document behavior, buffered uploads, explicit tool restrictions, and execution-tool blocking.
- Add unit tests for the new intent_patterns helpers and for RequestHookService’s document-summary behavior, including cases with missing document_id and new-document intents.

</details>

</details>

</details>

</details>

</details>

</details>