### PR TITLE
feat: tighten document workflow prompts and notice handling

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -38,7 +38,7 @@ _CONTINUE_UNTIL_EXPORT = (
     "请继续调用文档工具，直到 export_document 成功。中途不要发自然语言回复。"
 )
 _FINALIZE_PROMPT = (
-    "文档已定稿。请立即调用 export_document 导出文件，不要发自然语言回复。"
+    "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document，也不要发自然语言回复。"
 )
 
 
@@ -325,7 +325,11 @@ class CreateDocumentTool(DocumentToolBase):
         return _dump_result(
             ToolResult(
                 success=True,
-                message=f"文档会话已创建。下一步请调用 add_blocks 添加内容。{_CONTINUE_UNTIL_EXPORT}",
+                message=(
+                    "文档会话已创建。下一步只能调用 add_blocks 添加内容，"
+                    "不要提前调用 finalize_document 或 export_document。"
+                    f"{_CONTINUE_UNTIL_EXPORT}"
+                ),
                 document=build_document_summary(document),
             )
         )
@@ -877,11 +881,25 @@ class AddBlocksTool(DocumentToolBase):
             )
             document = self.store.add_blocks(request)
         except Exception as exc:
-            return _dump_result(ToolResult(success=False, message=str(exc)))
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=(
+                        "add_blocks 失败。继续使用同一个 document_id 再次调用 "
+                        "add_blocks，只修正报错字段，不要改调 finalize_document "
+                        f"或 export_document。原始错误：{exc}"
+                    ),
+                )
+            )
         return _dump_result(
             ToolResult(
                 success=True,
-                message=f"内容块已添加。如果还有更多内容，继续调用 add_blocks；否则调用 finalize_document。{_CONTINUE_UNTIL_EXPORT}",
+                message=(
+                    "内容块已添加。如果还有任何章节、表格或补充信息没写完，继续调用 "
+                    "add_blocks；只有确认全部内容写完，才调用 finalize_document。"
+                    "定稿前不要调用 export_document。"
+                    f"{_CONTINUE_UNTIL_EXPORT}"
+                ),
                 document=build_document_summary(document),
             )
         )

--- a/internal_hooks.py
+++ b/internal_hooks.py
@@ -45,6 +45,8 @@ class NoticeBuildContext:
     explicit_tool_name: str | None
     notices: list[str] = field(default_factory=list)
     section_names: list[str] = field(default_factory=list)
+    system_notices: list[str] = field(default_factory=list)
+    system_section_names: list[str] = field(default_factory=list)
 
 
 @dataclass(slots=True)

--- a/prompts/scenes/__init__.py
+++ b/prompts/scenes/__init__.py
@@ -1,11 +1,11 @@
 from .uploaded_file import (
     build_buffered_upload_prompt,
-    build_uploaded_file_notice,
-    format_upload_file_info,
+    build_uploaded_file_context_notice,
+    format_minimal_upload_file_info,
 )
 
 __all__ = [
     "build_buffered_upload_prompt",
-    "build_uploaded_file_notice",
-    "format_upload_file_info",
+    "build_uploaded_file_context_notice",
+    "format_minimal_upload_file_info",
 ]

--- a/prompts/scenes/uploaded_file.py
+++ b/prompts/scenes/uploaded_file.py
@@ -3,95 +3,34 @@ from ...services.upload_types import UploadInfo
 MAX_DETAILED_UPLOAD_INFOS = 3
 
 
-def format_upload_file_info(
-    info: UploadInfo,
-    *,
-    allow_external_input_files: bool,
-) -> str:
-    file_lines = [f"原始文件名: {info['original_name']} (类型: {info['file_suffix']})"]
+def format_minimal_upload_file_info(info: UploadInfo) -> str:
+    file_lines = [f"原始文件名: {info['original_name']}"]
     if info["stored_name"]:
         file_lines.append(f"  工作区文件名: {info['stored_name']}")
-    if allow_external_input_files and info["source_path"]:
-        file_lines.append(f"  外部绝对路径: {info['source_path']}")
     return "\n".join(file_lines)
 
 
-def build_uploaded_file_notice(
-    *,
-    type_desc: str,
-    original_name: str,
-    file_suffix: str,
-    stored_name: str,
-    source_path: str,
-    allow_external_input_files: bool,
-) -> str:
-    return (
-        "\n[System Notice] [ACTION REQUIRED] 已收到上传文件\n"
-        f"- 文件类型：{type_desc}\n"
-        f"- 原始文件名：{original_name}（后缀：{file_suffix}）\n"
-        f"- 工作区文件名：{stored_name}\n"
-        f"{_build_external_path_line(source_path=source_path, allow_external_input_files=allow_external_input_files)}"
-        "- 状态：已保存到工作区\n"
-        "\n"
-        "[路径提示]\n"
-        f"- 必须使用工作区文件名 `{stored_name}`\n"
-        f"- 读取时请使用工作区文件名：`{stored_name}`\n"
-        f"- 不要使用原始文件名：`{original_name}`\n"
-        f"{_build_external_path_hint(source_path=source_path, allow_external_input_files=allow_external_input_files)}"
-    )
-
-
-def build_uploaded_file_scene_notice(
-    *,
-    file_count: int,
-    allow_external_input_files: bool,
-) -> str:
-    file_requirement = (
-        "MUST 先调用 `read_file` 读取此文件"
-        if file_count == 1
-        else "MUST 先调用 `read_file` 依次读取这些文件"
-    )
-    return (
-        "\n[操作要求]\n"
-        f"1. {file_requirement}，不要自行猜测文件名，也不要列目录或调用 shell。"
-        f"{_build_relative_path_rule(allow_external_input_files=allow_external_input_files)}"
-        "在读取前 NEVER 创建新文档。\n"
-        "2. 如果用户意图明确，读取后按需处理；如果意图不清楚，读取后用中文追问用户。\n"
-        "3. 所有面向用户的回复 MUST 使用中文。\n"
-    )
-
-
-def build_uploaded_file_summary_notice(
-    *,
-    upload_infos: list[UploadInfo],
-    allow_external_input_files: bool,
-) -> str:
-    readable_infos = [info for info in upload_infos if info["is_supported"]]
-    if not readable_infos:
+def build_uploaded_file_context_notice(*, upload_infos: list[UploadInfo]) -> str:
+    if not upload_infos:
         return ""
 
-    file_info_list, omitted_infos = _build_limited_file_info_list(
-        readable_infos,
-        allow_external_input_files=allow_external_input_files,
+    file_info_list, omitted_infos = _build_limited_file_info_list(upload_infos)
+    file_requirement = (
+        "先调用 `read_file` 读取此文件。"
+        if len(upload_infos) == 1
+        else "先调用 `read_file` 依次读取这些文件。"
     )
-
     return (
         "\n[System Notice] [ACTION REQUIRED] 已收到上传文件\n"
-        + f"- 文件数量：{len(readable_infos)}\n"
-        + "- 状态：已保存到工作区\n"
-        + "\n"
+        + f"- 文件数量：{len(upload_infos)}\n\n"
         + "[文件信息]\n"
         + "\n".join(f"- {info}" for info in file_info_list)
-        + _build_omitted_upload_info_line(
-            omitted_infos,
-            allow_external_input_files=allow_external_input_files,
-        )
+        + _build_omitted_upload_info_line(omitted_infos)
         + "\n\n"
-        + "[路径提示]\n"
-        + "- 若使用相对路径，请使用上面的工作区文件名。\n"
-        + _build_multi_file_external_path_hint(
-            allow_external_input_files=allow_external_input_files
-        )
+        + "[处理要求]\n"
+        + f"1. {file_requirement}\n"
+        + "2. 不要猜文件名，不要列目录，不要调用 shell。\n"
+        + "3. 读取前不要创建新文档。"
     )
 
 
@@ -99,147 +38,60 @@ def build_buffered_upload_prompt(
     *,
     upload_infos: list[UploadInfo],
     user_instruction: str,
-    allow_external_input_files: bool,
 ) -> str:
-    file_info_list, omitted_infos = _build_limited_file_info_list(
-        upload_infos,
-        allow_external_input_files=allow_external_input_files,
-    )
+    file_info_list, omitted_infos = _build_limited_file_info_list(upload_infos)
     has_readable_file = any(info["is_supported"] for info in upload_infos)
-    relative_path_guidance = _build_relative_path_guidance(
-        allow_external_input_files=allow_external_input_files
-    )
-    omitted_info_line = _build_omitted_upload_info_line(
-        omitted_infos,
-        allow_external_input_files=allow_external_input_files,
+    file_info_block = (
+        f"\n[System Notice] 用户上传了 {len(upload_infos)} 个文件\n\n"
+        "[文件信息]\n"
+        + "\n".join(f"- {info}" for info in file_info_list)
+        + _build_omitted_upload_info_line(omitted_infos)
     )
 
     if has_readable_file and user_instruction:
         return (
-            f"\n[System Notice] 用户上传了 {len(upload_infos)} 个文件\n"
-            + "\n"
-            + "[文件信息]\n"
-            + "\n".join(f"- {info}" for info in file_info_list)
-            + omitted_info_line
-            + "\n"
-            + "\n"
-            + "[用户指令]\n"
-            + f"{user_instruction}\n"
-            + "\n"
-            + "[处理建议]\n"
+            "\n[用户指令]\n"
+            + f"{user_instruction}\n\n"
+            + file_info_block
+            + "\n\n"
+            + "[处理要求]\n"
             + "1. 优先围绕这些上传文件完成用户请求。\n"
-            + "2. 先调用 `read_file` 读取文件，不要自行猜测文件名，也不要列目录或调用 shell。\n"
-            + relative_path_guidance
-            + "4. 如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取后继续调用相应工具完成结果，不要停下来只回复过渡说明。\n"
-            + "5. 所有面向用户的回复 MUST 使用中文。"
+            + "2. 先调用 `read_file` 读取文件。\n"
+            + "3. 不要猜文件名，不要列目录，不要调用 shell。\n"
+            + "4. 读取后按用户指令继续调用工具，不要只回复过渡说明。"
         )
 
     if has_readable_file:
         return (
-            f"\n[System Notice] 用户上传了 {len(upload_infos)} 个文件\n"
-            + "\n"
-            + "[文件信息]\n"
-            + "\n".join(f"- {info}" for info in file_info_list)
-            + omitted_info_line
-            + "\n"
-            + "\n"
-            + "[处理建议]\n"
+            file_info_block
+            + "\n\n"
+            + "[处理要求]\n"
             + "1. 用户上传了可读取文件，后续应优先围绕这些文件处理。\n"
-            + "2. 如果要读取文件，不要自行猜测文件名，也不要列目录或调用 shell。\n"
-            + relative_path_guidance
+            + "2. 如需读取文件，先调用 `read_file`。\n"
+            + "3. 不要猜文件名，不要列目录，不要调用 shell。\n"
             + "4. 用户意图尚不明确时，再用中文询问用户想要如何处理。"
         )
 
     return (
-        f"\n[System Notice] 用户上传了 {len(upload_infos)} 个文件\n"
-        "\n"
-        "[文件信息]\n"
-        + "\n".join(f"- {info}" for info in file_info_list)
-        + omitted_info_line
-        + "\n"
-        "\n"
-        "[操作要求]\n"
-        "请根据用户要求处理这些文件，使用中文与用户沟通。"
+        file_info_block
+        + "\n\n"
+        + "[操作要求]\n"
+        + "请根据用户要求处理这些文件，使用中文与用户沟通。"
     )
-
-
-def _build_relative_path_guidance(*, allow_external_input_files: bool) -> str:
-    if allow_external_input_files:
-        return (
-            "3. 若使用相对路径，请使用上面的工作区文件名；"
-            "如果已提供外部绝对路径，则可直接使用该绝对路径。\n"
-        )
-    return "3. 若使用相对路径，请使用上面的工作区文件名。\n"
-
-
-def _build_relative_path_rule(*, allow_external_input_files: bool) -> str:
-    if allow_external_input_files:
-        return "若使用相对路径，请使用上面给出的工作区文件名；如果已提供外部绝对路径，也可以直接使用。"
-    return "若使用相对路径，请使用上面给出的工作区文件名。"
-
-
-def _build_external_path_line(
-    *,
-    source_path: str,
-    allow_external_input_files: bool,
-) -> str:
-    if allow_external_input_files and source_path:
-        return f"- 外部绝对路径：{source_path}\n"
-    return ""
-
-
-def _build_external_path_hint(
-    *,
-    source_path: str,
-    allow_external_input_files: bool,
-) -> str:
-    if allow_external_input_files and source_path:
-        return f"- 也可以直接使用外部绝对路径：`{source_path}`\n"
-    return "- 当前未启用外部绝对路径，不要使用工作区外路径。\n"
-
-
-def _build_multi_file_external_path_hint(*, allow_external_input_files: bool) -> str:
-    if allow_external_input_files:
-        return "- 已提供外部绝对路径时，也可以直接使用上面给出的绝对路径。\n"
-    return "- 当前未启用外部绝对路径，不要使用工作区外路径。\n"
 
 
 def _build_limited_file_info_list(
     upload_infos: list[UploadInfo],
-    *,
-    allow_external_input_files: bool,
 ) -> tuple[list[str], list[UploadInfo]]:
     limited_infos = upload_infos[:MAX_DETAILED_UPLOAD_INFOS]
     omitted_infos = upload_infos[MAX_DETAILED_UPLOAD_INFOS:]
-    file_info_list = [
-        format_upload_file_info(
-            info,
-            allow_external_input_files=allow_external_input_files,
-        )
-        for info in limited_infos
-    ]
+    file_info_list = [format_minimal_upload_file_info(info) for info in limited_infos]
     return file_info_list, omitted_infos
 
 
-def _build_omitted_upload_info_line(
-    omitted_infos: list[UploadInfo],
-    *,
-    allow_external_input_files: bool,
-) -> str:
+def _build_omitted_upload_info_line(omitted_infos: list[UploadInfo]) -> str:
     if not omitted_infos:
         return ""
-    if allow_external_input_files:
-        rendered_items = [
-            rendered_item
-            for info in omitted_infos
-            if (rendered_item := _build_compact_upload_path_item(info))
-        ]
-        if rendered_items:
-            return (
-                f"\n- 其余 {len(rendered_items)} 个文件："
-                + "；".join(rendered_items)
-                + "（未展开详细信息）"
-            )
     display_names = [
         display_name
         for info in omitted_infos
@@ -256,11 +108,3 @@ def _build_omitted_upload_info_line(
 
 def _display_upload_name(info: UploadInfo) -> str:
     return info.get("stored_name") or info.get("original_name") or ""
-
-
-def _build_compact_upload_path_item(info: UploadInfo) -> str:
-    display_name = _display_upload_name(info)
-    source_path = info.get("source_path") or ""
-    if display_name and source_path:
-        return f"{display_name} -> {source_path}"
-    return display_name

--- a/prompts/static/__init__.py
+++ b/prompts/static/__init__.py
@@ -1,11 +1,15 @@
 from .access import build_tools_denied_notice
 from .document_tools import (
+    build_document_follow_up_missing_notice,
+    build_document_follow_up_notice,
     build_document_tools_core_notice,
     build_document_tools_detail_notice,
     build_document_tools_guide_notice,
 )
 
 __all__ = [
+    "build_document_follow_up_missing_notice",
+    "build_document_follow_up_notice",
     "build_document_tools_core_notice",
     "build_document_tools_detail_notice",
     "build_document_tools_guide_notice",

--- a/prompts/static/document_tools.py
+++ b/prompts/static/document_tools.py
@@ -21,6 +21,11 @@ def build_document_tools_core_notice() -> str:
         "`document_id` 调用 `add_blocks`\n"
         "- `create_document` 参数：theme_name / table_template / density / accent_color\n"
         "- 按章节或逻辑块分批调用 `add_blocks`\n"
+        "- 只要还有任何章节、表格或补充信息没写完，继续调用 `add_blocks`，不要提前调用 "
+        "`finalize_document`\n"
+        "- 只有确认整份文档内容已经写完，才调用 `finalize_document`\n"
+        "- 一旦 `finalize_document` 成功，下一步只能调用 `export_document`，不要再回到 "
+        "`add_blocks` 或 `create_document`\n"
         "- `export_document` 会直接发送文件给用户\n"
         "\n"
         "[约束规则]\n"
@@ -29,6 +34,47 @@ def build_document_tools_core_notice() -> str:
         "3. 如果用户显式指定了某个工具名和参数，MUST 先按该工具调用；即使预期会报错，也不要擅自改调其他工具，也不要自行修改参数后重试。\n"
         "4. 一旦开始使用文档工具链，MUST 持续调用直到 `export_document` 成功，中途不要停下来发自然语言回复。\n"
         "5. 所有面向用户的回复和过渡说明 MUST 使用中文。"
+    )
+
+
+def build_document_follow_up_notice(
+    *,
+    document_id: str,
+    status: str,
+    block_count: int,
+) -> str:
+    if status == "draft":
+        return (
+            "\n[System Notice] 当前文档阶段\n"
+            f"- 当前 `document_id={document_id}` 仍是 draft，已写入 {block_count} 个内容块\n"
+            "- 如果还有任何内容没写完，继续调用 `add_blocks`\n"
+            "- 只有确认内容全部写完，才调用 `finalize_document`\n"
+        )
+    if status == "finalized":
+        return (
+            "\n[System Notice] 当前文档阶段\n"
+            f"- 当前 `document_id={document_id}` 已定稿\n"
+            "- 下一步只能调用 `export_document`\n"
+            "- 不要再调用 `add_blocks`、`finalize_document` 或 `create_document`\n"
+        )
+    if status == "exported":
+        return (
+            "\n[System Notice] 当前文档阶段\n"
+            f"- 当前 `document_id={document_id}` 已导出\n"
+            "- 不要继续对这份文档调用 `add_blocks`、`finalize_document` 或 `export_document`\n"
+        )
+    return (
+        "\n[System Notice] 当前文档阶段\n"
+        f"- 当前 `document_id={document_id}` 状态未知\n"
+        "- 先核对文档状态，不要切换到别的文档工具\n"
+    )
+
+
+def build_document_follow_up_missing_notice(*, document_id: str) -> str:
+    return (
+        "\n[System Notice] 当前文档阶段\n"
+        f"- 没有找到 `document_id={document_id}` 对应的文档会话\n"
+        "- 先核对 `document_id`，不要改调其他文档工具\n"
     )
 
 

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -170,21 +170,48 @@ class LLMRequestPolicy:
             for tool_name in EXECUTION_TOOLS:
                 req.func_tool.remove_tool(tool_name)
 
-    def _append_tools_denied_notice(self, req: ProviderRequest) -> None:
-        denied_section = self._prompt_context_service.build_tools_denied_section()
+    def _merge_notice_sections(
+        self,
+        req: ProviderRequest,
+        *,
+        section_names: list[str],
+        notices: list[str],
+        target: str,
+    ) -> None:
+        if not notices:
+            return
         ordered_names, ordered_notices = (
             self._prompt_context_service.order_notice_sections(
-                section_names=[denied_section.name],
-                notices=[denied_section.content],
+                section_names=section_names,
+                notices=notices,
             )
         )
-        req.system_prompt = (req.system_prompt or "") + "".join(ordered_notices)
+        merged_notice = "".join(ordered_notices)
+        if target == "system":
+            req.system_prompt = (req.system_prompt or "") + merged_notice
+        else:
+            current_prompt = str(req.prompt or "")
+            req.prompt = (
+                f"{current_prompt}\n\n{merged_notice}"
+                if current_prompt
+                else merged_notice
+            )
         logger.debug(
-            "[文件管理] Prompt sections: %s",
+            "[文件管理] Prompt sections(%s): %s",
+            target,
             self._prompt_context_service.build_section_trace(
                 section_names=ordered_names,
                 notices=ordered_notices,
             ),
+        )
+
+    def _append_tools_denied_notice(self, req: ProviderRequest) -> None:
+        denied_section = self._prompt_context_service.build_tools_denied_section()
+        self._merge_notice_sections(
+            req,
+            section_names=[denied_section.name],
+            notices=[denied_section.content],
+            target="system",
         )
 
     def _resolve_exposure_decision(
@@ -281,18 +308,15 @@ class LLMRequestPolicy:
                 explicit_tool_name=decision.explicit_tool_name,
             )
         )
-        if notice_context.notices:
-            ordered_names, ordered_notices = (
-                self._prompt_context_service.order_notice_sections(
-                    section_names=notice_context.section_names,
-                    notices=notice_context.notices,
-                )
-            )
-            req.system_prompt = (req.system_prompt or "") + "".join(ordered_notices)
-            logger.debug(
-                "[文件管理] Prompt sections: %s",
-                self._prompt_context_service.build_section_trace(
-                    section_names=ordered_names,
-                    notices=ordered_notices,
-                ),
-            )
+        self._merge_notice_sections(
+            req,
+            section_names=notice_context.section_names,
+            notices=notice_context.notices,
+            target="prompt_suffix",
+        )
+        self._merge_notice_sections(
+            req,
+            section_names=notice_context.system_section_names,
+            notices=notice_context.system_notices,
+            target="system",
+        )

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -5,11 +5,11 @@ from astrbot.api import logger
 
 from ..prompts.scenes.uploaded_file import (
     build_buffered_upload_prompt,
-    build_uploaded_file_notice,
-    build_uploaded_file_scene_notice,
-    build_uploaded_file_summary_notice,
+    build_uploaded_file_context_notice,
 )
 from ..prompts.static import (
+    build_document_follow_up_missing_notice,
+    build_document_follow_up_notice,
     build_document_tools_core_notice,
     build_document_tools_detail_notice,
     build_tools_denied_notice,
@@ -19,15 +19,15 @@ from .upload_types import UploadInfo
 SECTION_STATIC_ACCESS = "static_access"
 SECTION_STATIC_DOCUMENT_TOOLS = "static_document_tools"
 SECTION_STATIC_DOCUMENT_TOOLS_DETAIL = "static_document_tools_detail"
-SECTION_SCENE_UPLOADED_FILE = "scene_uploaded_file"
-SECTION_DYNAMIC_UPLOAD_SUMMARY = "dynamic_upload_summary"
-SECTION_DYNAMIC_DOCUMENT_SUMMARY = "dynamic_document_summary"
+SECTION_SCENE_UPLOADED_CONTEXT = "scene_uploaded_context"
+SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP = "dynamic_document_follow_up"
 
 
 @dataclass(frozen=True, slots=True)
 class PromptSection:
     name: str
     content: str
+    target: str = "prompt_suffix"
 
 
 class PromptContextService:
@@ -125,6 +125,7 @@ class PromptContextService:
         return PromptSection(
             name=SECTION_STATIC_ACCESS,
             content=build_tools_denied_notice(),
+            target="system",
         )
 
     def build_tools_denied_notice(self) -> str:
@@ -134,129 +135,53 @@ class PromptContextService:
         return PromptSection(
             name=SECTION_STATIC_DOCUMENT_TOOLS,
             content=build_document_tools_core_notice(),
+            target="prompt_suffix",
         )
 
     def build_document_tool_detail_section(self) -> PromptSection:
         return PromptSection(
             name=SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
             content=build_document_tools_detail_notice(),
+            target="prompt_suffix",
         )
 
-    def build_document_tool_guide_notice(self) -> str:
-        return self.render_sections(
-            self.build_document_tool_guide_section(),
-            self.build_document_tool_detail_section(),
-        )
-
-    def build_document_summary_section(
-        self,
-        *,
-        summary: dict[str, object],
-    ) -> PromptSection:
-        next_allowed_actions = (
-            ", ".join(
-                str(action)
-                for action in (summary.get("next_allowed_actions") or [])
-                if action
-            )
-            or "暂无"
-        )
-        status = str(summary.get("status") or "unknown")
-        block_count = int(summary.get("block_count") or 0)
-        document_id = str(summary.get("document_id") or "").strip()
-        return PromptSection(
-            name=SECTION_DYNAMIC_DOCUMENT_SUMMARY,
-            content=(
-                "\n[System Notice] 当前文档状态摘要\n"
-                f"- document_id: {document_id}\n"
-                f"- 状态: {status}\n"
-                f"- 块数: {block_count}\n"
-                f"- 下一步: {next_allowed_actions}\n"
-            ),
-        )
-
-    def build_document_summary_notice(
-        self,
-        *,
-        summary: dict[str, object],
-    ) -> str:
-        return self.render_sections(
-            self.build_document_summary_section(summary=summary)
-        )
-
-    def build_uploaded_file_notice_section(
-        self,
-        *,
-        type_desc: str,
-        original_name: str,
-        file_suffix: str,
-        stored_name: str,
-        source_path: str,
-    ) -> PromptSection:
-        return PromptSection(
-            name=SECTION_DYNAMIC_UPLOAD_SUMMARY,
-            content=build_uploaded_file_notice(
-                type_desc=type_desc,
-                original_name=original_name,
-                file_suffix=file_suffix,
-                stored_name=stored_name,
-                source_path=source_path,
-                allow_external_input_files=self._allow_external_input_files,
-            ),
-        )
-
-    def build_uploaded_file_scene_section(
-        self,
-        *,
-        file_count: int,
-    ) -> PromptSection:
-        return PromptSection(
-            name=SECTION_SCENE_UPLOADED_FILE,
-            content=build_uploaded_file_scene_notice(
-                file_count=file_count,
-                allow_external_input_files=self._allow_external_input_files,
-            ),
-        )
-
-    def build_uploaded_file_notice(
-        self,
-        *,
-        type_desc: str,
-        original_name: str,
-        file_suffix: str,
-        stored_name: str,
-        source_path: str,
-    ) -> str:
-        return self.render_sections(
-            self.build_uploaded_file_notice_section(
-                type_desc=type_desc,
-                original_name=original_name,
-                file_suffix=file_suffix,
-                stored_name=stored_name,
-                source_path=source_path,
-            )
-        )
-
-    def build_uploaded_file_summary_section(
+    def build_uploaded_file_context_section(
         self,
         *,
         upload_infos: list[UploadInfo],
     ) -> PromptSection:
         return PromptSection(
-            name=SECTION_DYNAMIC_UPLOAD_SUMMARY,
-            content=build_uploaded_file_summary_notice(
-                upload_infos=upload_infos,
-                allow_external_input_files=self._allow_external_input_files,
-            ),
+            name=SECTION_SCENE_UPLOADED_CONTEXT,
+            content=build_uploaded_file_context_notice(upload_infos=upload_infos),
+            target="prompt_suffix",
         )
 
-    def build_uploaded_file_summary_notice(
+    def build_document_follow_up_section(
         self,
         *,
-        upload_infos: list[UploadInfo],
-    ) -> str:
-        return self.render_sections(
-            self.build_uploaded_file_summary_section(upload_infos=upload_infos)
+        document_id: str,
+        status: str,
+        block_count: int,
+    ) -> PromptSection:
+        return PromptSection(
+            name=SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+            content=build_document_follow_up_notice(
+                document_id=document_id,
+                status=status,
+                block_count=block_count,
+            ),
+            target="prompt_suffix",
+        )
+
+    def build_document_follow_up_missing_section(
+        self,
+        *,
+        document_id: str,
+    ) -> PromptSection:
+        return PromptSection(
+            name=SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+            content=build_document_follow_up_missing_notice(document_id=document_id),
+            target="prompt_suffix",
         )
 
     def build_buffered_upload_prompt(
@@ -268,5 +193,4 @@ class PromptContextService:
         return build_buffered_upload_prompt(
             upload_infos=upload_infos,
             user_instruction=user_instruction,
-            allow_external_input_files=self._allow_external_input_files,
         )

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -43,7 +43,7 @@ class RequestHookService:
     )
     _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(r"\bdocument_id\b", flags=re.IGNORECASE)
     _DOCUMENT_ID_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b\s*(?:[:=]\s*|为\s*)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
+        r"\bdocument_id\b(?:\s*(?:[:=]|为|是)\s*|\s+)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
@@ -109,8 +109,9 @@ class RequestHookService:
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
         if self._is_document_follow_up(request_text=request_text):
             section = self._build_document_follow_up_section(request_text=request_text)
-            self._append_notice_section(context, section)
-            return context
+            if section is not None:
+                self._append_notice_section(context, section)
+                return context
         should_inject_core = self._should_inject_document_tool_guide(
             request_text=request_text
         )
@@ -191,8 +192,13 @@ class RequestHookService:
             )
         try:
             summary = self._lookup_document_summary(document_id)
-        except Exception:
+        except KeyError:
             summary = None
+        except Exception as exc:
+            logger.exception(
+                f"[文件管理] 查询文档会话摘要失败 document_id={document_id}: {exc}"
+            )
+            raise
         if not isinstance(summary, dict):
             return self.prompt_context_service.build_document_follow_up_missing_section(
                 document_id=document_id

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -21,7 +21,7 @@ from ..internal_hooks import (
     run_notice_hooks,
     run_tool_exposure_hooks,
 )
-from .prompt_context_service import PromptContextService
+from .prompt_context_service import PromptContextService, PromptSection
 from .upload_types import UploadInfo
 
 
@@ -30,24 +30,24 @@ class RequestHookService:
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
     )
-    _DOCUMENT_ID_RE = re.compile(
-        r'document_id["`\']?\s*[:=]\s*["`\']?(?P<document_id>[A-Za-z0-9_-]+)',
-        flags=re.IGNORECASE,
-    )
     _DOCUMENT_WORKFLOW_HINT_RE = re.compile(
         r"(create_document|add_blocks|finalize_document|export_document|"
-        r"document_id\b|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
+        r"正式汇报|正式报告|导出成\s*word|导出为\s*word|"
         r"\bword\b|\bdocx\b|汇报|报告|"
         r"生成\s*(?:word|docx|报告|汇报)|整理成\s*(?:word|docx|报告|汇报))",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_DETAIL_HINT_RE = re.compile(
-        r"(create_document|正式汇报|正式报告|导出成\s*word|导出为\s*word|"
-        r"\bword\b|\bdocx\b|汇报|报告|"
-        r"生成\s*(?:word|docx|报告|汇报)|整理成\s*(?:word|docx|报告|汇报)|"
-        r"business_report|project_review|executive_brief|accent_color|document_style)",
+        r"(business_report|project_review|executive_brief|accent_color|document_style)",
         flags=re.IGNORECASE,
     )
+    _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(r"\bdocument_id\b", flags=re.IGNORECASE)
+    _DOCUMENT_ID_CAPTURE_RE = re.compile(
+        r"\bdocument_id\b\s*(?:[:=]\s*|为\s*)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
+    _DOCUMENT_DETAIL_NOTICE_KEY = "document_detail_guide"
 
     def __init__(
         self,
@@ -58,17 +58,17 @@ class RequestHookService:
             [Comp.File], Awaitable[tuple[Path | None, str]]
         ],
         store_uploaded_file: Callable[[Path, str], Path],
+        consume_session_notice_once: Callable[[AstrMessageEvent, str], bool],
         allow_external_input_files: bool,
-        get_document_prompt_summary: (
-            Callable[[str], dict[str, object] | None] | None
-        ) = None,
         prompt_context_service: PromptContextService | None = None,
+        lookup_document_summary: Callable[[str], dict[str, object] | None] | None = None,
     ) -> None:
         self._auto_block_execution_tools = auto_block_execution_tools
         self._get_cached_upload_infos = get_cached_upload_infos
         self._extract_upload_source = extract_upload_source
         self._store_uploaded_file = store_uploaded_file
-        self._get_document_prompt_summary = get_document_prompt_summary
+        self._consume_session_notice_once = consume_session_notice_once
+        self._lookup_document_summary = lookup_document_summary
         self.prompt_context_service = prompt_context_service or PromptContextService(
             allow_external_input_files=allow_external_input_files
         )
@@ -107,36 +107,32 @@ class RequestHookService:
             return context
 
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
-        document_id = self._extract_document_id(request_text)
-        should_inject = self._should_inject_document_tool_guide(
-            request_text=request_text,
-            document_id=document_id,
+        if self._is_document_follow_up(request_text=request_text):
+            section = self._build_document_follow_up_section(request_text=request_text)
+            self._append_notice_section(context, section)
+            return context
+        should_inject_core = self._should_inject_document_tool_guide(
+            request_text=request_text
         )
-        if not should_inject:
+        should_inject_detail = self._should_inject_document_tool_detail(
+            request_text=request_text
+        )
+        if not should_inject_core and not should_inject_detail:
             return context
 
-        self._append_prompt_section(
-            context,
-            self.prompt_context_service.build_document_tool_guide_section(),
-        )
-        if self._should_inject_document_tool_detail(
-            request_text=request_text,
-            document_id=document_id,
+        if should_inject_core and self._consume_session_notice_once(
+            context.event, self._DOCUMENT_CORE_NOTICE_KEY
         ):
-            self._append_prompt_section(
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_document_tool_guide_section(),
+            )
+        if should_inject_detail and self._consume_session_notice_once(
+            context.event, self._DOCUMENT_DETAIL_NOTICE_KEY
+        ):
+            self._append_notice_section(
                 context,
                 self.prompt_context_service.build_document_tool_detail_section(),
-            )
-        if not (document_id and self._get_document_prompt_summary):
-            return context
-
-        summary = self._get_document_prompt_summary(document_id)
-        if summary:
-            self._append_prompt_section(
-                context,
-                self.prompt_context_service.build_document_summary_section(
-                    summary=summary
-                ),
             )
         return context
 
@@ -151,21 +147,7 @@ class RequestHookService:
         return stripped_prompt
 
     @classmethod
-    def _extract_document_id(cls, prompt: str) -> str | None:
-        match = cls._DOCUMENT_ID_RE.search(prompt)
-        if not match:
-            return None
-        return match.group("document_id")
-
-    @classmethod
-    def _should_inject_document_tool_guide(
-        cls,
-        *,
-        request_text: str,
-        document_id: str | None,
-    ) -> bool:
-        if document_id:
-            return True
+    def _should_inject_document_tool_guide(cls, *, request_text: str) -> bool:
         if not request_text:
             return False
         return bool(cls._DOCUMENT_WORKFLOW_HINT_RE.search(request_text))
@@ -175,23 +157,67 @@ class RequestHookService:
         cls,
         *,
         request_text: str,
-        document_id: str | None,
     ) -> bool:
         if not request_text:
             return False
-        if document_id and not cls._DOCUMENT_DETAIL_HINT_RE.search(request_text):
-            return False
         return bool(cls._DOCUMENT_DETAIL_HINT_RE.search(request_text))
 
+    @classmethod
+    def _is_document_follow_up(cls, *, request_text: str) -> bool:
+        if not request_text:
+            return False
+        return bool(cls._DOCUMENT_ID_FOLLOW_UP_RE.search(request_text))
+
+    @classmethod
+    def _extract_document_id(cls, *, request_text: str) -> str:
+        if not request_text:
+            return ""
+        match = cls._DOCUMENT_ID_CAPTURE_RE.search(request_text)
+        if not match:
+            return ""
+        return str(match.group("document_id") or "").strip()
+
+    def _build_document_follow_up_section(
+        self,
+        *,
+        request_text: str,
+    ) -> PromptSection | None:
+        document_id = self._extract_document_id(request_text=request_text)
+        if not document_id:
+            return None
+        if self._lookup_document_summary is None:
+            return self.prompt_context_service.build_document_follow_up_missing_section(
+                document_id=document_id
+            )
+        try:
+            summary = self._lookup_document_summary(document_id)
+        except Exception:
+            summary = None
+        if not isinstance(summary, dict):
+            return self.prompt_context_service.build_document_follow_up_missing_section(
+                document_id=document_id
+            )
+        return self.prompt_context_service.build_document_follow_up_section(
+            document_id=document_id,
+            status=str(summary.get("status") or ""),
+            block_count=int(summary.get("block_count") or 0),
+        )
+
     @staticmethod
-    def _append_prompt_section(
+    def _append_notice_section(
         context: NoticeBuildContext,
-        section,
+        section: PromptSection | None,
     ) -> None:
         if not section or not section.content:
             return
-        context.notices.append(section.content)
-        section_names = getattr(context, "section_names", None)
+        if section.target == "system":
+            notices = getattr(context, "system_notices", None)
+            section_names = getattr(context, "system_section_names", None)
+        else:
+            notices = getattr(context, "notices", None)
+            section_names = getattr(context, "section_names", None)
+        if isinstance(notices, list):
+            notices.append(section.content)
         if isinstance(section_names, list):
             section_names.append(section.name)
 
@@ -200,6 +226,8 @@ class RequestHookService:
         context: NoticeBuildContext,
     ) -> NoticeBuildContext:
         if not context.can_process_upload:
+            return context
+        if getattr(context.event, "_buffered", False) is True:
             return context
 
         event = context.event
@@ -286,49 +314,13 @@ class RequestHookService:
         if not readable_upload_infos:
             return context
 
-        if self._should_append_uploaded_file_scene_notice(
-            event=event,
-            prompt=str(req.prompt or ""),
-        ):
-            self._append_prompt_section(
-                context,
-                self.prompt_context_service.build_uploaded_file_scene_section(
-                    file_count=len(readable_upload_infos)
-                ),
-            )
-
-        if len(readable_upload_infos) == 1:
-            info = readable_upload_infos[0]
-            self._append_prompt_section(
-                context,
-                self.prompt_context_service.build_uploaded_file_notice_section(
-                    type_desc=info["type_desc"],
-                    original_name=info["original_name"],
-                    file_suffix=info["file_suffix"],
-                    stored_name=info["stored_name"],
-                    source_path=info["source_path"],
-                ),
-            )
-            return context
-
-        self._append_prompt_section(
+        self._append_notice_section(
             context,
-            self.prompt_context_service.build_uploaded_file_summary_section(
+            self.prompt_context_service.build_uploaded_file_context_section(
                 upload_infos=readable_upload_infos
             ),
         )
         return context
-
-    @classmethod
-    def _should_append_uploaded_file_scene_notice(
-        cls,
-        *,
-        event: AstrMessageEvent,
-        prompt: str,
-    ) -> bool:
-        if not getattr(event, "_buffered", False):
-            return True
-        return cls._BUFFERED_USER_INSTRUCTION_RE.search(prompt.strip()) is not None
 
     async def apply_execution_tool_block(
         self,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -26,6 +26,7 @@ from .upload_types import UploadInfo
 
 
 class RequestHookService:
+    _DOCUMENT_ID_TOKEN_RE = r"(?<![A-Za-z0-9_])document_id(?![A-Za-z0-9_])"
     _DOCUMENT_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _DOCUMENT_ID_DOC_PREFIX_RE = re.compile(
         r"doc-[A-Za-z0-9_-]+",
@@ -46,13 +47,18 @@ class RequestHookService:
         r"(business_report|project_review|executive_brief|accent_color|document_style)",
         flags=re.IGNORECASE,
     )
-    _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(r"\bdocument_id\b", flags=re.IGNORECASE)
+    _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(
+        _DOCUMENT_ID_TOKEN_RE,
+        flags=re.IGNORECASE,
+    )
     _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b(?:\s*[:=]\s*|\s+(?:为|是|is)\s+)[`\"']?(?P<document_id>[A-Za-z0-9_-]+)[`\"']?",
+        _DOCUMENT_ID_TOKEN_RE
+        + r"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<document_id>[A-Za-z0-9_-]+)[`\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_ID_BARE_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b\s+[`\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
+        _DOCUMENT_ID_TOKEN_RE
+        + r"\s+[`\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -42,8 +42,12 @@ class RequestHookService:
         flags=re.IGNORECASE,
     )
     _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(r"\bdocument_id\b", flags=re.IGNORECASE)
-    _DOCUMENT_ID_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b(?:\s*(?:[:=]|为|是)\s*|\s+)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
+    _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = re.compile(
+        r"\bdocument_id\b(?:\s*[:=]\s*|\s+(?:为|是|is)\s+)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
+        flags=re.IGNORECASE,
+    )
+    _DOCUMENT_ID_BARE_CAPTURE_RE = re.compile(
+        r"\bdocument_id\b\s+[\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
@@ -173,10 +177,14 @@ class RequestHookService:
     def _extract_document_id(cls, *, request_text: str) -> str:
         if not request_text:
             return ""
-        match = cls._DOCUMENT_ID_CAPTURE_RE.search(request_text)
-        if not match:
-            return ""
-        return str(match.group("document_id") or "").strip()
+        for pattern in (
+            cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
+            cls._DOCUMENT_ID_BARE_CAPTURE_RE,
+        ):
+            match = pattern.search(request_text)
+            if match:
+                return str(match.group("document_id") or "").strip()
+        return ""
 
     def _build_document_follow_up_section(
         self,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -26,6 +26,11 @@ from .upload_types import UploadInfo
 
 
 class RequestHookService:
+    _DOCUMENT_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
+    _DOCUMENT_ID_DOC_PREFIX_RE = re.compile(
+        r"doc-[A-Za-z0-9_-]+",
+        flags=re.IGNORECASE,
+    )
     _BUFFERED_USER_INSTRUCTION_RE = re.compile(
         r"\[用户指令\]\s*(?P<instruction>.*?)(?:\n\s*\[|\Z)",
         flags=re.DOTALL,
@@ -43,11 +48,11 @@ class RequestHookService:
     )
     _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(r"\bdocument_id\b", flags=re.IGNORECASE)
     _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b(?:\s*[:=]\s*|\s+(?:为|是|is)\s+)[\"']?(?P<document_id>[A-Za-z0-9_-]+)[\"']?",
+        r"\bdocument_id\b(?:\s*[:=]\s*|\s+(?:为|是|is)\s+)[`\"']?(?P<document_id>[A-Za-z0-9_-]+)[`\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_ID_BARE_CAPTURE_RE = re.compile(
-        r"\bdocument_id\b\s+[\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[\"']?",
+        r"\bdocument_id\b\s+[`\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
@@ -177,14 +182,25 @@ class RequestHookService:
     def _extract_document_id(cls, *, request_text: str) -> str:
         if not request_text:
             return ""
-        for pattern in (
-            cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
-            cls._DOCUMENT_ID_BARE_CAPTURE_RE,
-        ):
-            match = pattern.search(request_text)
-            if match:
-                return str(match.group("document_id") or "").strip()
+        explicit_match = cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE.search(request_text)
+        if explicit_match:
+            return str(explicit_match.group("document_id") or "").strip()
+
+        bare_match = cls._DOCUMENT_ID_BARE_CAPTURE_RE.search(request_text)
+        if bare_match:
+            candidate = str(bare_match.group("document_id") or "").strip()
+            if cls._looks_like_bare_document_id(candidate):
+                return candidate
         return ""
+
+    @classmethod
+    def _looks_like_bare_document_id(cls, candidate: str) -> bool:
+        if not candidate:
+            return False
+        return bool(
+            cls._DOCUMENT_ID_HEX_RE.fullmatch(candidate)
+            or cls._DOCUMENT_ID_DOC_PREFIX_RE.fullmatch(candidate)
+        )
 
     def _build_document_follow_up_section(
         self,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -217,9 +217,7 @@ class RequestHookService:
         if not document_id:
             return None
         if self._lookup_document_summary is None:
-            return self.prompt_context_service.build_document_follow_up_missing_section(
-                document_id=document_id
-            )
+            return None
         try:
             summary = self._lookup_document_summary(document_id)
         except KeyError:

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -234,24 +234,16 @@ def _build_request_pipeline_services(
     prompt_context_service = PromptContextService(
         allow_external_input_files=settings.allow_external_input_files
     )
-    document_store = getattr(document_toolset, "document_store", None)
-
-    def _get_document_prompt_summary(document_id: str) -> dict[str, object] | None:
-        if document_store is None:
-            return None
-        try:
-            return document_store.build_prompt_summary(document_id)
-        except KeyError:
-            return None
 
     request_hook_service = RequestHookService(
         auto_block_execution_tools=settings.auto_block_execution_tools,
         get_cached_upload_infos=upload_session_service.get_cached_upload_infos,
         extract_upload_source=extract_upload_source,
         store_uploaded_file=store_uploaded_file,
+        consume_session_notice_once=upload_session_service.consume_session_notice_once,
         allow_external_input_files=settings.allow_external_input_files,
-        get_document_prompt_summary=_get_document_prompt_summary,
         prompt_context_service=prompt_context_service,
+        lookup_document_summary=document_toolset.document_store.build_prompt_summary,
     )
     llm_request_policy = LLMRequestPolicy(
         document_toolset=document_toolset,

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -243,7 +243,7 @@ def _build_request_pipeline_services(
         consume_session_notice_once=upload_session_service.consume_session_notice_once,
         allow_external_input_files=settings.allow_external_input_files,
         prompt_context_service=prompt_context_service,
-        lookup_document_summary=document_toolset.document_store.build_prompt_summary,
+        lookup_document_summary=_build_document_summary_lookup(document_toolset),
     )
     llm_request_policy = LLMRequestPolicy(
         document_toolset=document_toolset,
@@ -259,6 +259,17 @@ def _build_request_pipeline_services(
         request_hook_service=request_hook_service,
         llm_request_policy=llm_request_policy,
     )
+
+
+def _build_document_summary_lookup(document_toolset):
+    document_store = getattr(document_toolset, "document_store", None)
+    build_prompt_summary = getattr(document_store, "build_prompt_summary", None)
+    if not callable(build_prompt_summary):
+        logger.warning(
+            "[文件管理] document_store.build_prompt_summary 不可用，文档跟进提示将退化为普通工具指南"
+        )
+        return None
+    return build_prompt_summary
 
 
 def _build_file_processing_services(

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -51,6 +51,9 @@ class UploadSessionService:
         self._session_uploads_by_session: dict[
             tuple[str, str, str], list[tuple[UploadInfo, float]]
         ] = {}
+        self._session_notice_state_by_session: dict[
+            tuple[str, str, str], tuple[set[str], float]
+        ] = {}
         self._session_uploads_last_cleanup_ts = 0.0
 
     def get_attachment_session_key(
@@ -111,7 +114,51 @@ class UploadSessionService:
         for session_key in expired_keys:
             self._session_uploads_by_session.pop(session_key, None)
 
+        expired_notice_keys = [
+            session_key
+            for session_key, (_, ts) in self._session_notice_state_by_session.items()
+            if ts <= expire_before
+        ]
+        for session_key in expired_notice_keys:
+            self._session_notice_state_by_session.pop(session_key, None)
+
         self._session_uploads_last_cleanup_ts = now
+
+    def consume_session_notice_once(
+        self,
+        event: AstrMessageEvent,
+        notice_key: str,
+    ) -> bool:
+        normalized_notice_key = notice_key.strip()
+        if not normalized_notice_key:
+            return False
+
+        now = time.time()
+        self._cleanup_session_upload_cache(now)
+        session_key = self.get_attachment_session_key(event)
+        existing_state = self._session_notice_state_by_session.get(session_key)
+        if existing_state is None:
+            self._session_notice_state_by_session[session_key] = (
+                {normalized_notice_key},
+                now,
+            )
+            return True
+
+        used_notice_keys, _ = existing_state
+        if normalized_notice_key in used_notice_keys:
+            self._session_notice_state_by_session[session_key] = (
+                used_notice_keys,
+                now,
+            )
+            return False
+
+        updated_notice_keys = set(used_notice_keys)
+        updated_notice_keys.add(normalized_notice_key)
+        self._session_notice_state_by_session[session_key] = (
+            updated_notice_keys,
+            now,
+        )
+        return True
 
     def _cleanup_recent_text_cache(self, now: float, *, force: bool = False) -> None:
         if (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,24 @@ def _ensure_local_package_alias() -> None:
 _ensure_local_package_alias()
 
 
+def build_notice_once_callback():
+    seen: dict[tuple[str, str, str], set[str]] = {}
+
+    def consume(event, notice_key: str) -> bool:
+        session_key = (
+            str(event.get_platform_id() or ""),
+            str(event.get_sender_id() or ""),
+            str(event.unified_msg_origin or ""),
+        )
+        used = seen.setdefault(session_key, set())
+        if notice_key in used:
+            return False
+        used.add(notice_key)
+        return True
+
+    return consume
+
+
 @pytest.fixture
 def workspace_root() -> Iterator[Path]:
     workspace_base = Path(__file__).resolve().parent / ".tmp_test_workspaces"

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -127,6 +127,73 @@ def test_build_document_toolset_uses_shared_store_and_default_workspace():
     assert stores[0].workspace_dir == expected_workspace
 
 
+@pytest.mark.asyncio
+async def test_document_tool_messages_enforce_workflow_after_create_and_finalize(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(workspace_root, "pytest-agent-tools-messages")
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            session_id="pytest-session",
+            title="Workflow Message",
+            output_name="workflow-message.docx",
+        )
+    )
+    document_id = created["document"]["document_id"]
+
+    assert "下一步只能调用 add_blocks 添加内容" in created["message"]
+    assert "不要提前调用 finalize_document 或 export_document" in created["message"]
+
+    await tool_by_name["add_blocks"].call(
+        None,
+        document_id=document_id,
+        blocks=[{"type": "paragraph", "text": "正文"}],
+    )
+    finalized = json.loads(
+        await tool_by_name["finalize_document"].call(
+            None,
+            document_id=document_id,
+        )
+    )
+
+    assert "下一步只能调用 export_document 导出文件" in finalized["message"]
+    assert "不要再调用 add_blocks、create_document 或 finalize_document" in finalized["message"]
+
+
+@pytest.mark.asyncio
+async def test_add_blocks_failure_message_keeps_model_on_same_tool(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-add-blocks-failure"
+    )
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            session_id="pytest-session",
+            title="Add Blocks Failure",
+            output_name="add-blocks-failure.docx",
+        )
+    )
+
+    failed = json.loads(
+        await tool_by_name["add_blocks"].call(
+            None,
+            document_id=created["document"]["document_id"],
+            blocks=[{"type": "table", "style": {"table_grid": "none"}, "rows": []}],
+        )
+    )
+
+    assert failed["success"] is False
+    assert "继续使用同一个 document_id 再次调用 add_blocks" in failed["message"]
+    assert "不要改调 finalize_document 或 export_document" in failed["message"]
+
+
 def test_document_tool_registry_keeps_document_tool_order():
     assert [spec.name for spec in get_document_tool_specs()] == [
         "create_document",

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -89,6 +89,24 @@ def _tool(name: str) -> FunctionTool:
     )
 
 
+def _build_notice_once_callback():
+    seen: dict[tuple[str, str, str], set[str]] = {}
+
+    def consume(event, notice_key: str) -> bool:
+        session_key = (
+            str(event.get_platform_id() or ""),
+            str(event.get_sender_id() or ""),
+            str(event.unified_msg_origin or ""),
+        )
+        used = seen.setdefault(session_key, set())
+        if notice_key in used:
+            return False
+        used.add(notice_key)
+        return True
+
+    return consume
+
+
 @pytest.mark.asyncio
 async def test_before_llm_chat_injects_document_tools_per_request():
     context = MagicMock()
@@ -120,42 +138,12 @@ async def test_before_llm_chat_injects_document_tools_per_request():
             "export_document",
         }.issubset(tool_names)
         assert "generate_complex_word_document" not in tool_names
-        assert "文件工具使用指南" in req.system_prompt
-        assert "文件工具细节指南" in req.system_prompt
-        assert "executive_brief" in req.system_prompt
-        assert "accent_color=RRGGBB" in req.system_prompt
-        assert "document_style={brief, heading_color, title_align" in req.system_prompt
-        assert "paragraph_space_after, list_space_after" in req.system_prompt
-        assert "summary_card_defaults, table_defaults" in req.system_prompt
-        assert "header_fill" in req.system_prompt
-        assert "banded_rows" in req.system_prompt
-        assert "first_column_bold" in req.system_prompt
-        assert (
-            "style={align, emphasis, font_scale, table_grid, cell_align}"
-            in req.system_prompt
-        )
-        assert (
-            "横向页面、节级页眉页脚、页码重置 MUST 使用独立的 `section_break` block"
-            in req.system_prompt
-        )
-        assert (
-            "不要把 `page_orientation`、`start_type`、`restart_page_numbering`"
-            in req.system_prompt
-        )
-        assert (
-            "`toc` 只使用 `title`、`levels`、`start_on_new_page`" in req.system_prompt
-        )
-        assert (
-            "表格列标题使用 `headers`；不要给 `table` 传 `columns`" in req.system_prompt
-        )
-        assert "按章节或逻辑块分批调用 `add_blocks`" in req.system_prompt
-        assert "MUST 持续调用直到 `export_document` 成功" in req.system_prompt
-        assert "NEVER 调用网络搜索" in req.system_prompt
-        assert (
-            "如果用户显式指定了某个工具名和参数，MUST 先按该工具调用"
-            in req.system_prompt
-        )
-        assert "所有面向用户的回复和过渡说明 MUST 使用中文" in req.system_prompt
+        assert "文件工具使用指南" in req.prompt
+        assert "文件工具细节指南" not in req.prompt
+        assert "MUST 持续调用直到 `export_document` 成功" in req.prompt
+        assert "NEVER 调用网络搜索" in req.prompt
+        assert "文件工具使用指南" not in req.system_prompt
+        assert req.prompt.startswith("请生成一份 Word 报告，并导出给我。")
     finally:
         await plugin.terminate()
 
@@ -187,11 +175,11 @@ async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
 
         await plugin.before_llm_chat(event, req)
 
-        assert "文件工具使用指南" in req.system_prompt
-        assert "当前文档状态摘要" in req.system_prompt
-        assert "executive_brief" not in req.system_prompt
-        assert "accent_color=RRGGBB" not in req.system_prompt
-        assert "文件工具细节指南" not in req.system_prompt
+        assert "文件工具使用指南" not in req.system_prompt
+        assert "当前文档状态摘要" not in req.system_prompt
+        assert "文件工具使用指南" not in req.prompt
+        assert "当前文档状态摘要" not in req.prompt
+        assert "文件工具细节指南" not in req.prompt
     finally:
         await plugin.terminate()
 
@@ -227,6 +215,7 @@ async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
             "export_document",
         }.issubset(tool_names)
         assert "文件工具使用指南" not in req.system_prompt
+        assert "文件工具使用指南" not in req.prompt
     finally:
         await plugin.terminate()
 
@@ -245,12 +234,12 @@ async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruct
             prompt=(
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
-                "- 原始文件名: source.docx (类型: .docx)\n"
+                "- 原始文件名: source.docx\n"
                 "  工作区文件名: source_1.docx\n\n"
                 "[用户指令]\n"
                 "请根据我刚上传的文档整理成正式汇报，并导出成 Word 发给我。\n\n"
-                "[处理建议]\n"
-                "1. 先调用 `read_file` 读取文件。\n"
+                "[处理要求]\n"
+                "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
             system_prompt="base",
             func_tool=ToolSet(
@@ -272,8 +261,9 @@ async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruct
             "finalize_document",
             "export_document",
         }.issubset(tool_names)
-        assert "文件工具使用指南" in req.system_prompt
-        assert "文件工具细节指南" in req.system_prompt
+        assert "文件工具使用指南" in req.prompt
+        assert "文件工具细节指南" not in req.prompt
+        assert "文件工具使用指南" not in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -376,14 +366,11 @@ async def test_before_llm_chat_requires_read_before_document_tools_for_uploaded_
 
         await plugin.before_llm_chat(event, req)
 
-        assert "MUST 先调用 `read_file` 读取内容，再创建文档" in req.system_prompt
-        assert "MUST 先调用 `read_file` 读取此文件" in req.system_prompt
-        assert "原始文件名：source.docx" in req.system_prompt
-        assert "工作区文件名：source_1.docx" in req.system_prompt
-        assert "必须使用工作区文件名 `source_1.docx`" in req.system_prompt
-        assert "NEVER 创建新文档" in req.system_prompt
-        assert "NEVER 调用网络搜索" in req.system_prompt
-        assert "MUST 使用中文" in req.system_prompt
+        assert "read_file" in req.prompt
+        assert "source.docx" in req.prompt
+        assert "source_1.docx" in req.prompt
+        assert "读取前不要创建新文档" in req.prompt
+        assert "source_1.docx" not in req.system_prompt
     finally:
         await plugin.terminate()
 
@@ -640,12 +627,12 @@ async def test_before_llm_chat_uses_buffered_user_instruction_for_explicit_tool_
             prompt=(
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
-                "- 原始文件名: source.docx (类型: .docx)\n"
+                "- 原始文件名: source.docx\n"
                 "  工作区文件名: source_1.docx\n\n"
                 "[用户指令]\n"
                 "请根据我刚上传的文档整理成正式汇报，标题叫《项目进展汇总》，最后导出成 Word 并发给我。\n\n"
-                "[处理建议]\n"
-                "1. 先调用 `read_file` 读取文件。\n"
+                "[处理要求]\n"
+                "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
             system_prompt="base",
             func_tool=ToolSet(
@@ -687,12 +674,12 @@ async def test_before_llm_chat_can_still_restrict_tool_from_buffered_user_instru
             prompt=(
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
-                "- 原始文件名: table.csv (类型: .csv)\n"
+                "- 原始文件名: table.csv\n"
                 "  工作区文件名: table_1.csv\n\n"
                 "[用户指令]\n"
                 "调用 read_file，filename=table_1.csv\n\n"
-                "[处理建议]\n"
-                "1. 先调用 `read_file` 读取文件。\n"
+                "[处理要求]\n"
+                "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
             system_prompt="base",
             func_tool=ToolSet(
@@ -745,7 +732,7 @@ async def test_llm_request_policy_runs_internal_notice_and_tool_hooks():
 
     await policy.apply(event, req)
 
-    assert "[custom notice]" in req.system_prompt
+    assert "[custom notice]" in req.prompt
     assert "create_document" not in set(req.func_tool.names())
     assert "existing_tool" in set(req.func_tool.names())
 
@@ -776,6 +763,7 @@ async def test_llm_request_policy_uses_injected_request_hook_service_for_default
         get_cached_upload_infos=lambda _event: [],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     policy = LLMRequestPolicy(
@@ -808,13 +796,72 @@ async def test_llm_request_policy_uses_injected_request_hook_service_for_default
     assert "create_document" in tool_names
     assert "existing_tool" in tool_names
     assert "astrbot_execute_shell" not in tool_names
-    assert "文件工具使用指南" in req.system_prompt
+    assert "文件工具使用指南" in req.prompt
+    assert req.prompt.startswith("请生成一份 Word 报告，并导出给我。")
+    assert "\n\n[System Notice] 文件工具使用指南" in req.prompt
     assert any(
         call.args
-        and call.args[0] == "[文件管理] Prompt sections: %s"
-        and SECTION_STATIC_DOCUMENT_TOOLS in str(call.args[1])
+        and call.args[0] == "[文件管理] Prompt sections(%s): %s"
+        and call.args[1] == "prompt_suffix"
+        and SECTION_STATIC_DOCUMENT_TOOLS in str(call.args[2])
         for call in logger_debug.call_args_list
     )
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_appends_notice_to_prompt_suffix_without_extra_prefix():
+    def _notice_hook(context):
+        context.section_names.append("scene_test")
+        context.notices.append("[notice]")
+        return context
+
+    policy = LLMRequestPolicy(
+        document_toolset=SimpleNamespace(tools=[]),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: True,
+        notice_hooks=[_notice_hook],
+        tool_exposure_hooks=[],
+    )
+    event = _build_event()
+    req = ProviderRequest(
+        prompt="hello",
+        system_prompt="base",
+        func_tool=ToolSet([_tool("existing_tool")]),
+    )
+
+    await policy.apply(event, req)
+
+    assert req.prompt == "hello\n\n[notice]"
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_uses_notice_directly_when_prompt_is_empty():
+    def _notice_hook(context):
+        context.section_names.append("scene_test")
+        context.notices.append("[notice]")
+        return context
+
+    policy = LLMRequestPolicy(
+        document_toolset=SimpleNamespace(tools=[]),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: True,
+        notice_hooks=[_notice_hook],
+        tool_exposure_hooks=[],
+    )
+    event = _build_event()
+    req = ProviderRequest(
+        prompt="",
+        system_prompt="base",
+        func_tool=ToolSet([_tool("existing_tool")]),
+    )
+
+    await policy.apply(event, req)
+
+    assert req.prompt == "[notice]"
 
 
 @pytest.mark.asyncio
@@ -877,6 +924,7 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
         ],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     policy = LLMRequestPolicy(
@@ -919,6 +967,7 @@ async def test_llm_request_policy_group_switch_off_hides_execution_tools():
         get_cached_upload_infos=lambda _event: [],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     policy = LLMRequestPolicy(
@@ -1206,16 +1255,14 @@ async def test_buffered_upload_with_prompt_uses_structured_notice_and_follow_thr
     assert "[文件信息]" in prompt_text
     assert "[用户指令]" in prompt_text
     assert "请根据上传文档整理成正式汇报" in prompt_text
-    assert "[处理建议]" in prompt_text
+    assert prompt_text.index("[用户指令]") < prompt_text.index("[文件信息]")
+    assert "[处理要求]" in prompt_text
     assert "优先围绕这些上传文件完成用户请求" in prompt_text
     assert "工作区文件名: report_1.docx" in prompt_text
-    assert "外部绝对路径:" in prompt_text
+    assert "外部绝对路径:" not in prompt_text
     assert "先调用 `read_file` 读取文件" in prompt_text
-    assert "不要自行猜测文件名，也不要列目录或调用 shell" in prompt_text
-    assert (
-        "如果用户已经明确要求整理成正式汇报、报告、文档或 Word 文件，读取后继续调用相应工具完成结果"
-        in prompt_text
-    )
+    assert "不要猜文件名，不要列目录，不要调用 shell" in prompt_text
+    assert "读取后按用户指令继续调用工具，不要只回复过渡说明" in prompt_text
     assert not queued_event.message_str.startswith("/")
     assert queued_event.message_str.endswith(prompt_text.strip())
     event_queue.put.assert_awaited_once()
@@ -1274,7 +1321,7 @@ async def test_before_llm_chat_exposes_file_tools_for_buffered_group_upload_when
         assert "add_blocks" in tool_names
         assert "export_document" in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
-        assert "工作区文件名：source_1.docx" in req.system_prompt
+        assert "source_1.docx" in req.prompt
     finally:
         await plugin.terminate()
 
@@ -1353,11 +1400,11 @@ async def test_before_llm_chat_exposes_file_tools_for_group_doc_command_without_
         event.message_str = (
             "[System Notice] 用户上传了 1 个文件\n\n"
             "[文件信息]\n"
-            "- 原始文件名: B.xlsx (类型: .xlsx)\n"
+            "- 原始文件名: B.xlsx\n"
             "  工作区文件名: B_1.xlsx\n\n"
             "[用户指令]\n"
             "根据这份文件整理成正式汇报\n\n"
-            "[处理建议]\n"
+            "[处理要求]\n"
             "1. 优先围绕这些上传文件完成用户请求。\n"
         )
         req = ProviderRequest(

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -30,6 +30,7 @@ import astrbot.api.message_components as Comp
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entities import ProviderRequest
+from conftest import build_notice_once_callback as _build_notice_once_callback
 
 
 def _build_config() -> dict:
@@ -87,24 +88,6 @@ def _tool(name: str) -> FunctionTool:
         parameters={"type": "object", "properties": {}},
         handler=None,
     )
-
-
-def _build_notice_once_callback():
-    seen: dict[tuple[str, str, str], set[str]] = {}
-
-    def consume(event, notice_key: str) -> bool:
-        session_key = (
-            str(event.get_platform_id() or ""),
-            str(event.get_sender_id() or ""),
-            str(event.unified_msg_origin or ""),
-        )
-        used = seen.setdefault(session_key, set())
-        if notice_key in used:
-            return False
-        used.add(notice_key)
-        return True
-
-    return consume
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1519,6 +1519,41 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_draft(
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_space_separated_document_id():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 6,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="继续完善 document_id doc-3 的内容",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-3` 仍是 draft" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_finalized():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -1581,6 +1616,73 @@ async def test_request_hook_service_injects_missing_notice_when_document_id_is_u
 
     assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
     assert "没有找到 `document_id=missing-doc` 对应的文档会话" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_falls_back_to_document_guide_when_document_id_is_not_parseable():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda _document_id: None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请返回 document_id 并导出成 Word 报告",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert "create_document" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_reraises_unexpected_summary_lookup_errors():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda _document_id: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        ),
+    )
+
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt='继续处理 document_id="doc-9"',
+            system_prompt="base",
+            func_tool=ToolSet([_tool("add_blocks")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        notices=[],
+    )
+
+    with patch(
+        "astrbot_plugin_office_assistant.services.request_hook_service.logger.exception"
+    ) as mock_exception:
+        with pytest.raises(RuntimeError, match="boom"):
+            await service.append_document_tool_guide_notice(context)
+
+    mock_exception.assert_called_once()
 
 
 def test_prompt_context_service_orders_dynamic_document_notice_after_scene_notice():

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -45,6 +45,9 @@ from astrbot_plugin_office_assistant.services import (
     WorkspaceService,
     build_plugin_runtime,
 )
+from astrbot_plugin_office_assistant.services.runtime_builder import (
+    _build_document_summary_lookup,
+)
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
     SECTION_SCENE_UPLOADED_CONTEXT,
@@ -1572,6 +1575,41 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_englis
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_backtick_quoted_document_id():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 5,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="继续处理 document_id=`doc-8`",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-8` 仍是 draft" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_finalized():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -1696,6 +1734,61 @@ async def test_request_hook_service_falls_back_to_document_guide_for_english_non
 
     assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
     assert "export_document" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_falls_back_to_document_guide_for_non_id_bare_token():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda _document_id: None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请根据 document_id token-1 导出成 Word",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert "export_document" in context.notices[0]
+
+
+def test_runtime_builder_returns_none_when_document_summary_lookup_is_unavailable():
+    document_toolset = SimpleNamespace(document_store=SimpleNamespace())
+
+    with patch(
+        "astrbot_plugin_office_assistant.services.runtime_builder.logger.warning"
+    ) as mock_warning:
+        lookup = _build_document_summary_lookup(document_toolset)
+
+    assert lookup is None
+    mock_warning.assert_called_once()
+
+
+def test_runtime_builder_uses_document_summary_lookup_when_available():
+    build_prompt_summary = MagicMock(return_value={"status": "draft"})
+    document_toolset = SimpleNamespace(
+        document_store=SimpleNamespace(build_prompt_summary=build_prompt_summary)
+    )
+
+    lookup = _build_document_summary_lookup(document_toolset)
+
+    assert lookup is build_prompt_summary
+    assert lookup("doc-1") == {"status": "draft"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -46,10 +46,10 @@ from astrbot_plugin_office_assistant.services import (
     build_plugin_runtime,
 )
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
-    SECTION_DYNAMIC_DOCUMENT_SUMMARY,
-    SECTION_DYNAMIC_UPLOAD_SUMMARY,
-    SECTION_SCENE_UPLOADED_FILE,
+    SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+    SECTION_SCENE_UPLOADED_CONTEXT,
     SECTION_STATIC_DOCUMENT_TOOLS,
+    SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
     PromptContextService,
 )
 from astrbot_plugin_office_assistant.utils import (
@@ -127,6 +127,24 @@ def _make_workspace(name: str) -> Path:
     workspace_dir = workspace_base / f"{name}-{uuid4().hex}"
     workspace_dir.mkdir(parents=True, exist_ok=True)
     return workspace_dir
+
+
+def _build_notice_once_callback():
+    seen: dict[tuple[str, str, str], set[str]] = {}
+
+    def consume(event, notice_key: str) -> bool:
+        session_key = (
+            str(event.get_platform_id() or ""),
+            str(event.get_sender_id() or ""),
+            str(event.unified_msg_origin or ""),
+        )
+        used = seen.setdefault(session_key, set())
+        if notice_key in used:
+            return False
+        used.add(notice_key)
+        return True
+
+    return consume
 
 
 def _write_png(path: Path) -> None:
@@ -1158,6 +1176,7 @@ async def test_request_hook_service_builds_default_tool_hooks():
         get_cached_upload_infos=lambda _event: [],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     context = SimpleNamespace(
@@ -1212,9 +1231,10 @@ async def test_request_hook_service_merges_multiple_uploaded_files_into_one_noti
         ],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
-    context = SimpleNamespace(
+    context = NoticeBuildContext(
         event=event,
         request=request,
         should_expose=True,
@@ -1222,23 +1242,27 @@ async def test_request_hook_service_merges_multiple_uploaded_files_into_one_noti
         explicit_tool_name=None,
         notices=[],
         section_names=[],
+        system_notices=[],
+        system_section_names=[],
     )
 
     context = await service.append_uploaded_file_notices(context)
 
-    assert len(context.notices) == 2
-    assert "MUST 先调用 `read_file` 依次读取这些文件" in context.notices[0]
-    notice = context.notices[1]
+    assert len(context.notices) == 1
+    notice = context.notices[0]
     assert notice.count("[System Notice] [ACTION REQUIRED] 已收到上传文件") == 1
     assert "文件数量：2" in notice
     assert "report.docx" in notice
     assert "notes.txt" in notice
     assert "report_1.docx" in notice
     assert "notes_1.txt" in notice
-    assert context.section_names == [
-        SECTION_SCENE_UPLOADED_FILE,
-        SECTION_DYNAMIC_UPLOAD_SUMMARY,
-    ]
+    assert "先调用 `read_file` 依次读取这些文件" in notice
+    assert "不要猜文件名，不要列目录，不要调用 shell" in notice
+    assert "读取前不要创建新文档" in notice
+    assert "source_path" not in notice
+    assert context.section_names == [SECTION_SCENE_UPLOADED_CONTEXT]
+    assert context.system_notices == []
+    assert context.system_section_names == []
 
 
 @pytest.mark.asyncio
@@ -1257,6 +1281,7 @@ async def test_request_hook_service_limits_multi_file_notice_details():
         get_cached_upload_infos=lambda _event: _build_upload_infos(5),
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     context = SimpleNamespace(
@@ -1271,7 +1296,7 @@ async def test_request_hook_service_limits_multi_file_notice_details():
 
     context = await service.append_uploaded_file_notices(context)
 
-    notice = context.notices[1]
+    notice = context.notices[0]
     assert "文件数量：5" in notice
     assert "file-0.txt" in notice
     assert "file-2.txt" in notice
@@ -1287,7 +1312,7 @@ async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_pr
         prompt=(
             "\n[System Notice] 用户上传了 2 个文件\n\n"
             "[文件信息]\n"
-            "- 原始文件名: file-0.txt (类型: .txt)\n"
+            "- 原始文件名: file-0.txt\n"
             "  工作区文件名: file_0.txt\n"
         ),
         system_prompt="base",
@@ -1303,6 +1328,7 @@ async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_pr
         get_cached_upload_infos=lambda _event: _build_upload_infos(2),
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     context = SimpleNamespace(
@@ -1317,18 +1343,17 @@ async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_pr
 
     context = await service.append_uploaded_file_notices(context)
 
-    assert len(context.notices) == 1
-    assert context.section_names == [SECTION_DYNAMIC_UPLOAD_SUMMARY]
-    assert "文件数量：2" in context.notices[0]
+    assert context.notices == []
+    assert context.section_names == []
 
 
 @pytest.mark.asyncio
-async def test_request_hook_service_keeps_scene_notice_for_buffered_prompt_with_instruction():
+async def test_request_hook_service_skips_additional_notice_for_buffered_prompt_with_instruction():
     request = ProviderRequest(
         prompt=(
             "\n[System Notice] 用户上传了 1 个文件\n\n"
             "[文件信息]\n"
-            "- 原始文件名: report.docx (类型: .docx)\n"
+            "- 原始文件名: report.docx\n"
             "  工作区文件名: report_1.docx\n\n"
             "[用户指令]\n"
             "根据文件整理成正式汇报\n"
@@ -1353,6 +1378,7 @@ async def test_request_hook_service_keeps_scene_notice_for_buffered_prompt_with_
         ],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
     )
     context = SimpleNamespace(
@@ -1367,15 +1393,12 @@ async def test_request_hook_service_keeps_scene_notice_for_buffered_prompt_with_
 
     context = await service.append_uploaded_file_notices(context)
 
-    assert len(context.notices) == 2
-    assert context.section_names == [
-        SECTION_SCENE_UPLOADED_FILE,
-        SECTION_DYNAMIC_UPLOAD_SUMMARY,
-    ]
+    assert context.notices == []
+    assert context.section_names == []
 
 
 @pytest.mark.asyncio
-async def test_request_hook_service_shows_compact_paths_for_omitted_files():
+async def test_request_hook_service_omitted_files_use_names_without_external_paths():
     request = ProviderRequest(
         prompt="根据上传文件整理内容",
         system_prompt="base",
@@ -1393,6 +1416,7 @@ async def test_request_hook_service_shows_compact_paths_for_omitted_files():
         ),
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
     context = SimpleNamespace(
@@ -1407,9 +1431,11 @@ async def test_request_hook_service_shows_compact_paths_for_omitted_files():
 
     context = await service.append_uploaded_file_notices(context)
 
-    notice = context.notices[1]
-    assert "file_3.txt -> /tmp/file_3.txt" in notice
-    assert "file_4.txt -> /tmp/file_4.txt" in notice
+    notice = context.notices[0]
+    assert "file_3.txt" in notice
+    assert "file_4.txt" in notice
+    assert "/tmp/file_3.txt" not in notice
+    assert "/tmp/file_4.txt" not in notice
     assert "其余 2 个文件：" in notice
     assert "未展开详细信息" in notice
 
@@ -1433,6 +1459,7 @@ async def test_request_hook_service_keeps_omitted_count_aligned_with_mixed_path_
         get_cached_upload_infos=lambda _event: upload_infos,
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
     context = SimpleNamespace(
@@ -1447,29 +1474,26 @@ async def test_request_hook_service_keeps_omitted_count_aligned_with_mixed_path_
 
     context = await service.append_uploaded_file_notices(context)
 
-    notice = context.notices[1]
+    notice = context.notices[0]
     assert "其余 2 个文件：" in notice
-    assert "file_3.txt -> /tmp/file_3.txt" in notice
     assert "file_4.txt" in notice
-    assert "file_4.txt ->" not in notice
+    assert "/tmp/file_3.txt" not in notice
     assert "其余 1 个文件：" not in notice
 
 
 @pytest.mark.asyncio
-async def test_request_hook_service_appends_document_summary_for_existing_document():
+async def test_request_hook_service_injects_document_follow_up_notice_for_draft():
     service = RequestHookService(
         auto_block_execution_tools=True,
         get_cached_upload_infos=lambda _event: [],
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=False,
-        get_document_prompt_summary=lambda document_id: {
+        lookup_document_summary=lambda document_id: {
             "document_id": document_id,
-            "title": "季度经营复盘",
             "status": "draft",
-            "block_count": 4,
-            "latest_block_types": ["heading", "table"],
-            "next_allowed_actions": ["add_blocks", "finalize_document"],
+            "block_count": 3,
         },
     )
     context = NoticeBuildContext(
@@ -1487,28 +1511,85 @@ async def test_request_hook_service_appends_document_summary_for_existing_docume
 
     context = await service.append_document_tool_guide_notice(context)
 
-    assert len(context.notices) == 2
-    assert "文件工具使用指南" in context.notices[0]
-    assert "executive_brief" not in context.notices[0]
-    assert "当前文档状态摘要" in context.notices[1]
-    assert "document_id: doc-1" in context.notices[1]
-    assert "状态: draft" in context.notices[1]
-    assert "块数: 4" in context.notices[1]
-    assert "下一步: add_blocks, finalize_document" in context.notices[1]
-    assert "最近块类型" not in context.notices[1]
-    assert context.section_names == [
-        SECTION_STATIC_DOCUMENT_TOOLS,
-        SECTION_DYNAMIC_DOCUMENT_SUMMARY,
-    ]
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-1` 仍是 draft" in context.notices[0]
+    assert "继续调用 `add_blocks`" in context.notices[0]
+    assert context.system_notices == []
+    assert context.system_section_names == []
 
 
-def test_prompt_context_service_orders_notice_sections_by_stability():
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_finalized():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "finalized",
+            "block_count": 15,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='请导出 document_id="doc-2"',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "下一步只能调用 `export_document`" in context.notices[0]
+    assert "不要再调用 `add_blocks`、`finalize_document` 或 `create_document`" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_missing_notice_when_document_id_is_unknown():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda _document_id: None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='继续处理 document_id="missing-doc"',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "没有找到 `document_id=missing-doc` 对应的文档会话" in context.notices[0]
+
+
+def test_prompt_context_service_orders_dynamic_document_notice_after_scene_notice():
     service = PromptContextService(allow_external_input_files=False)
 
     ordered_names, ordered_notices = service.order_notice_sections(
         section_names=[
-            SECTION_DYNAMIC_DOCUMENT_SUMMARY,
-            SECTION_SCENE_UPLOADED_FILE,
+            SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+            SECTION_SCENE_UPLOADED_CONTEXT,
             SECTION_STATIC_DOCUMENT_TOOLS,
         ],
         notices=[
@@ -1520,23 +1601,160 @@ def test_prompt_context_service_orders_notice_sections_by_stability():
 
     assert ordered_names == [
         SECTION_STATIC_DOCUMENT_TOOLS,
-        SECTION_SCENE_UPLOADED_FILE,
-        SECTION_DYNAMIC_DOCUMENT_SUMMARY,
+        SECTION_SCENE_UPLOADED_CONTEXT,
+        SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
     ]
     assert ordered_notices == ["static", "scene", "dynamic"]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_document_core_notice_only_once_per_session():
+    consume_once = _build_notice_once_callback()
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=consume_once,
+        allow_external_input_files=False,
+    )
+    event = _build_event()
+
+    first = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=event,
+            request=ProviderRequest(
+                prompt="请生成一份 Word 报告，并导出给我",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+    second = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=event,
+            request=ProviderRequest(
+                prompt="再生成一份 Word 报告",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert first.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert second.section_names == []
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_detail_notice_later_without_repeating_core():
+    consume_once = _build_notice_once_callback()
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=consume_once,
+        allow_external_input_files=False,
+    )
+    event = _build_event()
+
+    first = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=event,
+            request=ProviderRequest(
+                prompt="请生成一份 Word 报告",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+    second = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=event,
+            request=ProviderRequest(
+                prompt="请用 executive_brief 主题和 document_style 生成 Word 报告",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert first.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert second.section_names == [SECTION_STATIC_DOCUMENT_TOOLS_DETAIL]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_allows_detail_notice_without_core_when_only_style_signal_exists():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请使用 executive_brief 和 accent_color=112233",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS_DETAIL]
+
+
+def test_prompt_context_service_orders_notice_sections_by_stability():
+    service = PromptContextService(allow_external_input_files=False)
+
+    ordered_names, ordered_notices = service.order_notice_sections(
+        section_names=[
+            SECTION_SCENE_UPLOADED_CONTEXT,
+            SECTION_STATIC_DOCUMENT_TOOLS,
+        ],
+        notices=[
+            "scene",
+            "static",
+        ],
+    )
+
+    assert ordered_names == [
+        SECTION_STATIC_DOCUMENT_TOOLS,
+        SECTION_SCENE_UPLOADED_CONTEXT,
+    ]
+    assert ordered_notices == ["static", "scene"]
     trace = service.build_section_trace(
         section_names=ordered_names,
         notices=ordered_notices,
     )
     assert trace.startswith(
-        f"{SECTION_STATIC_DOCUMENT_TOOLS}, {SECTION_SCENE_UPLOADED_FILE}, {SECTION_DYNAMIC_DOCUMENT_SUMMARY}"
+        f"{SECTION_STATIC_DOCUMENT_TOOLS}, {SECTION_SCENE_UPLOADED_CONTEXT}"
     )
     assert (
-        f"[len={SECTION_STATIC_DOCUMENT_TOOLS}:6, {SECTION_SCENE_UPLOADED_FILE}:5, "
-        f"{SECTION_DYNAMIC_DOCUMENT_SUMMARY}:7]" in trace
+        f"[len={SECTION_STATIC_DOCUMENT_TOOLS}:6, "
+        f"{SECTION_SCENE_UPLOADED_CONTEXT}:5]" in trace
     )
-    assert "[groups=static:6, scene:5, dynamic:7]" in trace
-    assert "[total=18]" in trace
+    assert "[groups=static:6, scene:5]" in trace
+    assert "[total=11]" in trace
 
 
 def test_prompt_context_service_logs_section_length_mismatch():
@@ -1565,13 +1783,13 @@ def test_prompt_context_service_build_section_trace_tolerates_length_mismatch():
     trace = service.build_section_trace(
         section_names=[
             SECTION_STATIC_DOCUMENT_TOOLS,
-            SECTION_SCENE_UPLOADED_FILE,
+            SECTION_SCENE_UPLOADED_CONTEXT,
         ],
         notices=["static only"],
     )
 
     assert trace.startswith(
-        f"{SECTION_STATIC_DOCUMENT_TOOLS}, {SECTION_SCENE_UPLOADED_FILE}"
+        f"{SECTION_STATIC_DOCUMENT_TOOLS}, {SECTION_SCENE_UPLOADED_CONTEXT}"
     )
     assert f"[len={SECTION_STATIC_DOCUMENT_TOOLS}:11]" in trace
     assert "[groups=static:11]" in trace
@@ -1597,8 +1815,9 @@ def test_upload_prompt_service_builds_instructional_notice_for_readable_files():
     assert "[用户指令]" in prompt_text
     assert "看看里面的内容" in prompt_text
     assert "工作区文件名: report_1.docx" in prompt_text
-    assert "外部绝对路径: /AstrBot/data/temp/report.docx" in prompt_text
+    assert "外部绝对路径" not in prompt_text
     assert "先调用 `read_file` 读取文件" in prompt_text
+    assert "读取后按用户指令继续调用工具，不要只回复过渡说明" in prompt_text
 
 
 def test_upload_prompt_service_builds_notice_for_readable_files_without_instruction():
@@ -1665,8 +1884,7 @@ def test_upload_prompt_service_handles_mixed_readable_and_unreadable_files():
     assert "[文件信息]" in prompt_text
     assert "工作区文件名: readable_1.txt" in prompt_text
     assert "工作区文件名: unreadable_1.bin" in prompt_text
-    assert "外部绝对路径: /AstrBot/data/temp/readable.txt" in prompt_text
-    assert "外部绝对路径: /AstrBot/data/temp/unreadable.bin" in prompt_text
+    assert "外部绝对路径" not in prompt_text
     assert "先调用 `read_file` 读取文件" in prompt_text
 
 
@@ -1687,7 +1905,7 @@ def test_upload_prompt_service_limits_file_details_for_many_uploads():
     assert "未展开详细信息" in prompt_text
 
 
-def test_upload_prompt_service_shows_compact_paths_for_omitted_files():
+def test_upload_prompt_service_omitted_files_only_show_names():
     service = UploadPromptService(allow_external_input_files=True)
 
     prompt_text = service.build_prompt(
@@ -1698,8 +1916,10 @@ def test_upload_prompt_service_shows_compact_paths_for_omitted_files():
         user_instruction="整理成报告",
     )
 
-    assert "file_3.txt -> /tmp/file_3.txt" in prompt_text
-    assert "file_4.txt -> /tmp/file_4.txt" in prompt_text
+    assert "file_3.txt" in prompt_text
+    assert "file_4.txt" in prompt_text
+    assert "/tmp/file_3.txt" not in prompt_text
+    assert "/tmp/file_4.txt" not in prompt_text
     assert "其余 2 个文件：" in prompt_text
     assert "未展开详细信息" in prompt_text
 
@@ -1716,9 +1936,8 @@ def test_upload_prompt_service_keeps_omitted_count_aligned_with_mixed_path_items
     )
 
     assert "其余 2 个文件：" in prompt_text
-    assert "file_3.txt -> /tmp/file_3.txt" in prompt_text
     assert "file_4.txt" in prompt_text
-    assert "file_4.txt ->" not in prompt_text
+    assert "/tmp/file_3.txt" not in prompt_text
     assert "其余 1 个文件：" not in prompt_text
 
 
@@ -1848,6 +2067,32 @@ def test_upload_session_service_preserves_input_upload_infos_when_caching():
     assert "file_id" not in upload_infos[0]
     assert assigned_infos[0]["file_id"] == "f1"
     assert service.list_session_upload_infos(event)[0]["file_id"] == "f1"
+
+
+def test_upload_session_service_consumes_notice_once_per_session():
+    service = UploadSessionService(
+        context=MagicMock(),
+        recent_text_ttl_seconds=30,
+        upload_session_ttl_seconds=300,
+        recent_text_max_entries=32,
+        recent_text_cleanup_interval_seconds=10,
+        upload_session_cleanup_interval_seconds=30,
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        allow_external_input_files=False,
+    )
+    event = _build_event()
+
+    assert service.consume_session_notice_once(event, "document_core_guide") is True
+    assert service.consume_session_notice_once(event, "document_core_guide") is False
+    assert service.consume_session_notice_once(event, "document_detail_guide") is True
+    assert (
+        service.consume_session_notice_once(
+            _build_event(sender_id="user-2"),
+            "document_core_guide",
+        )
+        is True
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1610,6 +1610,76 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_backti
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_fullwidth_colon_document_id():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 6,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="继续处理 document_id：doc-9",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-9` 仍是 draft" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_compact_chinese_separator():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 7,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="继续处理 document_id为doc-10",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-10` 仍是 draft" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_finalized():
     service = RequestHookService(
         auto_block_execution_tools=True,

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -63,6 +63,7 @@ import astrbot.api.message_components as Comp
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entities import ProviderRequest
+from conftest import build_notice_once_callback as _build_notice_once_callback
 
 
 def _build_event(
@@ -127,24 +128,6 @@ def _make_workspace(name: str) -> Path:
     workspace_dir = workspace_base / f"{name}-{uuid4().hex}"
     workspace_dir.mkdir(parents=True, exist_ok=True)
     return workspace_dir
-
-
-def _build_notice_once_callback():
-    seen: dict[tuple[str, str, str], set[str]] = {}
-
-    def consume(event, notice_key: str) -> bool:
-        session_key = (
-            str(event.get_platform_id() or ""),
-            str(event.get_sender_id() or ""),
-            str(event.unified_msg_origin or ""),
-        )
-        used = seen.setdefault(session_key, set())
-        if notice_key in used:
-            return False
-        used.add(notice_key)
-        return True
-
-    return consume
 
 
 def _write_png(path: Path) -> None:
@@ -1554,6 +1537,41 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_space_
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_document_follow_up_notice_for_english_is_document_id():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 4,
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="document_id is doc-7, please continue",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("add_blocks")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP]
+    assert "当前 `document_id=doc-7` 仍是 draft" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_finalized():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -1647,6 +1665,37 @@ async def test_request_hook_service_falls_back_to_document_guide_when_document_i
 
     assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
     assert "create_document" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_falls_back_to_document_guide_for_english_non_id_token():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda _document_id: None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="please return document_id and export this as Word",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert "export_document" in context.notices[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1837,6 +1837,38 @@ async def test_request_hook_service_falls_back_to_document_guide_for_non_id_bare
     assert "export_document" in context.notices[0]
 
 
+@pytest.mark.asyncio
+async def test_request_hook_service_falls_back_to_document_guide_when_summary_lookup_is_disabled():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='继续导出 document_id="doc-11" 的 Word 报告',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_document")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS]
+    assert "export_document" in context.notices[0]
+    assert "没有找到 `document_id=" not in context.notices[0]
+
+
 def test_runtime_builder_returns_none_when_document_summary_lookup_is_unavailable():
     document_toolset = SimpleNamespace(document_store=SimpleNamespace())
 


### PR DESCRIPTION
## 概述

这个 PR 在插件侧收紧了文档工具链的阶段约束和提示注入逻辑，减少模型在 `add_blocks`、`finalize_document`、`export_document` 之间过早切换或来回切换的情况。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [x] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 收紧文档工作流提示，明确内容未写完时继续 `add_blocks`，只有确认完成后才进入 `finalize_document`
- 在跨轮继续处理 `document_id` 时增加短提示，避免模型在已有文档会话里误切工具
- 调整工具返回文案，把失败重试和后续动作限制在当前阶段允许的范围内
- 优化 notice 注入顺序，减少提示混杂带来的阶段判断偏移
- 增补文档工作流相关测试，覆盖 create/add/finalize 路径和 follow-up 提示

## 影响范围

- Word 文档四步工具链：`create_document`、`add_blocks`、`finalize_document`、`export_document`
- 文档场景下的 prompt suffix / notice 注入
- 文档会话 follow-up 处理
- 相关单元测试与回归测试

## 测试情况

- [x] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了核心场景

<details>
<summary>手动测试记录（可选）</summary>

本地执行：

- `pytest tests/test_office_assistant_services.py -q`
- `pytest tests/test_office_assistant_before_llm_chat.py -q`
- `pytest tests/test_office_assistant_agent_tools.py -q -k "workflow_after_create_and_finalize or add_blocks_failure_message_keeps_model_on_same_tool or build_document_toolset_uses_shared_store_and_default_workspace"`

</details>

## 备注

涉及文件：

- `agent_tools/document_tools.py`
- `internal_hooks.py`
- `prompts/scenes/__init__.py`
- `prompts/scenes/uploaded_file.py`
- `prompts/static/__init__.py`
- `prompts/static/document_tools.py`
- `services/llm_request_policy.py`
- `services/prompt_context_service.py`
- `services/request_hook_service.py`
- `services/runtime_builder.py`
- `services/upload_session_service.py`
- `tests/test_office_assistant_agent_tools.py`
- `tests/test_office_assistant_before_llm_chat.py`
- `tests/test_office_assistant_services.py`

说明：

- 这次 PR 重点是插件侧的文档工作流提示、notice 注入和测试补强

## Sourcery 总结

收紧 Word 文档工作流和上传文件提示处理，以让模型更准确地使用正确工具，并简化通知插入的位置和方式。

错误修复：
- 通过在会话级别跟踪通知键，防止在同一聊天会话中重复或错误位置地显示文档指导通知。
- 当后续提示显式带有 `document_id` 时，确保返回当前文档所处阶段或清晰的「会话缺失」警告，而不是泛泛的摘要信息。
- 避免将上传文件场景通知插入到已经缓冲的提示中，并确保这些提示被合并到用户提示的后缀中，而不会额外添加多余前缀。

功能增强：
- 优化文档工具指导文案和工具结果信息，使 `add_blocks`、`finalize_document` 和 `export_document` 拥有更严格、与阶段相匹配的下一步操作指引。
- 简化已上传文件的上下文提示，聚焦于文件名和高层处理要求，去除外部绝对路径，并将摘要/场景类通知进行合并。
- 将不同类型的通知段明确路由到用户提示或系统提示中，并在 LLM 请求策略中集中管理通知的合并与排序。
- 在上传会话服务中增加「单次通知」语义，使核心和详细文档指南及其他通知在每个会话中只展示一次。

测试：
- 扩展 Office 助手服务、LLM 前置逻辑以及代理工具测试，以覆盖新的文档后续通知、「仅通知一次」行为、更新后的上传文件提示以及更严格的文档工具工作流文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧 Office 助手的文档和上传工作流指引，使模型保持在正确的工具阶段，简化上传提示，并将提示/通知的处理集中化。

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或错位地显示文档/上传类通知。
- 避免将“上传场景”类通知注入到已经缓冲的提示中，并停止在用户可见的上传通知中暴露外部的绝对文件路径。
- 当用户提示引用特定的 `document_id` 时，返回清晰且具备状态感知的后续指引或缺失会话警告，而不是退回到通用的文档摘要。

增强改进：
- 加强文档工具消息和提示，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 能在对应阶段强制更严格的下一步约束。
- 简化并统一已上传文件的上下文通知，聚焦于文件名和高层处理要求，通过集中式的合并与排序策略，将不同类型的通知明确路由到用户提示后缀或系统提示中。
- 引入按会话的一次性文档指引语义，使核心和详细的文档通知在每个会话中只展示一次，并基于解析出的 `document_id` 和文档状态动态注入文档后续通知。
- 优化文档后续行为，解析多种自然语言形式的 `document_id` 模式，并为草稿/已完成/已导出文档注入具备状态感知的后续通知。
- 让“上传场景”通知忽略已缓冲事件，并确保它们作为提示后缀追加、且不带额外前缀，同时保留系统提示仅用于访问/拒绝类消息。

测试：
- 扩展 Office 助手、LLM 前置逻辑、请求钩子、上传会话以及代理工具的测试，用于覆盖新的文档后续通知、一次性通知行为、更新后的上传提示，以及更严格的文档工作流消息。
- 添加关于文档摘要查找的连接与错误处理、静态/场景/动态三类通知的排序，以及上传会话服务中新的一次性通知行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the Office assistant’s document and upload workflow guidance so the model stays in the correct tool phase, simplifies upload notices, and centralizes prompt/notice handling.

Bug Fixes:
- Prevent repeated or misplaced document/upload notices within the same chat session by tracking consumed notice keys per session.
- Avoid injecting upload-scene notices into already buffered prompts and stop exposing external absolute file paths in user-visible upload notices.
- Return clear, state-aware follow-up guidance or a missing-session warning when user prompts reference a specific document_id instead of falling back to generic document summaries.

Enhancements:
- Strengthen document tool messages and prompts so create_document, add_blocks, finalize_document, and export_document enforce stricter, stage-appropriate next-step constraints.
- Simplify and unify uploaded-file context notices to focus on filenames and high-level handling requirements, routing different notice types explicitly to user-prompt suffixes or system prompts via a centralized merge and ordering strategy.
- Introduce per-session one-time document guidance semantics so core and detail document notices are only shown once per session, with dynamic document follow-up notices injected based on parsed document_id and document status.
- Refine document follow-up behavior to parse multiple natural-language document_id patterns and inject status-aware follow-up notices for draft/finalized/exported documents.
- Make upload-scene notices ignore buffered events and ensure they are appended as prompt suffixes without extra prefixes, keeping system prompts reserved for access/denied messages.

Tests:
- Expand Office assistant, pre-LLM, request-hook, upload-session, and agent-tool tests to cover new document follow-up notices, one-time notice behavior, updated upload prompts, and stricter document workflow messaging.
- Add tests for document summary lookup wiring and error handling, notice ordering between static, scene, and dynamic sections, and the new per-session notice-once behavior in the upload session service.

</details>

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或放错位置地显示文档/上传通知。
- 当用户提示引用特定的 `document_id` 而不是泛化的文档摘要时，返回清晰的后续指引或缺失会话说明。
- 避免将上传场景通知注入到已缓冲的提示中，并停止在面向用户的通知中暴露外部的绝对文件路径。

增强：
- 加强文档工具指引和工具结果消息，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 对下一步操作施加更严格、分阶段匹配的指令约束。
- 简化并整合上传文件相关的上下文提示，聚焦于文件名和高层处理逻辑，将不同类型的通知分别路由到提示后缀或系统提示中，并在 LLM 请求策略中集中统一合并/排序逻辑。
- 引入按会话的一次性文档指引语义，使核心与详细文档通知在每个会话中只出现一次，并优化通知顺序，将动态的后续通知置于静态通知和场景通知之后。
- 调整文档后续行为，从自然语言中解析多种 `document_id` 变体，并针对草稿/已完成/已导出文档注入与状态感知的后续通知，而不会给泛化请求增加负担。

测试：
- 扩展 Office 助手、预 LLM、请求钩子、上传会话以及代理工具测试，覆盖新的文档后续通知、一次性通知行为、更新后的上传提示以及更严格的文档工作流消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧 Office 助手的文档和上传工作流指引，使模型保持在正确的工具阶段，简化上传提示，并将提示/通知的处理集中化。

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或错位地显示文档/上传类通知。
- 避免将“上传场景”类通知注入到已经缓冲的提示中，并停止在用户可见的上传通知中暴露外部的绝对文件路径。
- 当用户提示引用特定的 `document_id` 时，返回清晰且具备状态感知的后续指引或缺失会话警告，而不是退回到通用的文档摘要。

增强改进：
- 加强文档工具消息和提示，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 能在对应阶段强制更严格的下一步约束。
- 简化并统一已上传文件的上下文通知，聚焦于文件名和高层处理要求，通过集中式的合并与排序策略，将不同类型的通知明确路由到用户提示后缀或系统提示中。
- 引入按会话的一次性文档指引语义，使核心和详细的文档通知在每个会话中只展示一次，并基于解析出的 `document_id` 和文档状态动态注入文档后续通知。
- 优化文档后续行为，解析多种自然语言形式的 `document_id` 模式，并为草稿/已完成/已导出文档注入具备状态感知的后续通知。
- 让“上传场景”通知忽略已缓冲事件，并确保它们作为提示后缀追加、且不带额外前缀，同时保留系统提示仅用于访问/拒绝类消息。

测试：
- 扩展 Office 助手、LLM 前置逻辑、请求钩子、上传会话以及代理工具的测试，用于覆盖新的文档后续通知、一次性通知行为、更新后的上传提示，以及更严格的文档工作流消息。
- 添加关于文档摘要查找的连接与错误处理、静态/场景/动态三类通知的排序，以及上传会话服务中新的一次性通知行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the Office assistant’s document and upload workflow guidance so the model stays in the correct tool phase, simplifies upload notices, and centralizes prompt/notice handling.

Bug Fixes:
- Prevent repeated or misplaced document/upload notices within the same chat session by tracking consumed notice keys per session.
- Avoid injecting upload-scene notices into already buffered prompts and stop exposing external absolute file paths in user-visible upload notices.
- Return clear, state-aware follow-up guidance or a missing-session warning when user prompts reference a specific document_id instead of falling back to generic document summaries.

Enhancements:
- Strengthen document tool messages and prompts so create_document, add_blocks, finalize_document, and export_document enforce stricter, stage-appropriate next-step constraints.
- Simplify and unify uploaded-file context notices to focus on filenames and high-level handling requirements, routing different notice types explicitly to user-prompt suffixes or system prompts via a centralized merge and ordering strategy.
- Introduce per-session one-time document guidance semantics so core and detail document notices are only shown once per session, with dynamic document follow-up notices injected based on parsed document_id and document status.
- Refine document follow-up behavior to parse multiple natural-language document_id patterns and inject status-aware follow-up notices for draft/finalized/exported documents.
- Make upload-scene notices ignore buffered events and ensure they are appended as prompt suffixes without extra prefixes, keeping system prompts reserved for access/denied messages.

Tests:
- Expand Office assistant, pre-LLM, request-hook, upload-session, and agent-tool tests to cover new document follow-up notices, one-time notice behavior, updated upload prompts, and stricter document workflow messaging.
- Add tests for document summary lookup wiring and error handling, notice ordering between static, scene, and dynamic sections, and the new per-session notice-once behavior in the upload session service.

</details>

</details>

Bug 修复：
- 通过在每个会话内跟踪提示键，防止在同一聊天会话中出现重复或位置错误的文档/上传提示。
- 当用户提示引用特定的 `document_id` 而不是泛化的文档摘要时，返回清晰的后续步骤说明或“缺少会话”的指引。
- 避免将上传场景的提示注入到已经缓冲的提示中，并移除面向用户的提示中对外部绝对文件路径的暴露。

增强改进：
- 加强 `create_document` / `add_blocks` / `finalize_document` / `export_document` 工具消息及后续提示，以强制遵循严格、阶段适配的文档工作流。
- 简化并整合已上传文件上下文提示，使其聚焦于文件名和高层处理说明，并将不同类型的提示明确路由到用户提示后缀或系统提示中。
- 在 LLM 请求策略中集中处理提示合并和排序，使提示后缀能够在无额外前缀的情况下追加，并将系统级提示与用户可见指引区分开来。
- 为每个会话引入“仅提示一次”的语义，使核心和详细文档引导以及其他提示在每个会话中只显示一次，除非确有再次展示的需要。

测试：
- 扩展 Office assistant、pre-LLM、request-hook、upload-session 和 agent 工具相关测试，以覆盖更严格的文档工作流消息、改进后的 `document_id` 后续行为、新的上传提示格式，以及“仅提示一次”的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧 Office 助手的文档和上传工作流指引，使模型保持在正确的工具阶段，简化上传提示，并将提示/通知的处理集中化。

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或错位地显示文档/上传类通知。
- 避免将“上传场景”类通知注入到已经缓冲的提示中，并停止在用户可见的上传通知中暴露外部的绝对文件路径。
- 当用户提示引用特定的 `document_id` 时，返回清晰且具备状态感知的后续指引或缺失会话警告，而不是退回到通用的文档摘要。

增强改进：
- 加强文档工具消息和提示，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 能在对应阶段强制更严格的下一步约束。
- 简化并统一已上传文件的上下文通知，聚焦于文件名和高层处理要求，通过集中式的合并与排序策略，将不同类型的通知明确路由到用户提示后缀或系统提示中。
- 引入按会话的一次性文档指引语义，使核心和详细的文档通知在每个会话中只展示一次，并基于解析出的 `document_id` 和文档状态动态注入文档后续通知。
- 优化文档后续行为，解析多种自然语言形式的 `document_id` 模式，并为草稿/已完成/已导出文档注入具备状态感知的后续通知。
- 让“上传场景”通知忽略已缓冲事件，并确保它们作为提示后缀追加、且不带额外前缀，同时保留系统提示仅用于访问/拒绝类消息。

测试：
- 扩展 Office 助手、LLM 前置逻辑、请求钩子、上传会话以及代理工具的测试，用于覆盖新的文档后续通知、一次性通知行为、更新后的上传提示，以及更严格的文档工作流消息。
- 添加关于文档摘要查找的连接与错误处理、静态/场景/动态三类通知的排序，以及上传会话服务中新的一次性通知行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the Office assistant’s document and upload workflow guidance so the model stays in the correct tool phase, simplifies upload notices, and centralizes prompt/notice handling.

Bug Fixes:
- Prevent repeated or misplaced document/upload notices within the same chat session by tracking consumed notice keys per session.
- Avoid injecting upload-scene notices into already buffered prompts and stop exposing external absolute file paths in user-visible upload notices.
- Return clear, state-aware follow-up guidance or a missing-session warning when user prompts reference a specific document_id instead of falling back to generic document summaries.

Enhancements:
- Strengthen document tool messages and prompts so create_document, add_blocks, finalize_document, and export_document enforce stricter, stage-appropriate next-step constraints.
- Simplify and unify uploaded-file context notices to focus on filenames and high-level handling requirements, routing different notice types explicitly to user-prompt suffixes or system prompts via a centralized merge and ordering strategy.
- Introduce per-session one-time document guidance semantics so core and detail document notices are only shown once per session, with dynamic document follow-up notices injected based on parsed document_id and document status.
- Refine document follow-up behavior to parse multiple natural-language document_id patterns and inject status-aware follow-up notices for draft/finalized/exported documents.
- Make upload-scene notices ignore buffered events and ensure they are appended as prompt suffixes without extra prefixes, keeping system prompts reserved for access/denied messages.

Tests:
- Expand Office assistant, pre-LLM, request-hook, upload-session, and agent-tool tests to cover new document follow-up notices, one-time notice behavior, updated upload prompts, and stricter document workflow messaging.
- Add tests for document summary lookup wiring and error handling, notice ordering between static, scene, and dynamic sections, and the new per-session notice-once behavior in the upload session service.

</details>

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或放错位置地显示文档/上传通知。
- 当用户提示引用特定的 `document_id` 而不是泛化的文档摘要时，返回清晰的后续指引或缺失会话说明。
- 避免将上传场景通知注入到已缓冲的提示中，并停止在面向用户的通知中暴露外部的绝对文件路径。

增强：
- 加强文档工具指引和工具结果消息，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 对下一步操作施加更严格、分阶段匹配的指令约束。
- 简化并整合上传文件相关的上下文提示，聚焦于文件名和高层处理逻辑，将不同类型的通知分别路由到提示后缀或系统提示中，并在 LLM 请求策略中集中统一合并/排序逻辑。
- 引入按会话的一次性文档指引语义，使核心与详细文档通知在每个会话中只出现一次，并优化通知顺序，将动态的后续通知置于静态通知和场景通知之后。
- 调整文档后续行为，从自然语言中解析多种 `document_id` 变体，并针对草稿/已完成/已导出文档注入与状态感知的后续通知，而不会给泛化请求增加负担。

测试：
- 扩展 Office 助手、预 LLM、请求钩子、上传会话以及代理工具测试，覆盖新的文档后续通知、一次性通知行为、更新后的上传提示以及更严格的文档工作流消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

收紧 Office 助手的文档和上传工作流指引，使模型保持在正确的工具阶段，简化上传提示，并将提示/通知的处理集中化。

Bug 修复：
- 通过按会话跟踪已消费的通知键，防止在同一聊天会话中重复或错位地显示文档/上传类通知。
- 避免将“上传场景”类通知注入到已经缓冲的提示中，并停止在用户可见的上传通知中暴露外部的绝对文件路径。
- 当用户提示引用特定的 `document_id` 时，返回清晰且具备状态感知的后续指引或缺失会话警告，而不是退回到通用的文档摘要。

增强改进：
- 加强文档工具消息和提示，使 `create_document`、`add_blocks`、`finalize_document` 和 `export_document` 能在对应阶段强制更严格的下一步约束。
- 简化并统一已上传文件的上下文通知，聚焦于文件名和高层处理要求，通过集中式的合并与排序策略，将不同类型的通知明确路由到用户提示后缀或系统提示中。
- 引入按会话的一次性文档指引语义，使核心和详细的文档通知在每个会话中只展示一次，并基于解析出的 `document_id` 和文档状态动态注入文档后续通知。
- 优化文档后续行为，解析多种自然语言形式的 `document_id` 模式，并为草稿/已完成/已导出文档注入具备状态感知的后续通知。
- 让“上传场景”通知忽略已缓冲事件，并确保它们作为提示后缀追加、且不带额外前缀，同时保留系统提示仅用于访问/拒绝类消息。

测试：
- 扩展 Office 助手、LLM 前置逻辑、请求钩子、上传会话以及代理工具的测试，用于覆盖新的文档后续通知、一次性通知行为、更新后的上传提示，以及更严格的文档工作流消息。
- 添加关于文档摘要查找的连接与错误处理、静态/场景/动态三类通知的排序，以及上传会话服务中新的一次性通知行为的测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten the Office assistant’s document and upload workflow guidance so the model stays in the correct tool phase, simplifies upload notices, and centralizes prompt/notice handling.

Bug Fixes:
- Prevent repeated or misplaced document/upload notices within the same chat session by tracking consumed notice keys per session.
- Avoid injecting upload-scene notices into already buffered prompts and stop exposing external absolute file paths in user-visible upload notices.
- Return clear, state-aware follow-up guidance or a missing-session warning when user prompts reference a specific document_id instead of falling back to generic document summaries.

Enhancements:
- Strengthen document tool messages and prompts so create_document, add_blocks, finalize_document, and export_document enforce stricter, stage-appropriate next-step constraints.
- Simplify and unify uploaded-file context notices to focus on filenames and high-level handling requirements, routing different notice types explicitly to user-prompt suffixes or system prompts via a centralized merge and ordering strategy.
- Introduce per-session one-time document guidance semantics so core and detail document notices are only shown once per session, with dynamic document follow-up notices injected based on parsed document_id and document status.
- Refine document follow-up behavior to parse multiple natural-language document_id patterns and inject status-aware follow-up notices for draft/finalized/exported documents.
- Make upload-scene notices ignore buffered events and ensure they are appended as prompt suffixes without extra prefixes, keeping system prompts reserved for access/denied messages.

Tests:
- Expand Office assistant, pre-LLM, request-hook, upload-session, and agent-tool tests to cover new document follow-up notices, one-time notice behavior, updated upload prompts, and stricter document workflow messaging.
- Add tests for document summary lookup wiring and error handling, notice ordering between static, scene, and dynamic sections, and the new per-session notice-once behavior in the upload session service.

</details>

</details>

</details>

</details>