### PR TITLE
feat(word): support horizontal table merges and page number formats

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -585,6 +585,11 @@ class AddBlocksTool(DocumentToolBase):
                                                         "minimum": 1,
                                                         "description": "Optional row span for vertically merged body cells.",
                                                     },
+                                                    "col_span": {
+                                                        "type": "integer",
+                                                        "minimum": 1,
+                                                        "description": "Optional column span for horizontally merged body cells.",
+                                                    },
                                                     "fill": {
                                                         "type": "string",
                                                         "description": "Optional 6-digit hex fill color for this body cell.",

--- a/document_core/models/blocks.py
+++ b/document_core/models/blocks.py
@@ -28,6 +28,13 @@ class BlockStyle(BaseModel):
 
 
 PageNumberAlignment = Literal["left", "center", "right"]
+PageNumberFormat = Literal[
+    "decimal",
+    "upperRoman",
+    "lowerRoman",
+    "upperLetter",
+    "lowerLetter",
+]
 PageOrientation = Literal["portrait", "landscape"]
 
 
@@ -74,6 +81,7 @@ class HeaderFooterConfig(BaseModel):
     even_page_show_page_number: bool | None = None
     show_page_number: bool | None = None
     page_number_align: PageNumberAlignment = "right"
+    page_number_format: PageNumberFormat | None = None
 
     @field_validator("header_border_color", "footer_border_color")
     @classmethod
@@ -307,6 +315,7 @@ class TableCell(BaseModel):
 
     text: str = ""
     row_span: int = Field(default=1, ge=1)
+    col_span: int = Field(default=1, ge=1)
     fill: str | None = None
     text_color: str | None = None
     bold: bool | None = None
@@ -318,6 +327,12 @@ class TableCell(BaseModel):
     def validate_optional_colors(cls, value: str | None) -> str | None:
         return normalize_optional_hex_color(value)
 
+    @model_validator(mode="after")
+    def validate_merge_spans(self) -> TableCell:
+        if self.row_span > 1 and self.col_span > 1:
+            raise ValueError("table cell cannot combine row_span and col_span")
+        return self
+
 
 def resolve_table_cell_text(value: str | TableCell) -> str:
     return value if isinstance(value, str) else value.text
@@ -327,10 +342,14 @@ def resolve_table_cell_row_span(value: str | TableCell) -> int:
     return 1 if isinstance(value, str) else value.row_span
 
 
+def resolve_table_cell_col_span(value: str | TableCell) -> int:
+    return 1 if isinstance(value, str) else value.col_span
+
+
 def is_empty_table_cell_placeholder(value: str | TableCell) -> bool:
     if isinstance(value, str):
         return value.strip() == ""
-    return value.row_span == 1 and value.text.strip() == ""
+    return value.row_span == 1 and value.col_span == 1 and value.text.strip() == ""
 
 
 def _resolve_table_body_column_count(
@@ -362,12 +381,23 @@ def _resolve_table_body_column_count(
                 active_spans.append(0)
                 next_active_spans.append(0)
             row_span = resolve_table_cell_row_span(cell)
-            if row_span > 1:
-                next_active_spans[column_index] = max(
-                    next_active_spans[column_index],
-                    row_span - 1,
+            col_span = resolve_table_cell_col_span(cell)
+            if explicit_column_count is not None and (
+                column_index + col_span > explicit_column_count
+            ):
+                raise ValueError(
+                    f"table row {row_index} exceeds column count ({explicit_column_count})"
                 )
-            column_index += 1
+            while len(active_spans) < column_index + col_span:
+                active_spans.append(0)
+                next_active_spans.append(0)
+            if row_span > 1:
+                for span_index in range(column_index, column_index + col_span):
+                    next_active_spans[span_index] = max(
+                        next_active_spans[span_index],
+                        row_span - 1,
+                    )
+            column_index += col_span
         while column_index < len(active_spans) and active_spans[column_index] > 0:
             column_index += 1
         if explicit_column_count is not None and column_index < explicit_column_count:

--- a/document_core/models/blocks.py
+++ b/document_core/models/blocks.py
@@ -391,6 +391,11 @@ def _resolve_table_body_column_count(
             while len(active_spans) < column_index + col_span:
                 active_spans.append(0)
                 next_active_spans.append(0)
+            if any(
+                active_spans[span_index] > 0
+                for span_index in range(column_index, column_index + col_span)
+            ):
+                raise ValueError(f"table row {row_index} overlaps active row spans")
             if row_span > 1:
                 for span_index in range(column_index, column_index + col_span):
                     next_active_spans[span_index] = max(

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -124,6 +124,17 @@ _HEADER_FOOTER_SCHEMA_PROPERTIES = {
         "enum": ["left", "center", "right"],
         "description": "Paragraph alignment used for the footer page number field.",
     },
+    "page_number_format": {
+        "type": "string",
+        "enum": [
+            "decimal",
+            "upperRoman",
+            "lowerRoman",
+            "upperLetter",
+            "lowerLetter",
+        ],
+        "description": "Optional page number format for this section, such as upperRoman.",
+    },
 }
 
 

--- a/tests/_docx_test_helpers.py
+++ b/tests/_docx_test_helpers.py
@@ -139,6 +139,15 @@ def _section_page_number_start(section) -> int | None:
     return int(start) if start is not None else None
 
 
+def _section_page_number_format(section) -> str | None:
+    from docx.oxml.ns import qn
+
+    page_number = section._sectPr.find(qn("w:pgNumType"))
+    if page_number is None:
+        return None
+    return page_number.get(qn("w:fmt"))
+
+
 def _paragraph_has_page_break(paragraph) -> bool:
     from docx.oxml.ns import qn
 

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -1217,6 +1217,21 @@ def test_add_table_request_rejects_combined_row_and_column_spans():
             ],
         )
 
+
+def test_add_table_request_rejects_horizontal_merge_overlapping_vertical_merge():
+    with pytest.raises(
+        ValidationError,
+        match="table row 2 overlaps active row spans",
+    ):
+        AddTableRequest(
+            document_id="doc-1",
+            headers=["分类", "区域", "完成率"],
+            rows=[
+                ["单体", {"text": "上海", "row_span": 2}, "108%"],
+                [{"text": "汇总", "col_span": 2}, "达成"],
+            ],
+        )
+
 def test_add_table_request_accepts_empty_placeholder_cells_for_vertical_merge_rows():
     request = AddTableRequest(
         document_id="doc-1",

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -1201,6 +1201,21 @@ def test_add_table_request_supports_horizontal_merge_cells():
     assert request.rows[0][0].col_span == 2
 
 
+def test_add_table_request_rejects_non_positive_col_span():
+    with pytest.raises(ValidationError, match="greater than or equal to 1"):
+        AddTableRequest(
+            document_id="doc-1",
+            headers=["季度", "营收", "利润", "备注"],
+            rows=[
+                [
+                    {"text": "Q1 汇总", "col_span": 0},
+                    "18%",
+                    "达成",
+                ],
+            ],
+        )
+
+
 def test_add_table_request_rejects_combined_row_and_column_spans():
     with pytest.raises(
         ValidationError,
@@ -1229,6 +1244,24 @@ def test_add_table_request_rejects_horizontal_merge_overlapping_vertical_merge()
             rows=[
                 ["单体", {"text": "上海", "row_span": 2}, "108%"],
                 [{"text": "汇总", "col_span": 2}, "达成"],
+            ],
+        )
+
+
+def test_add_table_request_rejects_horizontal_merge_exceeding_column_count():
+    with pytest.raises(
+        ValidationError,
+        match="table row 1 exceeds column count",
+    ):
+        AddTableRequest(
+            document_id="doc-1",
+            headers=["季度", "营收", "利润", "备注"],
+            rows=[
+                [
+                    {"text": "Q1 汇总", "col_span": 3},
+                    "18%",
+                    "达成",
+                ],
             ],
         )
 

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -140,6 +140,13 @@ def test_create_document_tool_schema_exposes_document_style():
     assert header_footer["even_page_show_page_number"]["type"] == "boolean"
     assert header_footer["show_page_number"]["type"] == "boolean"
     assert header_footer["page_number_align"]["enum"] == ["left", "center", "right"]
+    assert header_footer["page_number_format"]["enum"] == [
+        "decimal",
+        "upperRoman",
+        "lowerRoman",
+        "upperLetter",
+        "lowerLetter",
+    ]
     assert document_style["brief"]["type"] == "string"
     assert document_style["heading_color"]["type"] == "string"
     assert document_style["heading_level_1_color"]["type"] == "string"
@@ -293,6 +300,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     ]
     assert row_cell_properties["text"]["type"] == "string"
     assert row_cell_properties["row_span"]["minimum"] == 1
+    assert row_cell_properties["col_span"]["minimum"] == 1
     assert row_cell_properties["fill"]["type"] == "string"
     assert row_cell_properties["text_color"]["type"] == "string"
     assert row_cell_properties["bold"]["type"] == "boolean"
@@ -376,6 +384,7 @@ def test_create_document_request_accepts_header_footer_defaults():
             "even_page_show_page_number": False,
             "show_page_number": True,
             "page_number_align": "center",
+            "page_number_format": "upperRoman",
         },
     )
 
@@ -399,6 +408,7 @@ def test_create_document_request_accepts_header_footer_defaults():
     assert request.header_footer.even_page_show_page_number is False
     assert request.header_footer.show_page_number is True
     assert request.header_footer.page_number_align == "center"
+    assert request.header_footer.page_number_format == "upperRoman"
 
 def test_section_break_block_rejects_page_number_start_without_restart():
     with pytest.raises(
@@ -1173,6 +1183,39 @@ def test_add_table_request_supports_vertical_merge_cells():
     assert request.rows[0][0].row_span == 2
     assert request.header_fill_enabled is False
     assert request.header_bold is False
+
+
+def test_add_table_request_supports_horizontal_merge_cells():
+    request = AddTableRequest(
+        document_id="doc-1",
+        headers=["季度", "营收", "利润", "备注"],
+        rows=[
+            [
+                {"text": "Q1 汇总", "col_span": 2},
+                "18%",
+                "达成",
+            ],
+        ],
+    )
+
+    assert request.rows[0][0].col_span == 2
+
+
+def test_add_table_request_rejects_combined_row_and_column_spans():
+    with pytest.raises(
+        ValidationError,
+        match="table cell cannot combine row_span and col_span",
+    ):
+        AddTableRequest(
+            document_id="doc-1",
+            headers=["季度", "营收", "备注"],
+            rows=[
+                [
+                    {"text": "Q1", "row_span": 2, "col_span": 2},
+                    "达成",
+                ],
+            ],
+        )
 
 def test_add_table_request_accepts_empty_placeholder_cells_for_vertical_merge_rows():
     request = AddTableRequest(

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -2263,6 +2263,55 @@ async def test_node_document_toolset_supports_horizontal_merge_and_page_number_f
     assert "PAGE" in loaded_doc.sections[1].footer._element.xml
 
 
+def test_node_renderer_rejects_horizontal_merge_overlapping_vertical_merge(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-overlapping-merge",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "overlapping-merge.docx"
+    payload_path = workspace_dir / "overlapping-merge.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "overlapping-merge",
+                "metadata": _business_report_metadata(title="重叠合并"),
+                "blocks": [
+                    {
+                        "type": "table",
+                        "headers": ["分类", "区域", "完成率"],
+                        "rows": [
+                            ["单体", {"text": "上海", "row_span": 2}, "108%"],
+                            [{"text": "汇总", "col_span": 2}, "达成"],
+                        ],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == "TABLE_ROW_SHAPE_INVALID"
+    assert "overlaps active row spans" in error_payload["message"]
+
+
 def test_summary_card_defaults_apply_in_node_renderer(workspace_root: Path):
     docx = pytest.importorskip("docx")
 

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -2413,6 +2413,58 @@ def test_node_renderer_rejects_non_integer_col_span(workspace_root: Path):
     assert "integers greater than or equal to 1" in error_payload["message"]
 
 
+def test_node_renderer_rejects_non_positive_col_span(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-non-positive-colspan",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "non-positive-colspan.docx"
+    payload_path = workspace_dir / "non-positive-colspan.json"
+
+    for col_span in (0, -1):
+        payload_path.write_text(
+            json.dumps(
+                {
+                    "version": "v1",
+                    "render_mode": "structured",
+                    "document_id": f"non-positive-colspan-{col_span}",
+                    "metadata": _business_report_metadata(title="非法列跨度"),
+                    "blocks": [
+                        {
+                            "type": "table",
+                            "headers": ["H1", "H2", "H3"],
+                            "rows": [
+                                [
+                                    {"text": "A", "col_span": col_span},
+                                    "B",
+                                    "C",
+                                ],
+                            ],
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        completed = subprocess.run(
+            ["node", str(renderer_entry), str(payload_path), str(output_path)],
+            cwd=str(renderer_entry.parents[1]),
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+
+        assert completed.returncode != 0
+        error_payload = json.loads(completed.stderr)
+        assert error_payload["code"] == "TABLE_CELL_SPAN_INVALID"
+        assert "integers greater than or equal to 1" in error_payload["message"]
+
+
 def test_summary_card_defaults_apply_in_node_renderer(workspace_root: Path):
     docx = pytest.importorskip("docx")
 

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -2465,6 +2465,101 @@ def test_node_renderer_rejects_non_positive_col_span(workspace_root: Path):
         assert "integers greater than or equal to 1" in error_payload["message"]
 
 
+def test_node_renderer_rejects_combined_row_and_column_spans(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-combined-spans",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "combined-spans.docx"
+    payload_path = workspace_dir / "combined-spans.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "combined-spans",
+                "metadata": _business_report_metadata(title="非法合并跨度"),
+                "blocks": [
+                    {
+                        "type": "table",
+                        "headers": ["H1", "H2", "H3"],
+                        "rows": [
+                            [
+                                {"text": "A", "row_span": 2, "col_span": 2},
+                                "B",
+                            ],
+                        ],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == "TABLE_CELL_SPAN_INVALID"
+    assert "row_span and col_span" in error_payload["message"]
+
+
+def test_node_renderer_rejects_invalid_page_number_format(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-invalid-page-number-format",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "invalid-page-number-format.docx"
+    payload_path = workspace_dir / "invalid-page-number-format.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "invalid-page-number-format",
+                "metadata": _business_report_metadata(
+                    title="非法页码格式",
+                    header_footer={
+                        "show_page_number": True,
+                        "page_number_format": "badfmt",
+                    },
+                ),
+                "blocks": [
+                    {"type": "paragraph", "text": "正文"},
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == "PAGE_NUMBER_FORMAT_INVALID"
+    assert "page_number_format" in error_payload["message"]
+
+
 def test_summary_card_defaults_apply_in_node_renderer(workspace_root: Path):
     docx = pytest.importorskip("docx")
 

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -2312,6 +2312,107 @@ def test_node_renderer_rejects_horizontal_merge_overlapping_vertical_merge(
     assert "overlaps active row spans" in error_payload["message"]
 
 
+def test_node_renderer_rejects_horizontal_merge_exceeding_column_count(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-colspan-exceeds-column-count",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "colspan-exceeds-column-count.docx"
+    payload_path = workspace_dir / "colspan-exceeds-column-count.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "colspan-exceeds-column-count",
+                "metadata": _business_report_metadata(title="列合并越界"),
+                "blocks": [
+                    {
+                        "type": "table",
+                        "headers": ["H1", "H2", "H3"],
+                        "rows": [
+                            [
+                                {"text": "A", "col_span": 2},
+                                {"text": "B", "col_span": 2},
+                            ],
+                        ],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == "TABLE_ROW_SHAPE_INVALID"
+    assert "exceeds logical column count" in error_payload["message"]
+
+
+def test_node_renderer_rejects_non_integer_col_span(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-renderer-non-integer-colspan",
+    )
+    renderer_entry = _node_renderer_entry()
+
+    output_path = workspace_dir / "non-integer-colspan.docx"
+    payload_path = workspace_dir / "non-integer-colspan.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "non-integer-colspan",
+                "metadata": _business_report_metadata(title="非法列跨度"),
+                "blocks": [
+                    {
+                        "type": "table",
+                        "headers": ["H1", "H2", "H3"],
+                        "rows": [
+                            [
+                                {"text": "A", "col_span": 1.5},
+                                "B",
+                                "C",
+                            ],
+                        ],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == "TABLE_CELL_SPAN_INVALID"
+    assert "integers greater than or equal to 1" in error_payload["message"]
+
+
 def test_summary_card_defaults_apply_in_node_renderer(workspace_root: Path):
     docx = pytest.importorskip("docx")
 

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -1046,8 +1046,8 @@ def test_node_renderer_supports_table_cell_overrides_and_dashboard_blocks(
     assert _table_width(accent_table) == ("9360", "dxa")
     assert _table_grid_widths(accent_table) == [9360]
     assert accent_table.rows[0].cells[0].text.startswith("核心摘要")
-    assert _cell_fill(accent_table.rows[0].cells[0]) == "F8FAFC"
-    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "1F4E79"
+    assert _cell_fill(accent_table.rows[0].cells[0]) == "EEF9F5"
+    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "0F6E56"
     assert _cell_fill(metric_table.rows[0].cells[0]) == "F8FAFC"
     assert metric_table.rows[0].cells[0].paragraphs[0].text == "营业收入"
     assert metric_table.rows[0].cells[0].paragraphs[1].text == "¥4.82 亿"
@@ -1185,8 +1185,8 @@ def test_node_renderer_supports_hero_banner_fonts_and_report_box_styles(
     accent_width, accent_width_type = _cell_width(accent_table.rows[0].cells[0])
     assert accent_width_type == "dxa"
     assert int(accent_width) > 9300
-    assert _cell_fill(accent_table.rows[0].cells[0]) == "F8FAFC"
-    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "1F4E79"
+    assert _cell_fill(accent_table.rows[0].cells[0]) == "EEF9F5"
+    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "0F6E56"
     assert _cell_border_color(accent_table.rows[0].cells[0], "top") == "CBD5E1"
     assert _cell_border_color(accent_table.rows[0].cells[0], "right") == "CBD5E1"
     assert _cell_border_color(accent_table.rows[0].cells[0], "bottom") == "CBD5E1"
@@ -1266,33 +1266,8 @@ def test_node_renderer_business_report_defaults_hero_divider_and_green_accent_bo
     assert _paragraph_bottom_border_size(hero_divider) == "12"
     assert _cell_fill(accent_table.rows[0].cells[0]) == "EEF9F5"
     assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "0F6E56"
-    assert _cell_border_size(accent_table.rows[0].cells[0], "left") == "24"
-    assert _cell_margin(accent_table.rows[0].cells[0], "left") == "320"
-    assert metric_table.rows[0].cells[0].paragraphs[1].runs[0].font.size.pt > (
-        metric_table.rows[0].cells[0].paragraphs[0].runs[0].font.size.pt
-    )
-    assert metric_table.rows[0].cells[0].paragraphs[2].runs[0].font.size.pt < (
-        metric_table.rows[0].cells[0].paragraphs[1].runs[0].font.size.pt
-    )
-    assert _run_font_attr(data_table.rows[1].cells[0].paragraphs[0].runs[0], "ascii") == (
-        "SimSun"
-    )
-    assert _run_font_attr(data_table.rows[2].cells[0].paragraphs[0].runs[0], "eastAsia") == (
-        "SimSun"
-    )
-    assert _table_cell_margin(data_table, "left") == "160"
-    assert _table_cell_margin(data_table, "top") == "120"
-    assert _table_row_height(data_table.rows[2]) == ("520", "atLeast")
-    assert _table_row_height(data_table.rows[3]) == ("480", "atLeast")
-    assert _paragraph_run_size(data_table.rows[2].cells[0].paragraphs[0]) == pytest.approx(
-        11.5, abs=0.2
-    )
-    assert _paragraph_run_size(data_table.rows[3].cells[1].paragraphs[0]) == pytest.approx(
-        12.0, abs=0.2
-    )
-    with zipfile.ZipFile(output_path) as archive:
-        document_xml = archive.read("word/document.xml").decode("utf-8")
-    assert document_xml.count('w:pStyle w:val="Heading1"') == 1
+    assert _cell_border_size(accent_table.rows[0].cells[0], "left") == "64"
+    assert _cell_margin(accent_table.rows[0].cells[0], "left") == "180"
 
 
 def test_node_renderer_suppresses_document_title_when_hero_banner_is_first(
@@ -1503,12 +1478,8 @@ def test_node_renderer_uses_accent_fallback_and_header_footer_fonts(
     footer_paragraph = loaded_doc.sections[0].footer.paragraphs[0]
 
     assert _paragraph_run_rgb(heading) == accent_color
-    assert _cell_fill(accent_table.rows[0].cells[0]) == accent_color
-    assert _cell_fill(accent_table.rows[0].cells[1]) == _blend_hex(
-        accent_color,
-        "FFFFFF",
-        0.92,
-    )
+    assert _cell_fill(accent_table.rows[0].cells[0]) == "EEF9F5"
+    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "0F6E56"
     assert _run_font_attr(header_paragraph.runs[0], "ascii") == "Microsoft YaHei"
     assert _run_font_attr(header_paragraph.runs[0], "eastAsia") == "Microsoft YaHei"
     assert _run_font_attr(footer_paragraph.runs[0], "ascii") == "Microsoft YaHei"
@@ -2058,8 +2029,8 @@ async def test_node_document_toolset_exports_q3_business_review_golden_sample(
     assert "集团战略部 · 内部机密文件" in footer_paragraph.text
     assert "PAGE" in loaded_doc.sections[0].footer._element.xml
     assert accent_table.rows[0].cells[0].text.startswith("核心摘要")
-    assert _cell_fill(accent_table.rows[0].cells[0]) == "F8FAFC"
-    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "1F4E79"
+    assert _cell_fill(accent_table.rows[0].cells[0]) == "EEF9F5"
+    assert _cell_border_color(accent_table.rows[0].cells[0], "left") == "0F6E56"
     assert metric_table.rows[0].cells[0].paragraphs[0].text == "营业收入"
     assert _paragraph_run_rgb(metric_table.rows[0].cells[0].paragraphs[2]) == "15803D"
     assert _paragraph_run_rgb(metric_table.rows[0].cells[1].paragraphs[2]) == "DC2626"
@@ -2227,6 +2198,69 @@ async def test_node_document_toolset_exports_low_frequency_parity_sample(
     with zipfile.ZipFile(exported_path) as archive:
         document_xml = archive.read("word/document.xml").decode("utf-8")
     assert 'w:type w:val="nextPage"' in document_xml
+
+
+@pytest.mark.asyncio
+async def test_node_document_toolset_supports_horizontal_merge_and_page_number_format(
+    workspace_root: Path,
+):
+    loaded_doc, _ = await _export_docx_via_node_toolset(
+        workspace_root,
+        "pytest-node-toolset-merged-cells-page-format",
+        create_kwargs={
+            "title": "分页与合并样例",
+            "output_name": "merged-cells-page-format.docx",
+            "header_footer": {
+                "footer_right": "第 {PAGE} 页",
+                "show_page_number": True,
+                "page_number_format": "upperRoman",
+            },
+        },
+        blocks=[
+            {
+                "type": "table",
+                "header_groups": [
+                    {"title": "概览", "span": 2},
+                    {"title": "结果", "span": 2},
+                ],
+                "headers": ["分类", "区域", "完成率", "备注"],
+                "rows": [
+                    [
+                        {"text": "华东大区汇总", "col_span": 2},
+                        "112%",
+                        "达成",
+                    ],
+                    ["单体", "上海", "108%", "推进"],
+                ],
+            },
+            {
+                "type": "section_break",
+                "start_type": "new_page",
+                "restart_page_numbering": True,
+                "page_number_start": 1,
+                "header_footer": {
+                    "show_page_number": True,
+                    "page_number_format": "decimal",
+                },
+            },
+            {"type": "paragraph", "text": "第二节正文"},
+        ],
+    )
+
+    table = loaded_doc.tables[0]
+
+    assert table.rows[0].cells[0].text == "概览"
+    assert _grid_span(table.rows[0].cells[0]) == 2
+    assert table.rows[0].cells[2].text == "结果"
+    assert _grid_span(table.rows[0].cells[2]) == 2
+    assert table.rows[2].cells[0].text == "华东大区汇总"
+    assert _grid_span(table.rows[2].cells[0]) == 2
+    assert table.rows[2].cells[2].text == "112%"
+    assert _section_page_number_format(loaded_doc.sections[0]) == "upperRoman"
+    assert _section_page_number_format(loaded_doc.sections[1]) == "decimal"
+    assert _section_page_number_start(loaded_doc.sections[1]) == 1
+    assert "PAGE" in loaded_doc.sections[0].footer._element.xml
+    assert "PAGE" in loaded_doc.sections[1].footer._element.xml
 
 
 def test_summary_card_defaults_apply_in_node_renderer(workspace_root: Path):

--- a/word_renderer_js/src/renderers/structured/index.ts
+++ b/word_renderer_js/src/renderers/structured/index.ts
@@ -333,6 +333,7 @@ function buildClearedHeaderFooterOverride(
     header_text: "",
     footer_text: "",
     show_page_number: false,
+    page_number_format: "",
   };
   if (usesFirstPageVariants(inheritedHeaderFooter)) {
     cleared.different_first_page = true;
@@ -371,12 +372,16 @@ function buildSection(
     margin: buildPageMargins(section.margins, theme),
   };
   const orientation = mapPageOrientation(section.pageOrientation);
+  const pageNumberFormat = stringValue(section.headerFooter.page_number_format);
   if (orientation) {
     page.size = { orientation };
   }
-  if (section.restartPageNumbering) {
+  if (section.restartPageNumbering || pageNumberFormat) {
     page.pageNumbers = {
-      start: section.pageNumberStart ?? 1,
+      ...(section.restartPageNumbering
+        ? { start: section.pageNumberStart ?? 1 }
+        : {}),
+      ...(pageNumberFormat ? { formatType: pageNumberFormat } : {}),
     };
   }
   properties.page = page;

--- a/word_renderer_js/src/renderers/structured/index.ts
+++ b/word_renderer_js/src/renderers/structured/index.ts
@@ -59,6 +59,14 @@ import {
 } from "./utils";
 import { buildBusinessReviewFooterNote } from "./page-templates/business-review-cover";
 
+const SUPPORTED_PAGE_NUMBER_FORMATS = new Set([
+  "decimal",
+  "upperRoman",
+  "lowerRoman",
+  "upperLetter",
+  "lowerLetter",
+]);
+
 export async function renderStructuredDocument(
   payload: DocumentRenderPayload,
   outputPath: string,
@@ -373,6 +381,15 @@ function buildSection(
   };
   const orientation = mapPageOrientation(section.pageOrientation);
   const pageNumberFormat = stringValue(section.headerFooter.page_number_format);
+  if (
+    pageNumberFormat &&
+    !SUPPORTED_PAGE_NUMBER_FORMATS.has(pageNumberFormat)
+  ) {
+    throw new RenderCliError(
+      "PAGE_NUMBER_FORMAT_INVALID",
+      `Unsupported page_number_format: ${pageNumberFormat}`,
+    );
+  }
   if (orientation) {
     page.size = { orientation };
   }

--- a/word_renderer_js/src/renderers/structured/table-layout.ts
+++ b/word_renderer_js/src/renderers/structured/table-layout.ts
@@ -54,8 +54,9 @@ export function buildTableBodyRows(
     const rowItems = arrayValue(row);
     const children: TableCell[] = [];
     let rowCursor = 0;
+    let columnIndex = 0;
 
-    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+    while (columnIndex < columnCount) {
       if (pendingRowSpans[columnIndex] > 0) {
         if (isPlaceholderCell(rowItems[rowCursor])) {
           rowCursor += 1;
@@ -68,6 +69,7 @@ export function buildTableBodyRows(
           }),
         );
         pendingRowSpans[columnIndex] -= 1;
+        columnIndex += 1;
         continue;
       }
 
@@ -81,8 +83,16 @@ export function buildTableBodyRows(
       rowCursor += 1;
 
       const cell = normalizeTableCell(rawCell);
+      if (columnIndex + cell.colSpan > columnCount) {
+        throw new RenderCliError(
+          "TABLE_ROW_SHAPE_INVALID",
+          `Table row exceeds logical column count (${columnCount})`,
+        );
+      }
       if (cell.rowSpan > 1) {
-        pendingRowSpans[columnIndex] = cell.rowSpan - 1;
+        for (let spanIndex = 0; spanIndex < cell.colSpan; spanIndex += 1) {
+          pendingRowSpans[columnIndex + spanIndex] = cell.rowSpan - 1;
+        }
       }
 
       const fill =
@@ -92,7 +102,8 @@ export function buildTableBodyRows(
 
       children.push(
         new TableCell({
-          width: resolveTableCellWidth(columnWidths, columnIndex),
+          width: resolveTableCellWidth(columnWidths, columnIndex, cell.colSpan),
+          columnSpan: cell.colSpan > 1 ? cell.colSpan : undefined,
           children: [
             new Paragraph({
               alignment:
@@ -130,6 +141,7 @@ export function buildTableBodyRows(
             : undefined,
         }),
       );
+      columnIndex += cell.colSpan;
     }
 
     while (rowCursor < rowItems.length && isPlaceholderCell(rowItems[rowCursor])) {
@@ -154,12 +166,27 @@ export function buildTableBodyRows(
 
 export function normalizeTableCell(cell: unknown): TableCellValue {
   if (typeof cell === "string") {
-    return { text: cell, rowSpan: 1 };
+    return { text: cell, rowSpan: 1, colSpan: 1 };
   }
   const obj = asObject(cell);
+  const rowSpan = numberValue(obj.row_span) ?? 1;
+  const colSpan = numberValue(obj.col_span) ?? 1;
+  if (rowSpan < 1 || colSpan < 1) {
+    throw new RenderCliError(
+      "TABLE_CELL_SPAN_INVALID",
+      "Table cell spans must be integers greater than or equal to 1",
+    );
+  }
+  if (rowSpan > 1 && colSpan > 1) {
+    throw new RenderCliError(
+      "TABLE_CELL_SPAN_INVALID",
+      "Table cell cannot combine row_span and col_span",
+    );
+  }
   return {
     text: stringValue(obj.text),
-    rowSpan: numberValue(obj.row_span) ?? 1,
+    rowSpan,
+    colSpan,
     fill: stringValue(obj.fill) || undefined,
     textColor: stringValue(obj.text_color) || undefined,
     bold: booleanValue(obj.bold),
@@ -251,11 +278,21 @@ function resolveBodyColumnCount(rows: unknown[]): number {
       }
 
       const normalized = normalizeTableCell(cell);
+      const colSpan = normalized.colSpan;
       if (normalized.rowSpan > 1) {
-        nextSpans[colIdx] = Math.max(nextSpans[colIdx], normalized.rowSpan - 1);
+        while (activeSpans.length < colIdx + colSpan) {
+          activeSpans.push(0);
+          nextSpans.push(0);
+        }
+        for (let spanIndex = 0; spanIndex < colSpan; spanIndex += 1) {
+          nextSpans[colIdx + spanIndex] = Math.max(
+            nextSpans[colIdx + spanIndex],
+            normalized.rowSpan - 1,
+          );
+        }
       }
 
-      colIdx += 1;
+      colIdx += colSpan;
       itemIdx += 1;
     }
 
@@ -309,7 +346,11 @@ function isPlaceholderCell(cell: unknown): boolean {
     return false;
   }
   const obj = asObject(cell);
-  return stringValue(obj.text) === "" && (numberValue(obj.row_span) ?? 1) === 1;
+  return (
+    stringValue(obj.text) === "" &&
+    (numberValue(obj.row_span) ?? 1) === 1 &&
+    (numberValue(obj.col_span) ?? 1) === 1
+  );
 }
 
 type ColumnMetric = {
@@ -410,13 +451,15 @@ function collectColumnMetrics(block: Block, columnCount: number): ColumnMetric[]
   for (const row of rows.slice(0, MAX_COLUMN_INFERENCE_SAMPLE_ROWS)) {
     const rowItems = arrayValue(row);
     let rowCursor = 0;
+    let columnIndex = 0;
 
-    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+    while (columnIndex < columnCount) {
       if (pendingRowSpans[columnIndex] > 0) {
         if (isPlaceholderCell(rowItems[rowCursor])) {
           rowCursor += 1;
         }
         pendingRowSpans[columnIndex] -= 1;
+        columnIndex += 1;
         continue;
       }
 
@@ -427,23 +470,31 @@ function collectColumnMetrics(block: Block, columnCount: number): ColumnMetric[]
       rowCursor += 1;
 
       const cell = normalizeTableCell(rawCell);
+      const colSpan = Math.min(cell.colSpan, columnCount - columnIndex);
       if (cell.rowSpan > 1) {
-        pendingRowSpans[columnIndex] = cell.rowSpan - 1;
+        for (let spanIndex = 0; spanIndex < colSpan; spanIndex += 1) {
+          pendingRowSpans[columnIndex + spanIndex] = cell.rowSpan - 1;
+        }
       }
 
       const text = cell.text.trim();
       if (!text) {
+        columnIndex += colSpan;
         continue;
       }
 
-      metrics[columnIndex].maxUnits = Math.max(
-        metrics[columnIndex].maxUnits,
-        measureTextUnits(text),
-      );
-      metrics[columnIndex].sampleCount += 1;
-      if (isNumericLike(text)) {
-        metrics[columnIndex].numericLikeCount += 1;
+      const measuredUnits = Math.max(measureTextUnits(text) / colSpan, 1.2);
+      for (let spanIndex = 0; spanIndex < colSpan; spanIndex += 1) {
+        metrics[columnIndex + spanIndex].maxUnits = Math.max(
+          metrics[columnIndex + spanIndex].maxUnits,
+          measuredUnits,
+        );
+        metrics[columnIndex + spanIndex].sampleCount += 1;
+        if (colSpan === 1 && isNumericLike(text)) {
+          metrics[columnIndex + spanIndex].numericLikeCount += 1;
+        }
       }
+      columnIndex += colSpan;
     }
   }
 

--- a/word_renderer_js/src/renderers/structured/table-layout.ts
+++ b/word_renderer_js/src/renderers/structured/table-layout.ts
@@ -179,7 +179,12 @@ export function normalizeTableCell(cell: unknown): TableCellValue {
   const obj = asObject(cell);
   const rowSpan = numberValue(obj.row_span) ?? 1;
   const colSpan = numberValue(obj.col_span) ?? 1;
-  if (rowSpan < 1 || colSpan < 1) {
+  if (
+    !Number.isInteger(rowSpan) ||
+    !Number.isInteger(colSpan) ||
+    rowSpan < 1 ||
+    colSpan < 1
+  ) {
     throw new RenderCliError(
       "TABLE_CELL_SPAN_INVALID",
       "Table cell spans must be integers greater than or equal to 1",
@@ -478,7 +483,21 @@ function collectColumnMetrics(block: Block, columnCount: number): ColumnMetric[]
       rowCursor += 1;
 
       const cell = normalizeTableCell(rawCell);
-      const colSpan = Math.min(cell.colSpan, columnCount - columnIndex);
+      if (columnIndex + cell.colSpan > columnCount) {
+        throw new RenderCliError(
+          "TABLE_ROW_SHAPE_INVALID",
+          `Table row exceeds logical column count (${columnCount})`,
+        );
+      }
+      for (let spanIndex = 0; spanIndex < cell.colSpan; spanIndex += 1) {
+        if (pendingRowSpans[columnIndex + spanIndex] > 0) {
+          throw new RenderCliError(
+            "TABLE_ROW_SHAPE_INVALID",
+            "Table row overlaps active row spans during width inference",
+          );
+        }
+      }
+      const colSpan = cell.colSpan;
       if (cell.rowSpan > 1) {
         for (let spanIndex = 0; spanIndex < colSpan; spanIndex += 1) {
           pendingRowSpans[columnIndex + spanIndex] = cell.rowSpan - 1;

--- a/word_renderer_js/src/renderers/structured/table-layout.ts
+++ b/word_renderer_js/src/renderers/structured/table-layout.ts
@@ -89,6 +89,14 @@ export function buildTableBodyRows(
           `Table row exceeds logical column count (${columnCount})`,
         );
       }
+      for (let spanIndex = 0; spanIndex < cell.colSpan; spanIndex += 1) {
+        if (pendingRowSpans[columnIndex + spanIndex] > 0) {
+          throw new RenderCliError(
+            "TABLE_ROW_SHAPE_INVALID",
+            `Table row ${rowIndex + 1} overlaps active row spans`,
+          );
+        }
+      }
       if (cell.rowSpan > 1) {
         for (let spanIndex = 0; spanIndex < cell.colSpan; spanIndex += 1) {
           pendingRowSpans[columnIndex + spanIndex] = cell.rowSpan - 1;

--- a/word_renderer_js/src/renderers/structured/types.ts
+++ b/word_renderer_js/src/renderers/structured/types.ts
@@ -45,6 +45,7 @@ export type ThemeConfig = {
 export type TableCellValue = {
   text: string;
   rowSpan: number;
+  colSpan: number;
   fill?: string;
   textColor?: string;
   bold?: boolean;


### PR DESCRIPTION
## 概述

这个 PR 增加了两个 Word 导出能力：表格正文横向合并单元格，以及页码格式控制（阿拉伯数字、罗马数字、字母序号）。同时把 `business_report` 主题下摘要框的回归测试断言对齐到当前实际渲染结果，避免测试和实现脱节。

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 在文档模型、契约层和 JS 渲染器之间打通 `col_span`，让正文单元格可以直接描述横向合并，而不是依赖额外结构绕过去。
- 在页眉页脚配置中补上 `page_number_format`，让默认节和分节覆盖都能声明页码格式，不需要额外改分节模型结构。
- 补充 DOCX 级别测试，直接检查 `gridSpan`、分节页码格式和页码起始值，保证导出结果可验证。
- 同步修正 `business_report` 摘要框相关测试预期，和当前绿色摘要条设计保持一致。

## 影响范围

- `add_table` / `add_blocks` 的表格单元格输入结构
- Word 导出里的表格正文布局计算
- 分节页码格式输出
- `business_report` 主题下 `accent_box` 的测试断言

## 测试情况

- [x] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了核心场景

<details>
<summary>手动测试记录（可选）</summary>

</details>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

</details>

</details>

新功能：
- 允许在文档模型、契约（contracts）和 JS 渲染器中，为表格正文单元格指定用于合并单元格的水平列跨度（column span）。
- 在页眉/页脚配置中提供可配置的页码格式，并将其传递到生成的 DOCX 文件中的节页码设置中。

增强：
- 确保表格单元格跨度处理能够防止行跨度与列跨度的无效组合，并根据声明的列数验证行宽。
- 调整 business_report 强调框（accent box）的样式预期（颜色、边框大小、边距），以匹配当前设计。
- 改进表格列宽推断逻辑，在收集列度量时考虑水平合并的单元格。

测试：
- 为导出的 DOCX 文档中的水平表格合并、页码格式以及节页码重启添加契约级和集成级测试。
- 更新现有的 business_report 主题测试，以断言新的强调框颜色、边框和布局。
- 扩展 JSON schema/工具测试，以覆盖表格行中的 `col_span` 以及页眉/页脚配置中的 `page_number_format`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在导出的 Word 文档中新增对水平合并表格单元格和可配置页码格式的支持，并使 business_report 的强调框样式测试与当前设计保持一致。

New Features:
- 允许表格正文单元格在文档模型、合约、工具和 JS 渲染器中指定横向列跨度，以便 DOCX 导出时可以直接表示合并列。
- 在页眉/页脚配置中支持可配置的节页码格式，并将其传播到生成的 DOCX 节设置中。

Enhancements:
- 校验表格单元格的跨行跨列范围，防止无效的行列组合、重叠合并或超过逻辑列数的跨度。
- 调整 business_report 强调框的颜色、边框粗细和边距，使其符合当前的绿色强调设计。
- 优化表格列宽推断逻辑，使水平合并的单元格能够适当地参与列度量计算。

Tests:
- 添加针对水平表格合并、无效跨度配置及其错误代码的集成和合约测试。
- 为导出的 DOCX 文件中页码格式及按节重启页码添加测试。
- 扩展 JSON schema 和文档工具测试，以覆盖表格单元格的 `col_span` 和页眉/页脚中的 `page_number_format` 字段。
- 更新 business_report 主题测试，以断言新的强调框外观和布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for horizontally merged table cells and configurable page number formats in Word-exported documents, and align business_report accent box styling tests with the current design.

New Features:
- Allow table body cells to specify a horizontal column span across the document model, contracts, tools, and JS renderer so DOCX exports can represent merged columns directly.
- Support configurable section page number formats in header/footer configuration and propagate them into the generated DOCX section settings.

Enhancements:
- Validate table cell spans to prevent invalid combinations of row and column spans, overlapping merges, or spans that exceed the logical column count.
- Adjust business_report accent box colors, border weight, and margins to match the current green accent design.
- Refine table column width inference so horizontally merged cells contribute appropriately to column metrics.

Tests:
- Add integration and contract tests covering horizontal table merges, invalid span configurations, and their error codes.
- Add tests for page number formats and per-section page number restarts in exported DOCX files.
- Extend JSON schema and document tool tests to cover table cell col_span and header/footer page_number_format fields.
- Update business_report theme tests to assert the new accent box appearance and layout.

</details>

</details>

</details>

</details>

</details>