### PR TITLE
fix: use short sequential document ids

### DIFF
--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import re
 from threading import RLock
-from uuid import uuid4
 
 from astrbot.api import logger
 from astrbot.core.utils.astrbot_path import get_astrbot_plugin_data_path
@@ -159,6 +158,7 @@ class DocumentSessionStore:
     ) -> None:
         self._lock = RLock()
         self._documents: dict[str, DocumentModel] = {}
+        self._next_document_id = 1
         self.workspace_dir = workspace_dir or _default_workspace_dir()
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
         self._max_documents = max_documents
@@ -202,9 +202,14 @@ class DocumentSessionStore:
         self._evict_expired_locked()
         self._evict_excess_locked()
 
+    def _allocate_document_id_locked(self) -> str:
+        document_id = f"doc-{self._next_document_id}"
+        self._next_document_id += 1
+        return document_id
+
     def create_document(self, request: CreateDocumentRequest) -> DocumentModel:
         with self._lock:
-            document_id = uuid4().hex
+            document_id = self._allocate_document_id_locked()
             document_style = merge_document_style_defaults(
                 request.document_style,
                 get_document_style_defaults(self),

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -194,6 +194,17 @@ async def test_add_blocks_failure_message_keeps_model_on_same_tool(workspace_roo
     assert "不要改调 finalize_document 或 export_document" in failed["message"]
 
 
+@pytest.mark.asyncio
+async def test_create_document_tool_returns_incrementing_short_document_ids():
+    tool = CreateDocumentTool()
+
+    first = json.loads(await tool.call(None, title="第一份"))
+    second = json.loads(await tool.call(None, title="第二份"))
+
+    assert first["document"]["document_id"] == "doc-1"
+    assert second["document"]["document_id"] == "doc-2"
+
+
 def test_document_tool_registry_keeps_document_tool_order():
     assert [spec.name for spec in get_document_tool_specs()] == [
         "create_document",

--- a/tests/test_office_assistant_session_store.py
+++ b/tests/test_office_assistant_session_store.py
@@ -740,6 +740,19 @@ def test_document_session_store_builds_prompt_summary_for_later_states():
     assert exported_summary["next_allowed_actions"] == []
 
 
+def test_document_session_store_assigns_incrementing_short_document_ids():
+    store = DocumentSessionStore()
+    first = store.create_document(
+        CreateDocumentRequest(title="季度复盘", session_id="pytest-session")
+    )
+    second = store.create_document(
+        CreateDocumentRequest(title="经营复盘", session_id="pytest-session")
+    )
+
+    assert first.document_id == "doc-1"
+    assert second.document_id == "doc-2"
+
+
 def test_document_session_store_rejects_add_blocks_after_finalize():
     store = DocumentSessionStore()
     document = store.create_document(CreateDocumentRequest(title="经营复盘"))


### PR DESCRIPTION
Fixes #52 

## 概述

把文档会话的 `document_id` 从 `uuid4().hex` 改成 `doc-1`、`doc-2` 这种短序号，直接降低模型在工具调用里回传 ID 时的出错概率。这个改动不调整工具协议，只把 ID 变得更短、更稳定、更容易原样传回。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 将文档 ID 改为进程内自增短 ID，避免长随机串在 agent 工具链里被模型误写。
- 保持现有 `document_id` 字段和工具调用方式不变，降低接入层和调用方的改动成本。
- 补充回归测试，确认短 ID 分配行为在 store 和 agent tool 两层都成立。

## 影响范围

- `create_document` 返回的 `document_id`
- 后续 `add_blocks` / `finalize_document` / `export_document` 使用该 ID 的调用链
- 请求钩子里对 `doc-*` 形式文档 ID 的识别场景

## 测试情况

- [x] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了核心场景

- 已执行：
  - `pytest tests/test_office_assistant_session_store.py -k "incrementing_short_document_ids or prompt_summary_for_later_states or rejects_add_blocks_after_finalize"`
  - `pytest tests/test_office_assistant_agent_tools.py -k "incrementing_short_document_ids or workflow_after_create_and_finalize or add_blocks_failure_message or mcp_registers_only_core_document_tools"`
  - `pytest tests/test_office_assistant_before_llm_chat.py -k "keeps_document_id_follow_up_prompt_lightweight"`
  - `pytest tests/test_office_assistant_services.py -k "injects_document_follow_up_notice_for_draft or injects_document_follow_up_notice_for_space_separated_document_id or injects_document_follow_up_notice_for_english_is_document_id"`

## 备注

- 这次只改了文档会话 ID 的生成方式，没有改工具入参结构。
- 文档会话本身是内存态，进程重启后清空，因此自增短 ID 不会带来持久化冲突问题。

## Summary by Sourcery

将文档会话 ID 切换为简短的递增值，以减少通过智能体工具引用时出错的概率。

Bug Fixes:
- 将文档会话 ID 从较长的随机 UUID 改为简短的顺序标识符，使其在工具调用中更易于被模型处理。

Tests:
- 添加回归测试，以确保会话存储和 `create_document` 工具返回递增的短文档 ID。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch document session IDs to short, incremental values to reduce errors when referenced through agent tools.

Bug Fixes:
- Generate document session IDs as short sequential identifiers instead of long random UUIDs to make them easier for models to handle in tool calls.

Tests:
- Add regression tests to ensure the session store and create_document tool return incrementing short document IDs.

</details>