### PR TITLE
feat: add structured workbook primitives

### DIFF
--- a/agent_tools/__init__.py
+++ b/agent_tools/__init__.py
@@ -1,3 +1,3 @@
-from .factory import build_document_toolset
+from .factory import build_document_toolset, build_workbook_toolset
 
-__all__ = ["build_document_toolset"]
+__all__ = ["build_document_toolset", "build_workbook_toolset"]

--- a/agent_tools/factory.py
+++ b/agent_tools/factory.py
@@ -7,7 +7,10 @@ from astrbot.core.astr_agent_context import AstrAgentContext
 
 from ..domain.document.hooks import AfterExportHook, BeforeExportHook
 from ..domain.document.render_backends import DocumentRenderBackendConfig
-from ..tools.astrbot_adapter import build_document_toolset_from_registry
+from ..tools.astrbot_adapter import (
+    build_document_toolset_from_registry,
+    build_workbook_toolset_from_registry,
+)
 
 
 def build_document_toolset(
@@ -30,5 +33,16 @@ def build_document_toolset(
         default_document_style=default_document_style,
     )
 
+def build_workbook_toolset(
+    workspace_dir: Path | None = None,
+    after_export: (
+        Callable[[ContextWrapper[AstrAgentContext], str], Awaitable[str | None]] | None
+    ) = None,
+) -> ToolSet:
+    return build_workbook_toolset_from_registry(
+        workspace_dir=workspace_dir,
+        after_export=after_export,
+    )
 
-__all__ = ["build_document_toolset"]
+
+__all__ = ["build_document_toolset", "build_workbook_toolset"]

--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -75,8 +75,13 @@ class CreateWorkbookTool(WorkbookToolBase):
                 filename=str(kwargs.get("filename") or "workbook.xlsx"),
             )
             workbook = self.store.create_workbook(request)
-        except Exception as exc:
-            return _dump_result(ToolResult(success=False, message=str(exc)))
+        except (ValidationError, ValueError, KeyError, OSError) as exc:
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=f"create_workbook failed: {exc}",
+                )
+            )
         return _dump_result(
             ToolResult(
                 success=True,
@@ -144,7 +149,7 @@ class WriteRowsTool(WorkbookToolBase):
                     ),
                 )
             )
-        except Exception as exc:
+        except (ValueError, KeyError, OSError) as exc:
             return _dump_result(
                 ToolResult(
                     success=False,
@@ -199,8 +204,13 @@ class ExportWorkbookTool(WorkbookToolBase):
                 self.store.export_workbook,
                 request,
             )
-        except Exception as exc:
-            return _dump_result(ToolResult(success=False, message=str(exc)))
+        except (ValidationError, ValueError, KeyError, OSError) as exc:
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=f"export_workbook failed: {exc}",
+                )
+            )
 
         callback_message = ""
         delivery_handled = False

--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -19,7 +20,6 @@ from ..domain.workbook.contracts import (
     WriteRowsRequest,
     build_workbook_summary,
 )
-from ..domain.workbook.exporter import export_workbook_to_xlsx
 from ..domain.workbook.session_store import WorkbookSessionStore
 
 
@@ -186,9 +186,10 @@ class ExportWorkbookTool(WorkbookToolBase):
                 workbook_id=str(kwargs.get("workbook_id") or ""),
                 output_name=str(kwargs.get("output_name") or ""),
             )
-            workbook, output_path = self.store.prepare_export_path(request)
-            export_workbook_to_xlsx(workbook, output_path)
-            workbook = self.store.complete_export(workbook.workbook_id)
+            workbook, output_path = await asyncio.to_thread(
+                self.store.export_workbook,
+                request,
+            )
         except Exception as exc:
             return _dump_result(ToolResult(success=False, message=str(exc)))
 

--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import ConfigDict, Field
+from pydantic.dataclasses import dataclass
+
+from astrbot import logger
+from astrbot.core.agent.run_context import ContextWrapper
+from astrbot.core.agent.tool import FunctionTool, ToolExecResult
+from astrbot.core.astr_agent_context import AstrAgentContext
+
+from ..domain.workbook.contracts import (
+    CreateWorkbookRequest,
+    ExportWorkbookRequest,
+    ExportWorkbookResult,
+    ToolResult,
+    WriteRowsRequest,
+    build_workbook_summary,
+)
+from ..domain.workbook.exporter import export_workbook_to_xlsx
+from ..domain.workbook.session_store import WorkbookSessionStore
+
+
+def _build_default_store() -> WorkbookSessionStore:
+    from ..tools.registry import build_workbook_store
+
+    return build_workbook_store()
+
+
+def _dump_result(result: ToolResult) -> str:
+    return result.model_dump_json(exclude_none=True)
+
+
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class WorkbookToolBase(FunctionTool[AstrAgentContext]):
+    store: WorkbookSessionStore = Field(default_factory=_build_default_store)
+
+
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class CreateWorkbookTool(WorkbookToolBase):
+    name: str = "create_workbook"
+    description: str = (
+        "Create a draft workbook session and return workbook_id for structured Excel generation."
+    )
+    parameters: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Optional conversation session id.",
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional workbook title for summary context.",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Preferred output filename. Defaults to workbook.xlsx.",
+                },
+            },
+        }
+    )
+
+    async def call(
+        self, context: ContextWrapper[AstrAgentContext], **kwargs: Any
+    ) -> ToolExecResult:
+        try:
+            request = CreateWorkbookRequest(
+                session_id=str(kwargs.get("session_id") or ""),
+                title=str(kwargs.get("title") or ""),
+                filename=str(kwargs.get("filename") or "workbook.xlsx"),
+            )
+            workbook = self.store.create_workbook(request)
+        except Exception as exc:
+            return _dump_result(ToolResult(success=False, message=str(exc)))
+        return _dump_result(
+            ToolResult(
+                success=True,
+                message=(
+                    "Workbook session created. Continue with write_rows for each batch, "
+                    "then call export_workbook after all sheets are complete."
+                ),
+                workbook=build_workbook_summary(workbook),
+            )
+        )
+
+
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class WriteRowsTool(WorkbookToolBase):
+    name: str = "write_rows"
+    description: str = (
+        "Write row data into one worksheet. Sheet is auto-created when missing."
+    )
+    parameters: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "workbook_id": {
+                    "type": "string",
+                    "description": "Target workbook_id returned by create_workbook.",
+                },
+                "sheet": {
+                    "type": "string",
+                    "description": "Target worksheet name.",
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "array"},
+                    "description": "2D row array. Cells can be string/number/bool/null.",
+                },
+                "start_row": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "1-based start row. Defaults to 1.",
+                },
+            },
+            "required": ["workbook_id", "sheet", "rows"],
+        }
+    )
+
+    async def call(
+        self, context: ContextWrapper[AstrAgentContext], **kwargs: Any
+    ) -> ToolExecResult:
+        try:
+            request = WriteRowsRequest(
+                workbook_id=str(kwargs.get("workbook_id") or ""),
+                sheet=str(kwargs.get("sheet") or ""),
+                rows=list(kwargs.get("rows") or []),
+                start_row=int(kwargs.get("start_row") or 1),
+            )
+            workbook = self.store.write_rows(request)
+        except Exception as exc:
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=(
+                        "write_rows failed. Retry write_rows with the same workbook_id "
+                        f"and only fix invalid fields. Original error: {exc}"
+                    ),
+                )
+            )
+        return _dump_result(
+            ToolResult(
+                success=True,
+                message=(
+                    "Rows written. Continue calling write_rows for additional sheets "
+                    "or batches, then call export_workbook."
+                ),
+                workbook=build_workbook_summary(workbook),
+            )
+        )
+
+
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
+class ExportWorkbookTool(WorkbookToolBase):
+    name: str = "export_workbook"
+    description: str = "Export workbook draft to .xlsx and return file path."
+    parameters: dict[str, Any] = Field(
+        default_factory=lambda: {
+            "type": "object",
+            "properties": {
+                "workbook_id": {
+                    "type": "string",
+                    "description": "Target workbook_id returned by create_workbook.",
+                },
+                "output_name": {
+                    "type": "string",
+                    "description": "Optional output filename.",
+                },
+            },
+            "required": ["workbook_id"],
+        }
+    )
+    after_export: (
+        Callable[[ContextWrapper[AstrAgentContext], str], Awaitable[str | None]] | None
+    ) = None
+
+    async def call(
+        self, context: ContextWrapper[AstrAgentContext], **kwargs: Any
+    ) -> ToolExecResult:
+        try:
+            request = ExportWorkbookRequest(
+                workbook_id=str(kwargs.get("workbook_id") or ""),
+                output_name=str(kwargs.get("output_name") or ""),
+            )
+            workbook, output_path = self.store.prepare_export_path(request)
+            export_workbook_to_xlsx(workbook, output_path)
+            workbook = self.store.complete_export(workbook.workbook_id)
+        except Exception as exc:
+            return _dump_result(ToolResult(success=False, message=str(exc)))
+
+        callback_message = ""
+        delivery_handled = False
+        if self.after_export is not None and context is not None:
+            try:
+                logger.debug(
+                    "[office-assistant] invoking workbook after_export callback for workbook=%s output=%s",
+                    workbook.workbook_id,
+                    output_path,
+                )
+                callback_message = (
+                    await self.after_export(context, str(output_path)) or ""
+                )
+                delivery_handled = True
+                logger.debug(
+                    "[office-assistant] workbook after_export callback completed for workbook=%s output=%s delivered=%s",
+                    workbook.workbook_id,
+                    output_path,
+                    delivery_handled,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "[office-assistant] workbook after_export callback failed for %s: %s",
+                    output_path,
+                    exc,
+                )
+                callback_message = (
+                    f"Workbook exported, but post-export delivery failed: {exc}"
+                )
+        if delivery_handled:
+            return None
+
+        return _dump_result(
+            ExportWorkbookResult(
+                success=True,
+                message=callback_message or "Workbook exported.",
+                workbook=build_workbook_summary(workbook),
+                file_path=str(output_path),
+            )
+        )
+
+
+__all__ = ["CreateWorkbookTool", "ExportWorkbookTool", "WriteRowsTool"]

--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from pydantic import ValidationError
 from pydantic import ConfigDict, Field
 from pydantic.dataclasses import dataclass
 
@@ -132,7 +133,7 @@ class WriteRowsTool(WorkbookToolBase):
                 start_row=int(kwargs.get("start_row") or 1),
             )
             workbook = self.store.write_rows(request)
-        except Exception as exc:
+        except ValidationError as exc:
             return _dump_result(
                 ToolResult(
                     success=False,
@@ -140,6 +141,13 @@ class WriteRowsTool(WorkbookToolBase):
                         "write_rows failed. Retry write_rows with the same workbook_id "
                         f"and only fix invalid fields. Original error: {exc}"
                     ),
+                )
+            )
+        except Exception as exc:
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=f"write_rows failed: {exc}",
                 )
             )
         return _dump_result(

--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -126,11 +126,12 @@ class WriteRowsTool(WorkbookToolBase):
         self, context: ContextWrapper[AstrAgentContext], **kwargs: Any
     ) -> ToolExecResult:
         try:
+            raw_start_row = kwargs.get("start_row")
             request = WriteRowsRequest(
                 workbook_id=str(kwargs.get("workbook_id") or ""),
                 sheet=str(kwargs.get("sheet") or ""),
                 rows=list(kwargs.get("rows") or []),
-                start_row=int(kwargs.get("start_row") or 1),
+                start_row=1 if raw_start_row is None else raw_start_row,
             )
             workbook = self.store.write_rows(request)
         except ValidationError as exc:

--- a/app/runtime.py
+++ b/app/runtime.py
@@ -49,6 +49,7 @@ class PluginRuntimeBundle:
     access_policy_service: AccessPolicyService
     upload_session_service: UploadSessionService
     document_toolset: Any
+    workbook_toolset: Any
     llm_request_policy: LLMRequestPolicy
     prompt_context_service: PromptContextService
     delivery_service: DeliveryService

--- a/constants.py
+++ b/constants.py
@@ -89,6 +89,9 @@ FILE_TOOLS = (
     "add_blocks",
     "finalize_document",
     "export_document",
+    "create_workbook",
+    "write_rows",
+    "export_workbook",
     "convert_to_pdf",
     "convert_from_pdf",
 )

--- a/domain/workbook/__init__.py
+++ b/domain/workbook/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+__all__ = [
+    "CreateWorkbookRequest",
+    "ExportWorkbookRequest",
+    "ExportWorkbookResult",
+    "ToolResult",
+    "WorkbookModel",
+    "WorkbookSessionStore",
+    "WorkbookStatus",
+    "WorkbookSummary",
+    "WriteRowsRequest",
+    "build_workbook_summary",
+    "export_workbook_to_xlsx",
+]
+
+
+def __getattr__(name: str):
+    if name == "WorkbookSessionStore":
+        from .session_store import WorkbookSessionStore
+
+        return WorkbookSessionStore
+    if name in {
+        "WorkbookModel",
+        "WorkbookStatus",
+    }:
+        from . import models as models_module
+
+        return getattr(models_module, name)
+    if name in {
+        "CreateWorkbookRequest",
+        "ExportWorkbookRequest",
+        "ExportWorkbookResult",
+        "ToolResult",
+        "WorkbookSummary",
+        "WriteRowsRequest",
+        "build_workbook_summary",
+    }:
+        from .contracts import __dict__ as contracts_namespace
+
+        return contracts_namespace[name]
+    if name == "export_workbook_to_xlsx":
+        from .exporter import export_workbook_to_xlsx
+
+        return export_workbook_to_xlsx
+    raise AttributeError(name)

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -41,6 +41,19 @@ def _normalize_xlsx_filename(
     return candidate
 
 
+def _normalize_xlsx_output_path(
+    value: str,
+    default: str = DEFAULT_XLSX_FILENAME,
+) -> str:
+    parts = _split_path_parts(value)
+    if not parts:
+        return default
+    normalized_leaf = _normalize_xlsx_filename(parts[-1], default=default)
+    if len(parts) == 1:
+        return normalized_leaf
+    return "/".join([*parts[:-1], normalized_leaf])
+
+
 def _normalize_sheet_name(value: str) -> str:
     candidate = value.strip()
     if not candidate:
@@ -138,7 +151,7 @@ class ExportWorkbookRequest(BaseModel):
             return ""
         if _looks_like_absolute_path(candidate):
             raise ValueError("output_name must not be an absolute path")
-        return _normalize_xlsx_filename(candidate)
+        return _normalize_xlsx_output_path(candidate)
 
 
 class WorkbookSummary(BaseModel):

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -57,6 +57,7 @@ class CreateWorkbookRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     session_id: str = ""
+    title: str = ""
     filename: str = DEFAULT_XLSX_FILENAME
 
     @field_validator("filename")

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .models import WorkbookCellValue, WorkbookModel
 
 DEFAULT_XLSX_FILENAME = "workbook.xlsx"
+MAX_WORKBOOK_ROW_INDEX = 100_000
 WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:([\\/]|$)")
 SHEET_NAME_FORBIDDEN_CHARS = set("[]:*?/\\")
 
@@ -72,7 +73,7 @@ class WriteRowsRequest(BaseModel):
     workbook_id: str
     sheet: str
     rows: list[list[WorkbookCellValue]] = Field(min_length=1)
-    start_row: int = Field(default=1, ge=1)
+    start_row: int = Field(default=1, ge=1, le=MAX_WORKBOOK_ROW_INDEX)
 
     @field_validator("workbook_id")
     @classmethod
@@ -104,6 +105,15 @@ class WriteRowsRequest(BaseModel):
         if not normalized_rows:
             raise ValueError("rows must contain at least one row")
         return normalized_rows
+
+    @model_validator(mode="after")
+    def validate_row_window(self) -> WriteRowsRequest:
+        final_row = self.start_row + len(self.rows) - 1
+        if final_row > MAX_WORKBOOK_ROW_INDEX:
+            raise ValueError(
+                f"final written row must not exceed {MAX_WORKBOOK_ROW_INDEX}"
+            )
+        return self
 
 
 class ExportWorkbookRequest(BaseModel):

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from .models import WorkbookCellValue, WorkbookModel
+
+DEFAULT_XLSX_FILENAME = "workbook.xlsx"
+WINDOWS_DRIVE_PATTERN = re.compile(r"^[A-Za-z]:([\\/]|$)")
+SHEET_NAME_FORBIDDEN_CHARS = set("[]:*?/\\")
+
+
+def _split_path_parts(value: str) -> list[str]:
+    return [
+        part
+        for part in re.split(r"[\\/]+", value.strip())
+        if part and part not in {".", ""}
+    ]
+
+
+def _looks_like_absolute_path(value: str) -> bool:
+    candidate = value.strip()
+    return (
+        candidate.startswith(("/", "\\", "~"))
+        or WINDOWS_DRIVE_PATTERN.match(candidate) is not None
+    )
+
+
+def _normalize_xlsx_filename(
+    value: str,
+    default: str = DEFAULT_XLSX_FILENAME,
+) -> str:
+    parts = _split_path_parts(value)
+    candidate = parts[-1] if parts else default
+    candidate = candidate or default
+    if not candidate.lower().endswith(".xlsx"):
+        candidate = f"{candidate}.xlsx"
+    return candidate
+
+
+def _normalize_sheet_name(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError("sheet name cannot be empty")
+    if len(candidate) > 31:
+        raise ValueError("sheet name cannot exceed 31 characters")
+    if any(char in SHEET_NAME_FORBIDDEN_CHARS for char in candidate):
+        raise ValueError("sheet name contains unsupported characters")
+    if candidate[0] == "'" or candidate[-1] == "'":
+        raise ValueError("sheet name cannot start or end with apostrophe")
+    return candidate
+
+
+class CreateWorkbookRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str = ""
+    filename: str = DEFAULT_XLSX_FILENAME
+
+    @field_validator("filename")
+    @classmethod
+    def validate_filename(cls, value: str) -> str:
+        return _normalize_xlsx_filename(value)
+
+
+class WriteRowsRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workbook_id: str
+    sheet: str
+    rows: list[list[WorkbookCellValue]] = Field(min_length=1)
+    start_row: int = Field(default=1, ge=1)
+
+    @field_validator("workbook_id")
+    @classmethod
+    def validate_workbook_id(cls, value: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            raise ValueError("workbook_id must not be empty")
+        return candidate
+
+    @field_validator("sheet")
+    @classmethod
+    def validate_sheet(cls, value: str) -> str:
+        return _normalize_sheet_name(value)
+
+    @field_validator("rows")
+    @classmethod
+    def validate_rows(
+        cls,
+        value: list[list[WorkbookCellValue]],
+    ) -> list[list[WorkbookCellValue]]:
+        normalized_rows: list[list[WorkbookCellValue]] = []
+        for row in value:
+            if not isinstance(row, list):
+                raise TypeError("rows must be a two-dimensional array")
+            for cell in row:
+                if isinstance(cell, str) and cell.startswith("="):
+                    raise ValueError("formula cell values are not supported in write_rows")
+            normalized_rows.append(list(row))
+        if not normalized_rows:
+            raise ValueError("rows must contain at least one row")
+        return normalized_rows
+
+
+class ExportWorkbookRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workbook_id: str
+    output_name: str = ""
+
+    @field_validator("workbook_id")
+    @classmethod
+    def validate_workbook_id(cls, value: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            raise ValueError("workbook_id must not be empty")
+        return candidate
+
+    @field_validator("output_name")
+    @classmethod
+    def validate_output_name(cls, value: str) -> str:
+        candidate = str(value or "").strip()
+        if not candidate:
+            return ""
+        if _looks_like_absolute_path(candidate):
+            raise ValueError("output_name must not be an absolute path")
+        return _normalize_xlsx_filename(candidate)
+
+
+class WorkbookSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workbook_id: str
+    session_id: str
+    title: str
+    format: str
+    status: str
+    sheet_names: list[str] = Field(default_factory=list)
+    sheet_count: int
+    latest_written_sheets: list[str] = Field(default_factory=list)
+    output_path: str = ""
+    preferred_filename: str
+
+
+class ToolResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    success: bool
+    message: str
+    workbook: WorkbookSummary | None = None
+
+
+class ExportWorkbookResult(ToolResult):
+    model_config = ConfigDict(extra="forbid")
+
+    file_path: str = ""
+
+
+def build_workbook_summary(workbook_model: WorkbookModel) -> WorkbookSummary:
+    return WorkbookSummary(
+        workbook_id=workbook_model.workbook_id,
+        session_id=workbook_model.session_id,
+        title=workbook_model.metadata.title,
+        format=workbook_model.format,
+        status=workbook_model.status.value,
+        sheet_names=[worksheet.name for worksheet in workbook_model.worksheets],
+        sheet_count=len(workbook_model.worksheets),
+        latest_written_sheets=list(workbook_model.latest_written_sheets),
+        output_path=workbook_model.output_path,
+        preferred_filename=workbook_model.metadata.preferred_filename,
+    )
+
+
+__all__ = [
+    "CreateWorkbookRequest",
+    "DEFAULT_XLSX_FILENAME",
+    "ExportWorkbookRequest",
+    "ExportWorkbookResult",
+    "ToolResult",
+    "WorkbookSummary",
+    "WriteRowsRequest",
+    "build_workbook_summary",
+]

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -170,19 +170,23 @@ class ExportWorkbookResult(ToolResult):
     file_path: str = ""
 
 
+def _build_workbook_summary_payload(workbook_model: WorkbookModel) -> dict[str, object]:
+    return {
+        "workbook_id": workbook_model.workbook_id,
+        "session_id": workbook_model.session_id,
+        "title": workbook_model.metadata.title,
+        "format": workbook_model.format,
+        "status": workbook_model.status.value,
+        "sheet_names": [worksheet.name for worksheet in workbook_model.worksheets],
+        "sheet_count": len(workbook_model.worksheets),
+        "latest_written_sheets": list(workbook_model.latest_written_sheets),
+        "output_path": workbook_model.output_path,
+        "preferred_filename": workbook_model.metadata.preferred_filename,
+    }
+
+
 def build_workbook_summary(workbook_model: WorkbookModel) -> WorkbookSummary:
-    return WorkbookSummary(
-        workbook_id=workbook_model.workbook_id,
-        session_id=workbook_model.session_id,
-        title=workbook_model.metadata.title,
-        format=workbook_model.format,
-        status=workbook_model.status.value,
-        sheet_names=[worksheet.name for worksheet in workbook_model.worksheets],
-        sheet_count=len(workbook_model.worksheets),
-        latest_written_sheets=list(workbook_model.latest_written_sheets),
-        output_path=workbook_model.output_path,
-        preferred_filename=workbook_model.metadata.preferred_filename,
-    )
+    return WorkbookSummary(**_build_workbook_summary_payload(workbook_model))
 
 
 __all__ = [

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+
+from .models import WorkbookModel
+
+HEADER_FONT = Font(bold=True)
+HEADER_FILL = PatternFill(fill_type="solid", fgColor="D9D9D9")
+DEFAULT_ALIGNMENT = Alignment(horizontal="left", vertical="center")
+
+
+def export_workbook_to_xlsx(workbook: WorkbookModel, output_path: Path) -> Path:
+    workbook_writer = Workbook()
+    default_sheet = workbook_writer.active
+
+    if workbook.worksheets:
+        workbook_writer.remove(default_sheet)
+        for worksheet_model in workbook.worksheets:
+            worksheet = workbook_writer.create_sheet(title=worksheet_model.name)
+            _write_worksheet_rows(worksheet, worksheet_model.rows)
+    else:
+        default_sheet.title = "Sheet1"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    workbook_writer.save(output_path)
+    return output_path
+
+
+def _write_worksheet_rows(worksheet, rows: list[list[object]]) -> None:
+    for row_index, row in enumerate(rows, start=1):
+        for column_index, value in enumerate(row, start=1):
+            cell = worksheet.cell(row=row_index, column=column_index, value=value)
+            cell.alignment = DEFAULT_ALIGNMENT
+            if row_index == 1:
+                cell.font = HEADER_FONT
+                cell.fill = HEADER_FILL
+
+
+__all__ = ["export_workbook_to_xlsx"]

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -21,6 +21,7 @@ def export_workbook_to_xlsx(workbook: WorkbookModel, output_path: Path) -> Path:
         for worksheet_model in workbook.worksheets:
             worksheet = workbook_writer.create_sheet(title=worksheet_model.name)
             _write_worksheet_rows(worksheet, worksheet_model.rows)
+            _apply_worksheet_options(worksheet, worksheet_model)
     else:
         default_sheet.title = "Sheet1"
 
@@ -37,6 +38,21 @@ def _write_worksheet_rows(worksheet, rows: list[list[object]]) -> None:
             if row_index == 1:
                 cell.font = HEADER_FONT
                 cell.fill = HEADER_FILL
+
+
+def _apply_worksheet_options(worksheet, worksheet_model) -> None:
+    options = getattr(worksheet_model, "options", None)
+    if options is None:
+        return
+
+    if options.freeze_panes:
+        worksheet.freeze_panes = options.freeze_panes
+
+    for column_letter, width in options.column_widths.items():
+        worksheet.column_dimensions[column_letter].width = width
+
+    if options.autofilter and worksheet_model.rows:
+        worksheet.auto_filter.ref = worksheet.dimensions
 
 
 __all__ = ["export_workbook_to_xlsx"]

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+WorkbookCellValue = str | int | float | bool | None
+
+
+class WorkbookStatus(str, Enum):
+    DRAFT = "draft"
+    EXPORTED = "exported"
+
+
+class WorksheetOptions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    freeze_panes: str = ""
+    column_widths: dict[str, float] = Field(default_factory=dict)
+    autofilter: bool = False
+
+
+class WorksheetModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    rows: list[list[WorkbookCellValue]] = Field(default_factory=list)
+    options: WorksheetOptions = Field(default_factory=WorksheetOptions)
+
+
+class WorkbookMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = ""
+    preferred_filename: str = "workbook.xlsx"
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+
+class WorkbookModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workbook_id: str
+    session_id: str = ""
+    format: str = "excel"
+    status: WorkbookStatus = WorkbookStatus.DRAFT
+    metadata: WorkbookMetadata = Field(default_factory=WorkbookMetadata)
+    worksheets: list[WorksheetModel] = Field(default_factory=list)
+    output_path: str = ""
+    latest_written_sheets: list[str] = Field(default_factory=list)
+
+    def touch(self) -> None:
+        self.metadata.updated_at = _utc_now()
+
+    def get_sheet(self, sheet_name: str) -> WorksheetModel | None:
+        for worksheet in self.worksheets:
+            if worksheet.name == sheet_name:
+                return worksheet
+        return None
+
+    def get_worksheet(self, sheet_name: str) -> WorksheetModel | None:
+        return self.get_sheet(sheet_name)
+
+    def get_or_create_sheet(self, sheet_name: str) -> WorksheetModel:
+        worksheet = self.get_sheet(sheet_name)
+        if worksheet is not None:
+            return worksheet
+        worksheet = WorksheetModel(name=sheet_name)
+        self.worksheets.append(worksheet)
+        self.touch()
+        return worksheet
+
+    def remember_written_sheet(self, sheet_name: str) -> None:
+        self.latest_written_sheets = [
+            existing for existing in self.latest_written_sheets if existing != sheet_name
+        ]
+        self.latest_written_sheets.append(sheet_name)
+        self.latest_written_sheets = self.latest_written_sheets[-3:]
+        self.touch()

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -15,6 +15,7 @@ WorkbookCellValue = str | int | float | bool | None
 
 class WorkbookStatus(str, Enum):
     DRAFT = "draft"
+    EXPORTING = "exporting"
     EXPORTED = "exported"
 
 

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -58,9 +58,14 @@ class WorkbookModel(BaseModel):
     def touch(self) -> None:
         self.metadata.updated_at = _utc_now()
 
+    @staticmethod
+    def _normalize_sheet_key(sheet_name: str) -> str:
+        return sheet_name.strip().casefold()
+
     def get_sheet(self, sheet_name: str) -> WorksheetModel | None:
+        target_key = self._normalize_sheet_key(sheet_name)
         for worksheet in self.worksheets:
-            if worksheet.name == sheet_name:
+            if self._normalize_sheet_key(worksheet.name) == target_key:
                 return worksheet
         return None
 
@@ -77,8 +82,11 @@ class WorkbookModel(BaseModel):
         return worksheet
 
     def remember_written_sheet(self, sheet_name: str) -> None:
+        target_key = self._normalize_sheet_key(sheet_name)
         self.latest_written_sheets = [
-            existing for existing in self.latest_written_sheets if existing != sheet_name
+            existing
+            for existing in self.latest_written_sheets
+            if self._normalize_sheet_key(existing) != target_key
         ]
         self.latest_written_sheets.append(sheet_name)
         self.latest_written_sheets = self.latest_written_sheets[-3:]

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import RLock
 
@@ -34,12 +35,57 @@ def _is_within_workspace(path: Path, workspace_dir: Path) -> bool:
 
 
 class WorkbookSessionStore:
-    def __init__(self, workspace_dir: Path | None = None) -> None:
+    def __init__(
+        self,
+        workspace_dir: Path | None = None,
+        *,
+        max_workbooks: int | None = 256,
+        ttl: timedelta | None = None,
+    ) -> None:
         self._lock = RLock()
         self._workbooks: dict[str, WorkbookModel] = {}
         self._next_workbook_id = 1
         self.workspace_dir = workspace_dir or _default_workspace_dir()
         self.workspace_dir.mkdir(parents=True, exist_ok=True)
+        self._max_workbooks = max_workbooks
+        self._ttl = ttl
+
+    def _evict_expired_locked(self) -> None:
+        if self._ttl is None:
+            return
+
+        now = datetime.now(timezone.utc)
+        expired_ids = [
+            workbook_id
+            for workbook_id, workbook in self._workbooks.items()
+            if workbook.metadata.updated_at + self._ttl < now
+        ]
+        for workbook_id in expired_ids:
+            self._workbooks.pop(workbook_id, None)
+
+    def _evict_excess_locked(self) -> None:
+        if self._max_workbooks is None:
+            return
+
+        excess = len(self._workbooks) - self._max_workbooks
+        if excess <= 0:
+            return
+
+        oldest_workbooks = sorted(
+            self._workbooks.items(),
+            key=lambda item: item[1].metadata.updated_at,
+        )
+        for workbook_id, _ in oldest_workbooks[:excess]:
+            self._workbooks.pop(workbook_id, None)
+
+    def _prune_locked(self) -> None:
+        self._evict_expired_locked()
+        self._evict_excess_locked()
+
+    @staticmethod
+    def _compact_workbook_after_export_locked(workbook: WorkbookModel) -> None:
+        for worksheet in workbook.worksheets:
+            worksheet.rows = []
 
     def _allocate_workbook_id_locked(self) -> str:
         workbook_id = f"wb-{self._next_workbook_id}"
@@ -60,10 +106,12 @@ class WorkbookSessionStore:
                 ),
             )
             self._workbooks[workbook_id] = workbook
+            self._prune_locked()
             return workbook
 
     def get_workbook(self, workbook_id: str) -> WorkbookModel | None:
         with self._lock:
+            self._evict_expired_locked()
             return self._workbooks.get(workbook_id)
 
     def require_workbook(self, workbook_id: str) -> WorkbookModel:
@@ -130,6 +178,8 @@ class WorkbookSessionStore:
             export_workbook_to_xlsx(workbook, output_path)
             workbook.status = WorkbookStatus.EXPORTED
             workbook.touch()
+            self._compact_workbook_after_export_locked(workbook)
+            self._prune_locked()
             return workbook, output_path
 
     def complete_export(self, workbook_id: str) -> WorkbookModel:
@@ -137,6 +187,8 @@ class WorkbookSessionStore:
             workbook = self.require_workbook(workbook_id)
             workbook.status = WorkbookStatus.EXPORTED
             workbook.touch()
+            self._compact_workbook_after_export_locked(workbook)
+            self._prune_locked()
             return workbook
 
     def build_prompt_summary(self, workbook_id: str) -> dict[str, object]:

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -50,11 +50,12 @@ class WorkbookSessionStore:
         with self._lock:
             workbook_id = self._allocate_workbook_id_locked()
             preferred_filename = _normalize_xlsx_filename(request.filename)
+            title = request.title.strip() or Path(preferred_filename).stem
             workbook = WorkbookModel(
                 workbook_id=workbook_id,
                 session_id=request.session_id,
                 metadata=WorkbookMetadata(
-                    title=Path(preferred_filename).stem,
+                    title=title,
                     preferred_filename=preferred_filename,
                 ),
             )
@@ -106,6 +107,8 @@ class WorkbookSessionStore:
                     "export_workbook is only allowed while the workbook status is draft"
                 )
             preferred_name = request.output_name or workbook.metadata.preferred_filename
+            if "/" in preferred_name or "\\" in preferred_name:
+                raise ValueError("output_path cannot escape the workbook workspace")
             file_name = _normalize_xlsx_filename(preferred_name)
 
             workspace_dir = self.workspace_dir.resolve()

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -14,6 +14,7 @@ from .contracts import (
     CreateWorkbookRequest,
     ExportWorkbookRequest,
     WriteRowsRequest,
+    _build_workbook_summary_payload,
     _normalize_xlsx_filename,
 )
 from .exporter import export_workbook_to_xlsx
@@ -223,20 +224,25 @@ class WorkbookSessionStore:
             return self._build_prompt_summary_locked(workbook)
 
     def _build_prompt_summary_locked(self, workbook: WorkbookModel) -> dict[str, object]:
+        summary_payload = _build_workbook_summary_payload(workbook)
         next_allowed_actions: list[str]
         if workbook.status == WorkbookStatus.DRAFT:
             next_allowed_actions = ["write_rows", "export_workbook"]
         else:
             next_allowed_actions = []
-        return {
-            "workbook_id": workbook.workbook_id,
-            "title": workbook.metadata.title,
-            "status": workbook.status.value,
-            "sheet_names": [worksheet.name for worksheet in workbook.worksheets],
-            "sheet_count": len(workbook.worksheets),
-            "latest_written_sheets": list(workbook.latest_written_sheets),
-            "next_allowed_actions": next_allowed_actions,
+        prompt_summary = {
+            key: summary_payload[key]
+            for key in (
+                "workbook_id",
+                "title",
+                "status",
+                "sheet_names",
+                "sheet_count",
+                "latest_written_sheets",
+            )
         }
+        prompt_summary["next_allowed_actions"] = next_allowed_actions
+        return prompt_summary
 
 
 __all__ = [

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -16,6 +16,7 @@ from .contracts import (
     WriteRowsRequest,
     _build_workbook_summary_payload,
     _normalize_xlsx_filename,
+    _normalize_xlsx_output_path,
 )
 from .exporter import export_workbook_to_xlsx
 from .models import WorkbookMetadata, WorkbookModel, WorkbookStatus, WorksheetModel
@@ -173,9 +174,7 @@ class WorkbookSessionStore:
                 "export_workbook is only allowed while the workbook status is draft"
             )
         preferred_name = request.output_name or workbook.metadata.preferred_filename
-        if "/" in preferred_name or "\\" in preferred_name:
-            raise ValueError("output_path cannot escape the workbook workspace")
-        file_name = _normalize_xlsx_filename(preferred_name)
+        file_name = _normalize_xlsx_output_path(preferred_name)
 
         workspace_dir = self.workspace_dir.resolve()
         output_dir = workspace_dir
@@ -192,6 +191,7 @@ class WorkbookSessionStore:
         workbook.status = WorkbookStatus.DRAFT
         workbook.output_path = ""
         workbook.touch()
+        self._prune_locked(protected_workbook_ids={workbook_id})
 
     def prepare_export_path(
         self,

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -125,10 +125,12 @@ class WorkbookSessionStore:
         self,
         request: ExportWorkbookRequest,
     ) -> tuple[WorkbookModel, Path]:
-        workbook, output_path = self.prepare_export_path(request)
-        export_workbook_to_xlsx(workbook, output_path)
-        exported_workbook = self.complete_export(workbook.workbook_id)
-        return exported_workbook, output_path
+        with self._lock:
+            workbook, output_path = self.prepare_export_path(request)
+            export_workbook_to_xlsx(workbook, output_path)
+            workbook.status = WorkbookStatus.EXPORTED
+            workbook.touch()
+            return workbook, output_path
 
     def complete_export(self, workbook_id: str) -> WorkbookModel:
         with self._lock:

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+from threading import RLock
+
+try:
+    from astrbot.core.utils.astrbot_path import get_astrbot_plugin_data_path
+except ModuleNotFoundError:  # pragma: no cover - test fallback
+    def get_astrbot_plugin_data_path() -> str:
+        return str(Path.cwd() / ".tmp_services")
+
+from .contracts import (
+    CreateWorkbookRequest,
+    ExportWorkbookRequest,
+    WriteRowsRequest,
+    _normalize_xlsx_filename,
+)
+from .exporter import export_workbook_to_xlsx
+from .models import WorkbookMetadata, WorkbookModel, WorkbookStatus, WorksheetModel
+
+PLUGIN_NAME = "astrbot_plugin_office_assistant"
+
+
+def _default_workspace_dir() -> Path:
+    return Path(get_astrbot_plugin_data_path()) / PLUGIN_NAME / "workbooks"
+
+
+def _is_within_workspace(path: Path, workspace_dir: Path) -> bool:
+    try:
+        path.relative_to(workspace_dir)
+        return True
+    except ValueError:
+        return False
+
+
+class WorkbookSessionStore:
+    def __init__(self, workspace_dir: Path | None = None) -> None:
+        self._lock = RLock()
+        self._workbooks: dict[str, WorkbookModel] = {}
+        self._next_workbook_id = 1
+        self.workspace_dir = workspace_dir or _default_workspace_dir()
+        self.workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    def _allocate_workbook_id_locked(self) -> str:
+        workbook_id = f"wb-{self._next_workbook_id}"
+        self._next_workbook_id += 1
+        return workbook_id
+
+    def create_workbook(self, request: CreateWorkbookRequest) -> WorkbookModel:
+        with self._lock:
+            workbook_id = self._allocate_workbook_id_locked()
+            preferred_filename = _normalize_xlsx_filename(request.filename)
+            workbook = WorkbookModel(
+                workbook_id=workbook_id,
+                session_id=request.session_id,
+                metadata=WorkbookMetadata(
+                    title=Path(preferred_filename).stem,
+                    preferred_filename=preferred_filename,
+                ),
+            )
+            self._workbooks[workbook_id] = workbook
+            return workbook
+
+    def get_workbook(self, workbook_id: str) -> WorkbookModel | None:
+        with self._lock:
+            return self._workbooks.get(workbook_id)
+
+    def require_workbook(self, workbook_id: str) -> WorkbookModel:
+        workbook = self.get_workbook(workbook_id)
+        if workbook is None:
+            raise KeyError(f"Workbook not found: {workbook_id}")
+        return workbook
+
+    def write_rows(self, request: WriteRowsRequest) -> WorkbookModel:
+        with self._lock:
+            workbook = self.require_workbook(request.workbook_id)
+            if workbook.status != WorkbookStatus.DRAFT:
+                raise ValueError(
+                    "write_rows is only allowed while the workbook status is draft"
+                )
+
+            worksheet = workbook.get_sheet(request.sheet)
+            if worksheet is None:
+                worksheet = WorksheetModel(name=request.sheet)
+                workbook.worksheets.append(worksheet)
+
+            start_index = request.start_row - 1
+            required_size = start_index + len(request.rows)
+            while len(worksheet.rows) < required_size:
+                worksheet.rows.append([])
+
+            for offset, row in enumerate(request.rows):
+                worksheet.rows[start_index + offset] = list(row)
+
+            workbook.remember_written_sheet(worksheet.name)
+            return workbook
+
+    def prepare_export_path(
+        self,
+        request: ExportWorkbookRequest,
+    ) -> tuple[WorkbookModel, Path]:
+        with self._lock:
+            workbook = self.require_workbook(request.workbook_id)
+            if workbook.status != WorkbookStatus.DRAFT:
+                raise ValueError(
+                    "export_workbook is only allowed while the workbook status is draft"
+                )
+            preferred_name = request.output_name or workbook.metadata.preferred_filename
+            file_name = _normalize_xlsx_filename(preferred_name)
+
+            workspace_dir = self.workspace_dir.resolve()
+            output_dir = workspace_dir
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_path = (output_dir / file_name).resolve()
+            if not _is_within_workspace(output_path, workspace_dir):
+                raise ValueError("output_path cannot escape the workbook workspace")
+            workbook.output_path = str(output_path)
+            workbook.touch()
+            return workbook, output_path
+
+    def export_workbook(
+        self,
+        request: ExportWorkbookRequest,
+    ) -> tuple[WorkbookModel, Path]:
+        workbook, output_path = self.prepare_export_path(request)
+        export_workbook_to_xlsx(workbook, output_path)
+        exported_workbook = self.complete_export(workbook.workbook_id)
+        return exported_workbook, output_path
+
+    def complete_export(self, workbook_id: str) -> WorkbookModel:
+        with self._lock:
+            workbook = self.require_workbook(workbook_id)
+            workbook.status = WorkbookStatus.EXPORTED
+            workbook.touch()
+            return workbook
+
+    def build_prompt_summary(self, workbook_id: str) -> dict[str, object]:
+        with self._lock:
+            workbook = self.require_workbook(workbook_id)
+            return self._build_prompt_summary_locked(workbook)
+
+    def _build_prompt_summary_locked(self, workbook: WorkbookModel) -> dict[str, object]:
+        next_allowed_actions: list[str]
+        if workbook.status == WorkbookStatus.DRAFT:
+            next_allowed_actions = ["write_rows", "export_workbook"]
+        else:
+            next_allowed_actions = []
+        return {
+            "workbook_id": workbook.workbook_id,
+            "title": workbook.metadata.title,
+            "status": workbook.status.value,
+            "sheet_names": [worksheet.name for worksheet in workbook.worksheets],
+            "sheet_count": len(workbook.worksheets),
+            "latest_written_sheets": list(workbook.latest_written_sheets),
+            "next_allowed_actions": next_allowed_actions,
+        }
+
+
+__all__ = [
+    "WorkbookSessionStore",
+    "_default_workspace_dir",
+    "_is_within_workspace",
+]

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -65,7 +65,11 @@ class WorkbookSessionStore:
         for workbook_id in expired_ids:
             self._workbooks.pop(workbook_id, None)
 
-    def _evict_excess_locked(self) -> None:
+    def _evict_excess_locked(
+        self,
+        *,
+        protected_workbook_ids: set[str] | None = None,
+    ) -> None:
         if self._max_workbooks is None:
             return
 
@@ -73,20 +77,29 @@ class WorkbookSessionStore:
         if excess <= 0:
             return
 
+        protected_ids = protected_workbook_ids or set()
         oldest_workbooks = sorted(
             (
                 item
                 for item in self._workbooks.items()
                 if item[1].status != WorkbookStatus.EXPORTING
+                if item[0] not in protected_ids
             ),
-            key=lambda item: item[1].metadata.updated_at,
+            key=lambda item: (
+                0 if item[1].status == WorkbookStatus.EXPORTED else 1,
+                item[1].metadata.updated_at,
+            ),
         )
         for workbook_id, _ in oldest_workbooks[:excess]:
             self._workbooks.pop(workbook_id, None)
 
-    def _prune_locked(self) -> None:
+    def _prune_locked(
+        self,
+        *,
+        protected_workbook_ids: set[str] | None = None,
+    ) -> None:
         self._evict_expired_locked()
-        self._evict_excess_locked()
+        self._evict_excess_locked(protected_workbook_ids=protected_workbook_ids)
 
     @staticmethod
     def _compact_workbook_after_export_locked(workbook: WorkbookModel) -> None:
@@ -112,7 +125,7 @@ class WorkbookSessionStore:
                 ),
             )
             self._workbooks[workbook_id] = workbook
-            self._prune_locked()
+            self._prune_locked(protected_workbook_ids={workbook_id})
             return workbook
 
     def get_workbook(self, workbook_id: str) -> WorkbookModel | None:

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -58,6 +58,7 @@ class WorkbookSessionStore:
         expired_ids = [
             workbook_id
             for workbook_id, workbook in self._workbooks.items()
+            if workbook.status != WorkbookStatus.EXPORTING
             if workbook.metadata.updated_at + self._ttl < now
         ]
         for workbook_id in expired_ids:
@@ -72,7 +73,11 @@ class WorkbookSessionStore:
             return
 
         oldest_workbooks = sorted(
-            self._workbooks.items(),
+            (
+                item
+                for item in self._workbooks.items()
+                if item[1].status != WorkbookStatus.EXPORTING
+            ),
             key=lambda item: item[1].metadata.updated_at,
         )
         for workbook_id, _ in oldest_workbooks[:excess]:
@@ -144,38 +149,59 @@ class WorkbookSessionStore:
             workbook.remember_written_sheet(worksheet.name)
             return workbook
 
+    def _prepare_export_path_locked(
+        self,
+        request: ExportWorkbookRequest,
+    ) -> tuple[WorkbookModel, Path]:
+        workbook = self.require_workbook(request.workbook_id)
+        if workbook.status != WorkbookStatus.DRAFT:
+            raise ValueError(
+                "export_workbook is only allowed while the workbook status is draft"
+            )
+        preferred_name = request.output_name or workbook.metadata.preferred_filename
+        if "/" in preferred_name or "\\" in preferred_name:
+            raise ValueError("output_path cannot escape the workbook workspace")
+        file_name = _normalize_xlsx_filename(preferred_name)
+
+        workspace_dir = self.workspace_dir.resolve()
+        output_dir = workspace_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = (output_dir / file_name).resolve()
+        if not _is_within_workspace(output_path, workspace_dir):
+            raise ValueError("output_path cannot escape the workbook workspace")
+        workbook.output_path = str(output_path)
+        workbook.touch()
+        return workbook, output_path
+
+    def _reset_failed_export_locked(self, workbook_id: str) -> None:
+        workbook = self.require_workbook(workbook_id)
+        workbook.status = WorkbookStatus.DRAFT
+        workbook.output_path = ""
+        workbook.touch()
+
     def prepare_export_path(
         self,
         request: ExportWorkbookRequest,
     ) -> tuple[WorkbookModel, Path]:
         with self._lock:
-            workbook = self.require_workbook(request.workbook_id)
-            if workbook.status != WorkbookStatus.DRAFT:
-                raise ValueError(
-                    "export_workbook is only allowed while the workbook status is draft"
-                )
-            preferred_name = request.output_name or workbook.metadata.preferred_filename
-            if "/" in preferred_name or "\\" in preferred_name:
-                raise ValueError("output_path cannot escape the workbook workspace")
-            file_name = _normalize_xlsx_filename(preferred_name)
-
-            workspace_dir = self.workspace_dir.resolve()
-            output_dir = workspace_dir
-            output_dir.mkdir(parents=True, exist_ok=True)
-            output_path = (output_dir / file_name).resolve()
-            if not _is_within_workspace(output_path, workspace_dir):
-                raise ValueError("output_path cannot escape the workbook workspace")
-            workbook.output_path = str(output_path)
-            workbook.touch()
-            return workbook, output_path
+            return self._prepare_export_path_locked(request)
 
     def export_workbook(
         self,
         request: ExportWorkbookRequest,
     ) -> tuple[WorkbookModel, Path]:
         with self._lock:
-            workbook, output_path = self.prepare_export_path(request)
+            workbook, output_path = self._prepare_export_path_locked(request)
+            workbook.status = WorkbookStatus.EXPORTING
+            workbook.touch()
+        try:
             export_workbook_to_xlsx(workbook, output_path)
+        except Exception:
+            with self._lock:
+                self._reset_failed_export_locked(request.workbook_id)
+            raise
+        with self._lock:
+            workbook = self.require_workbook(request.workbook_id)
             workbook.status = WorkbookStatus.EXPORTED
             workbook.touch()
             self._compact_workbook_after_export_locked(workbook)

--- a/domain/workbook/tool_contracts.py
+++ b/domain/workbook/tool_contracts.py
@@ -1,0 +1,19 @@
+from .contracts import (
+    CreateWorkbookRequest,
+    ExportWorkbookRequest,
+    ExportWorkbookResult,
+    ToolResult,
+    WorkbookSummary,
+    WriteRowsRequest,
+    build_workbook_summary,
+)
+
+__all__ = [
+    "CreateWorkbookRequest",
+    "ExportWorkbookRequest",
+    "ExportWorkbookResult",
+    "ToolResult",
+    "WorkbookSummary",
+    "WriteRowsRequest",
+    "build_workbook_summary",
+]

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -13,7 +13,8 @@ from ..domain.document.session_store import (
     DocumentSessionStore,
     attach_document_style_defaults,
 )
-from .tools import register_document_tools
+from ..domain.workbook.session_store import WorkbookSessionStore
+from .tools import register_document_tools, register_workbook_tools
 
 
 def create_server(
@@ -27,11 +28,13 @@ def create_server(
     server = FastMCP(
         name="astrbot-office-assistant",
         instructions=(
-            "Stateful document builder for complex Word generation. "
-            "Use create_document first, then append content blocks, finalize, and export."
+            "Stateful Office builder for structured Word and Excel generation. "
+            "Use create_document/add_blocks/finalize_document/export_document for Word, "
+            "and use create_workbook/write_rows/export_workbook for Excel."
         ),
     )
     store = DocumentSessionStore(workspace_dir=workspace_dir)
+    workbook_store = WorkbookSessionStore(workspace_dir=workspace_dir)
     attach_render_backend_config(store, render_backend_config)
     attach_document_style_defaults(store, default_document_style)
     register_document_tools(
@@ -40,6 +43,7 @@ def create_server(
         before_export_hooks=before_export_hooks,
         after_export_hooks=after_export_hooks,
     )
+    register_workbook_tools(server, workbook_store)
     return server
 
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import importlib
 from pathlib import Path
 
+from astrbot.api import logger
 from mcp.server.fastmcp import FastMCP
 
 from ..domain.document.hooks import AfterExportHook, BeforeExportHook
@@ -15,10 +17,19 @@ from ..domain.document.session_store import (
 )
 from .tools import register_document_tools, register_workbook_tools
 
-try:
-    from ..domain.workbook.session_store import WorkbookSessionStore
-except Exception:  # pragma: no cover - workbook domain may be provided by another worker.
-    WorkbookSessionStore = None  # type: ignore[assignment]
+
+def _load_workbook_session_store():
+    try:
+        workbook_module = importlib.import_module(
+            "astrbot_plugin_office_assistant.domain.workbook.session_store"
+        )
+    except (ImportError, ModuleNotFoundError) as exc:  # pragma: no cover
+        logger.warning(
+            "[office-assistant] workbook support disabled during MCP server startup: %s",
+            exc,
+        )
+        return None
+    return workbook_module.WorkbookSessionStore
 
 
 def create_server(
@@ -29,7 +40,8 @@ def create_server(
     render_backend_config: DocumentRenderBackendConfig | None = None,
     default_document_style: dict[str, object] | None = None,
 ) -> FastMCP:
-    workbook_supported = WorkbookSessionStore is not None
+    workbook_session_store_cls = _load_workbook_session_store()
+    workbook_supported = workbook_session_store_cls is not None
     instructions = (
         "Stateful Office builder for structured Word generation. "
         "Use create_document/add_blocks/finalize_document/export_document for Word."
@@ -52,7 +64,7 @@ def create_server(
         after_export_hooks=after_export_hooks,
     )
     if workbook_supported:
-        workbook_store = WorkbookSessionStore(workspace_dir=workspace_dir)
+        workbook_store = workbook_session_store_cls(workspace_dir=workspace_dir)
         register_workbook_tools(server, workbook_store)
     return server
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -29,13 +29,18 @@ def create_server(
     render_backend_config: DocumentRenderBackendConfig | None = None,
     default_document_style: dict[str, object] | None = None,
 ) -> FastMCP:
+    workbook_supported = WorkbookSessionStore is not None
+    instructions = (
+        "Stateful Office builder for structured Word generation. "
+        "Use create_document/add_blocks/finalize_document/export_document for Word."
+    )
+    if workbook_supported:
+        instructions += (
+            " Use create_workbook/write_rows/export_workbook for Excel."
+        )
     server = FastMCP(
         name="astrbot-office-assistant",
-        instructions=(
-            "Stateful Office builder for structured Word and Excel generation. "
-            "Use create_document/add_blocks/finalize_document/export_document for Word, "
-            "and use create_workbook/write_rows/export_workbook for Excel."
-        ),
+        instructions=instructions,
     )
     store = DocumentSessionStore(workspace_dir=workspace_dir)
     attach_render_backend_config(store, render_backend_config)
@@ -46,7 +51,7 @@ def create_server(
         before_export_hooks=before_export_hooks,
         after_export_hooks=after_export_hooks,
     )
-    if WorkbookSessionStore is not None:
+    if workbook_supported:
         workbook_store = WorkbookSessionStore(workspace_dir=workspace_dir)
         register_workbook_tools(server, workbook_store)
     return server

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -13,8 +13,12 @@ from ..domain.document.session_store import (
     DocumentSessionStore,
     attach_document_style_defaults,
 )
-from ..domain.workbook.session_store import WorkbookSessionStore
 from .tools import register_document_tools, register_workbook_tools
+
+try:
+    from ..domain.workbook.session_store import WorkbookSessionStore
+except Exception:  # pragma: no cover - workbook domain may be provided by another worker.
+    WorkbookSessionStore = None  # type: ignore[assignment]
 
 
 def create_server(
@@ -43,7 +47,9 @@ def create_server(
         before_export_hooks=before_export_hooks,
         after_export_hooks=after_export_hooks,
     )
-    register_workbook_tools(server, workbook_store)
+    if WorkbookSessionStore is not None:
+        workbook_store = WorkbookSessionStore(workspace_dir=workspace_dir)
+        register_workbook_tools(server, workbook_store)
     return server
 
 

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -38,7 +38,6 @@ def create_server(
         ),
     )
     store = DocumentSessionStore(workspace_dir=workspace_dir)
-    workbook_store = WorkbookSessionStore(workspace_dir=workspace_dir)
     attach_render_backend_config(store, render_backend_config)
     attach_document_style_defaults(store, default_document_style)
     register_document_tools(

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from mcp.server.fastmcp import FastMCP
 
 from ...domain.document.hooks import AfterExportHook, BeforeExportHook
@@ -5,11 +9,8 @@ from ...domain.document.session_store import DocumentSessionStore
 from ...tools.mcp_adapter import register_document_tools_from_registry
 from ...tools.mcp_adapter import register_workbook_tools_from_registry
 
-
-try:
+if TYPE_CHECKING:
     from ...domain.workbook.session_store import WorkbookSessionStore
-except Exception:  # pragma: no cover - workbook domain may be provided by another worker.
-    WorkbookSessionStore = object  # type: ignore[assignment]
 
 
 def register_document_tools(

--- a/mcp_server/tools/__init__.py
+++ b/mcp_server/tools/__init__.py
@@ -3,6 +3,13 @@ from mcp.server.fastmcp import FastMCP
 from ...domain.document.hooks import AfterExportHook, BeforeExportHook
 from ...domain.document.session_store import DocumentSessionStore
 from ...tools.mcp_adapter import register_document_tools_from_registry
+from ...tools.mcp_adapter import register_workbook_tools_from_registry
+
+
+try:
+    from ...domain.workbook.session_store import WorkbookSessionStore
+except Exception:  # pragma: no cover - workbook domain may be provided by another worker.
+    WorkbookSessionStore = object  # type: ignore[assignment]
 
 
 def register_document_tools(
@@ -18,3 +25,10 @@ def register_document_tools(
         before_export_hooks=before_export_hooks,
         after_export_hooks=after_export_hooks,
     )
+
+
+def register_workbook_tools(
+    server: FastMCP,
+    store: WorkbookSessionStore,
+) -> None:
+    register_workbook_tools_from_registry(server, store)

--- a/mcp_server/tools/create_workbook.py
+++ b/mcp_server/tools/create_workbook.py
@@ -1,0 +1,34 @@
+from mcp.server.fastmcp import FastMCP
+
+from ...domain.workbook.session_store import WorkbookSessionStore
+from ...domain.workbook.contracts import (
+    CreateWorkbookRequest,
+    ToolResult,
+    build_workbook_summary,
+)
+
+
+def register_create_workbook_tool(server: FastMCP, store: WorkbookSessionStore) -> None:
+    @server.tool(
+        name="create_workbook",
+        description=(
+            "Create a draft workbook session and return workbook_id for structured Excel generation."
+        ),
+        structured_output=True,
+    )
+    def create_workbook(
+        session_id: str = "",
+        title: str = "",
+        filename: str = "workbook.xlsx",
+    ) -> ToolResult:
+        request = CreateWorkbookRequest(
+            session_id=session_id,
+            title=title,
+            filename=filename,
+        )
+        workbook = store.create_workbook(request)
+        return ToolResult(
+            success=True,
+            message="Workbook session created.",
+            workbook=build_workbook_summary(workbook),
+        )

--- a/mcp_server/tools/export_workbook.py
+++ b/mcp_server/tools/export_workbook.py
@@ -1,6 +1,7 @@
+import asyncio
+
 from mcp.server.fastmcp import FastMCP
 
-from ...domain.workbook.exporter import export_workbook_to_xlsx
 from ...domain.workbook.session_store import WorkbookSessionStore
 from ...domain.workbook.contracts import (
     ExportWorkbookRequest,
@@ -23,9 +24,7 @@ def register_export_workbook_tool(server: FastMCP, store: WorkbookSessionStore) 
             workbook_id=workbook_id,
             output_name=output_name,
         )
-        workbook, output_path = store.prepare_export_path(request)
-        export_workbook_to_xlsx(workbook, output_path)
-        workbook = store.complete_export(workbook.workbook_id)
+        workbook, output_path = await asyncio.to_thread(store.export_workbook, request)
         return ExportWorkbookResult(
             success=True,
             message="Workbook exported.",

--- a/mcp_server/tools/export_workbook.py
+++ b/mcp_server/tools/export_workbook.py
@@ -1,0 +1,34 @@
+from mcp.server.fastmcp import FastMCP
+
+from ...domain.workbook.exporter import export_workbook_to_xlsx
+from ...domain.workbook.session_store import WorkbookSessionStore
+from ...domain.workbook.contracts import (
+    ExportWorkbookRequest,
+    ExportWorkbookResult,
+    build_workbook_summary,
+)
+
+
+def register_export_workbook_tool(server: FastMCP, store: WorkbookSessionStore) -> None:
+    @server.tool(
+        name="export_workbook",
+        description="Export workbook draft to .xlsx and return file path.",
+        structured_output=True,
+    )
+    async def export_workbook(
+        workbook_id: str,
+        output_name: str = "",
+    ) -> ExportWorkbookResult:
+        request = ExportWorkbookRequest(
+            workbook_id=workbook_id,
+            output_name=output_name,
+        )
+        workbook, output_path = store.prepare_export_path(request)
+        export_workbook_to_xlsx(workbook, output_path)
+        workbook = store.complete_export(workbook.workbook_id)
+        return ExportWorkbookResult(
+            success=True,
+            message="Workbook exported.",
+            workbook=build_workbook_summary(workbook),
+            file_path=str(output_path),
+        )

--- a/mcp_server/tools/write_rows.py
+++ b/mcp_server/tools/write_rows.py
@@ -1,0 +1,36 @@
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from ...domain.workbook.session_store import WorkbookSessionStore
+from ...domain.workbook.contracts import (
+    ToolResult,
+    WriteRowsRequest,
+    build_workbook_summary,
+)
+
+
+def register_write_rows_tool(server: FastMCP, store: WorkbookSessionStore) -> None:
+    @server.tool(
+        name="write_rows",
+        description="Write row data into one worksheet. Sheet is auto-created when missing.",
+        structured_output=True,
+    )
+    def write_rows(
+        workbook_id: str,
+        sheet: str,
+        rows: list[list[Any]],
+        start_row: int = 1,
+    ) -> ToolResult:
+        request = WriteRowsRequest(
+            workbook_id=workbook_id,
+            sheet=sheet,
+            rows=rows,
+            start_row=start_row,
+        )
+        workbook = store.write_rows(request)
+        return ToolResult(
+            success=True,
+            message="Rows written.",
+            workbook=build_workbook_summary(workbook),
+        )

--- a/mcp_server/tools/write_rows.py
+++ b/mcp_server/tools/write_rows.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import ValidationError
 
 from ...domain.workbook.session_store import WorkbookSessionStore
 from ...domain.workbook.contracts import (
@@ -22,13 +23,27 @@ def register_write_rows_tool(server: FastMCP, store: WorkbookSessionStore) -> No
         rows: list[list[Any]],
         start_row: int = 1,
     ) -> ToolResult:
-        request = WriteRowsRequest(
-            workbook_id=workbook_id,
-            sheet=sheet,
-            rows=rows,
-            start_row=start_row,
-        )
-        workbook = store.write_rows(request)
+        try:
+            request = WriteRowsRequest(
+                workbook_id=workbook_id,
+                sheet=sheet,
+                rows=rows,
+                start_row=start_row,
+            )
+            workbook = store.write_rows(request)
+        except ValidationError as exc:
+            return ToolResult(
+                success=False,
+                message=(
+                    "write_rows failed. Retry write_rows with the same workbook_id "
+                    f"and only fix invalid fields. Original error: {exc}"
+                ),
+            )
+        except (KeyError, ValueError) as exc:
+            return ToolResult(
+                success=False,
+                message=f"write_rows failed: {exc}",
+            )
         return ToolResult(
             success=True,
             message="Rows written.",

--- a/prompts/static/__init__.py
+++ b/prompts/static/__init__.py
@@ -6,6 +6,13 @@ from .document_tools import (
     build_document_tools_detail_notice,
     build_document_tools_guide_notice,
 )
+from .workbook_tools import (
+    build_workbook_follow_up_missing_notice,
+    build_workbook_follow_up_notice,
+    build_workbook_tools_core_notice,
+    build_workbook_tools_detail_notice,
+    build_workbook_tools_guide_notice,
+)
 
 __all__ = [
     "build_document_follow_up_missing_notice",
@@ -13,5 +20,10 @@ __all__ = [
     "build_document_tools_core_notice",
     "build_document_tools_detail_notice",
     "build_document_tools_guide_notice",
+    "build_workbook_follow_up_missing_notice",
+    "build_workbook_follow_up_notice",
+    "build_workbook_tools_core_notice",
+    "build_workbook_tools_detail_notice",
+    "build_workbook_tools_guide_notice",
     "build_tools_denied_notice",
 ]

--- a/prompts/static/workbook_tools.py
+++ b/prompts/static/workbook_tools.py
@@ -1,0 +1,84 @@
+def build_workbook_tools_guide_notice() -> str:
+    return build_workbook_tools_core_notice() + build_workbook_tools_detail_notice()
+
+
+def build_workbook_tools_core_notice() -> str:
+    return (
+        "\n[System Notice] Excel 原语工具使用指南\n"
+        "\n"
+        "[核心工作流]\n"
+        "生成结构化 Excel MUST 按以下顺序调用工具链：\n"
+        "  `create_workbook` → `write_rows`(可多次) → `export_workbook`\n"
+        "- 同一份工作簿在拿到 `workbook_id` 后，不要再次调用 `create_workbook`\n"
+        "- `write_rows` 可按 Sheet 分批调用；多 Sheet 场景继续重复调用 `write_rows`\n"
+        "- `sheet` 不存在时自动创建，`start_row` 使用 1-based 行号\n"
+        "- 不要把整本工作簿一次性塞进 `create_workbook`\n"
+        "- 只有确认数据写完才调用 `export_workbook`\n"
+        "- `export_workbook` 会直接发送 `.xlsx` 文件给用户\n"
+        "\n"
+        "[边界说明]\n"
+        "- 这条路径只覆盖结构化表格写入，不覆盖公式、图表、条件格式、数据验证\n"
+        "- `create_office_file` 仍是旧的简单一次性入口，不等价于上述结构化工作流\n"
+    )
+
+
+def build_workbook_follow_up_notice(
+    *,
+    workbook_id: str,
+    status: str,
+    sheet_names: list[str],
+    sheet_count: int,
+    latest_written_sheets: list[str],
+    next_allowed_actions: list[str],
+) -> str:
+    normalized_sheet_count = max(sheet_count, 0)
+    normalized_sheet_names = ", ".join(sheet_names) if sheet_names else "无"
+    normalized_latest_sheets = (
+        ", ".join(latest_written_sheets) if latest_written_sheets else "无"
+    )
+    normalized_actions = ", ".join(next_allowed_actions) if next_allowed_actions else "无"
+
+    if status == "draft":
+        return (
+            "\n[System Notice] 当前工作簿阶段\n"
+            f"- 当前 `workbook_id={workbook_id}` 仍是 draft\n"
+            f"- Sheet 数量：{normalized_sheet_count}，当前 Sheet：{normalized_sheet_names}\n"
+            f"- 最近写入 Sheet：{normalized_latest_sheets}\n"
+            f"- 下一步允许动作：{normalized_actions}\n"
+            "- 如果还有数据没写完，继续调用 `write_rows`\n"
+            "- 只有确认内容写完，才调用 `export_workbook`\n"
+        )
+    if status == "exported":
+        return (
+            "\n[System Notice] 当前工作簿阶段\n"
+            f"- 当前 `workbook_id={workbook_id}` 已导出\n"
+            "- 不要继续对这份工作簿调用 `write_rows` 或 `export_workbook`\n"
+        )
+    return (
+        "\n[System Notice] 当前工作簿阶段\n"
+        f"- 当前 `workbook_id={workbook_id}` 状态未知\n"
+        f"- 当前 Sheet：{normalized_sheet_names}\n"
+        f"- 下一步允许动作：{normalized_actions}\n"
+        "- 先核对工作簿状态，不要切换到别的 Excel 工具\n"
+    )
+
+
+def build_workbook_follow_up_missing_notice(*, workbook_id: str) -> str:
+    return (
+        "\n[System Notice] 当前工作簿阶段\n"
+        f"- 没有找到 `workbook_id={workbook_id}` 对应的工作簿会话\n"
+        "- 先核对 `workbook_id`，不要改调其他 Excel 工具\n"
+    )
+
+
+def build_workbook_tools_detail_notice() -> str:
+    return (
+        "\n[System Notice] Excel 原语工具细节指南\n"
+        "\n"
+        "[工具选择]\n"
+        "- 结构化 Excel（多 Sheet、分批写入）→ 使用 `create_workbook` / `write_rows` / `export_workbook`\n"
+        "- 简单一次性 Excel/PPT → 使用 `create_office_file`\n"
+        "- `write_rows` 的 `rows` 传二维数组，避免超大单次 JSON\n"
+        "- 多 Sheet 场景推荐每个 Sheet 分批写入，按需设置 `start_row`\n"
+        "- 需要公式、图表、条件格式、数据验证时，不要继续扩展这条原语路径\n"
+    )

--- a/services/llm_request_policy.py
+++ b/services/llm_request_policy.py
@@ -46,6 +46,7 @@ class LLMRequestPolicy:
         self,
         *,
         document_toolset,
+        workbook_toolset=None,
         require_at_in_group: bool,
         is_group_feature_enabled: Callable[[AstrMessageEvent], bool],
         check_permission: Callable[[AstrMessageEvent], bool],
@@ -56,6 +57,12 @@ class LLMRequestPolicy:
         tool_exposure_hooks: list[ToolExposureHook] | None = None,
     ) -> None:
         self._document_toolset = document_toolset
+        self._workbook_toolset = workbook_toolset
+        self._structured_toolsets = [
+            toolset
+            for toolset in (document_toolset, workbook_toolset)
+            if toolset is not None
+        ]
         self._require_at_in_group = require_at_in_group
         self._is_group_feature_enabled = is_group_feature_enabled
         self._check_permission = check_permission
@@ -286,8 +293,9 @@ class LLMRequestPolicy:
             return
 
         if decision.should_expose and req.func_tool:
-            for tool in self._document_toolset.tools:
-                req.func_tool.add_tool(tool)
+            for toolset in self._structured_toolsets:
+                for tool in getattr(toolset, "tools", []):
+                    req.func_tool.add_tool(tool)
 
         await self._run_before_expose_tools(
             ToolExposureContext(

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -13,14 +13,21 @@ from ..prompts.static import (
     build_document_tools_core_notice,
     build_document_tools_detail_notice,
     build_tools_denied_notice,
+    build_workbook_follow_up_missing_notice,
+    build_workbook_follow_up_notice,
+    build_workbook_tools_core_notice,
+    build_workbook_tools_detail_notice,
 )
 from .upload_types import UploadInfo
 
 SECTION_STATIC_ACCESS = "static_access"
 SECTION_STATIC_DOCUMENT_TOOLS = "static_document_tools"
 SECTION_STATIC_DOCUMENT_TOOLS_DETAIL = "static_document_tools_detail"
+SECTION_STATIC_WORKBOOK_TOOLS = "static_workbook_tools"
+SECTION_STATIC_WORKBOOK_TOOLS_DETAIL = "static_workbook_tools_detail"
 SECTION_SCENE_UPLOADED_CONTEXT = "scene_uploaded_context"
 SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP = "dynamic_document_follow_up"
+SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP = "dynamic_workbook_follow_up"
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,6 +152,20 @@ class PromptContextService:
             target="prompt_suffix",
         )
 
+    def build_workbook_tool_guide_section(self) -> PromptSection:
+        return PromptSection(
+            name=SECTION_STATIC_WORKBOOK_TOOLS,
+            content=build_workbook_tools_core_notice(),
+            target="prompt_suffix",
+        )
+
+    def build_workbook_tool_detail_section(self) -> PromptSection:
+        return PromptSection(
+            name=SECTION_STATIC_WORKBOOK_TOOLS_DETAIL,
+            content=build_workbook_tools_detail_notice(),
+            target="prompt_suffix",
+        )
+
     def build_uploaded_file_context_section(
         self,
         *,
@@ -181,6 +202,40 @@ class PromptContextService:
         return PromptSection(
             name=SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
             content=build_document_follow_up_missing_notice(document_id=document_id),
+            target="prompt_suffix",
+        )
+
+    def build_workbook_follow_up_section(
+        self,
+        *,
+        workbook_id: str,
+        status: str,
+        sheet_names: list[str],
+        sheet_count: int,
+        latest_written_sheets: list[str],
+        next_allowed_actions: list[str],
+    ) -> PromptSection:
+        return PromptSection(
+            name=SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
+            content=build_workbook_follow_up_notice(
+                workbook_id=workbook_id,
+                status=status,
+                sheet_names=sheet_names,
+                sheet_count=sheet_count,
+                latest_written_sheets=latest_written_sheets,
+                next_allowed_actions=next_allowed_actions,
+            ),
+            target="prompt_suffix",
+        )
+
+    def build_workbook_follow_up_missing_section(
+        self,
+        *,
+        workbook_id: str,
+    ) -> PromptSection:
+        return PromptSection(
+            name=SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
+            content=build_workbook_follow_up_missing_notice(workbook_id=workbook_id),
             target="prompt_suffix",
         )
 

--- a/services/request_follow_up.py
+++ b/services/request_follow_up.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class IdentifierDescriptor:
+    token_name: str
+    group_name: str
+    follow_up_re: re.Pattern[str]
+    explicit_capture_re: re.Pattern[str]
+    bare_capture_re: re.Pattern[str]
+    bare_validator_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class FollowUpNoticeStrategy:
+    identifier: IdentifierDescriptor
+    lookup_attr_name: str
+    section_builder_name: str
+    missing_section_builder_name: str
+    payload_builder_name: str
+    log_label: str
+
+
+def build_identifier_token_pattern(token_name: str) -> str:
+    return rf"(?<![A-Za-z0-9_]){re.escape(token_name)}(?![A-Za-z0-9_])"
+
+
+def compile_identifier_token_regex(token_name: str) -> re.Pattern[str]:
+    return re.compile(build_identifier_token_pattern(token_name), flags=re.IGNORECASE)
+
+
+def compile_identifier_explicit_capture_regex(
+    token_name: str,
+    group_name: str,
+) -> re.Pattern[str]:
+    return re.compile(
+        build_identifier_token_pattern(token_name)
+        + rf"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<{group_name}>[A-Za-z0-9_-]+)[`\"']?",
+        flags=re.IGNORECASE,
+    )
+
+
+def compile_identifier_bare_capture_regex(
+    token_name: str,
+    group_name: str,
+) -> re.Pattern[str]:
+    return re.compile(
+        build_identifier_token_pattern(token_name)
+        + rf"\s+[`\"']?(?P<{group_name}>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
+        flags=re.IGNORECASE,
+    )
+
+
+def build_identifier_descriptor(
+    *,
+    token_name: str,
+    bare_validator_name: str,
+) -> IdentifierDescriptor:
+    return IdentifierDescriptor(
+        token_name=token_name,
+        group_name=token_name,
+        follow_up_re=compile_identifier_token_regex(token_name),
+        explicit_capture_re=compile_identifier_explicit_capture_regex(
+            token_name,
+            token_name,
+        ),
+        bare_capture_re=compile_identifier_bare_capture_regex(
+            token_name,
+            token_name,
+        ),
+        bare_validator_name=bare_validator_name,
+    )
+
+
+def extract_identifier_from_text(
+    *,
+    request_text: str,
+    explicit_capture_re: re.Pattern[str],
+    bare_capture_re: re.Pattern[str],
+    group_name: str,
+    is_valid_bare_id: Callable[[str], bool],
+) -> str:
+    if not request_text:
+        return ""
+
+    explicit_match = explicit_capture_re.search(request_text)
+    if explicit_match:
+        return str(explicit_match.group(group_name) or "").strip()
+
+    bare_match = bare_capture_re.search(request_text)
+    if not bare_match:
+        return ""
+
+    candidate = str(bare_match.group(group_name) or "").strip()
+    if is_valid_bare_id(candidate):
+        return candidate
+    return ""
+
+
+__all__ = [
+    "FollowUpNoticeStrategy",
+    "IdentifierDescriptor",
+    "build_identifier_descriptor",
+    "build_identifier_token_pattern",
+    "extract_identifier_from_text",
+]

--- a/services/request_hook_notice_helpers.py
+++ b/services/request_hook_notice_helpers.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..internal_hooks import NoticeBuildContext
+    from .prompt_context_service import PromptSection
+    from .request_follow_up import FollowUpNoticeStrategy
+else:
+    NoticeBuildContext = object
+    PromptSection = object
+    FollowUpNoticeStrategy = object
+
+NoticeAvailabilityChecker = Callable[[set[str]], bool]
+BuildFollowUpSection = Callable[..., PromptSection | None]
+AppendNoticeSection = Callable[[NoticeBuildContext, PromptSection | None], None]
+IsFollowUpRequest = Callable[..., bool]
+
+
+@dataclass(frozen=True)
+class FollowUpNoticeRule:
+    strategy: FollowUpNoticeStrategy
+    availability_checker: NoticeAvailabilityChecker | None = None
+
+
+class FollowUpNoticeHelper:
+    def __init__(
+        self,
+        *,
+        is_follow_up_request: IsFollowUpRequest,
+        build_follow_up_section: BuildFollowUpSection,
+        append_notice_section: AppendNoticeSection,
+    ) -> None:
+        self._is_follow_up_request = is_follow_up_request
+        self._build_follow_up_section = build_follow_up_section
+        self._append_notice_section = append_notice_section
+
+    def append_first_matching_notice(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+        exposed_tool_names: set[str],
+        rules: Sequence[FollowUpNoticeRule],
+    ) -> bool:
+        for rule in rules:
+            if not self._matches_rule(
+                request_text=request_text,
+                exposed_tool_names=exposed_tool_names,
+                rule=rule,
+            ):
+                continue
+            section = self._build_follow_up_section(
+                request_text=request_text,
+                strategy=rule.strategy,
+            )
+            if section is None:
+                continue
+            self._append_notice_section(context, section)
+            return True
+        return False
+
+    def _matches_rule(
+        self,
+        *,
+        request_text: str,
+        exposed_tool_names: set[str],
+        rule: FollowUpNoticeRule,
+    ) -> bool:
+        if rule.availability_checker is not None and not rule.availability_checker(
+            exposed_tool_names
+        ):
+            return False
+        return bool(
+            self._is_follow_up_request(
+                request_text=request_text,
+                descriptor=rule.strategy.identifier,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class WorkbookGuideDecision:
+    inject_core: bool
+    inject_detail: bool
+
+
+class WorkbookGuideMatcher:
+    _TOOL_CALL_RE = re.compile(
+        r"(create_workbook|write_rows|export_workbook)",
+        flags=re.IGNORECASE,
+    )
+    _SUBJECT_RE = re.compile(
+        r"(\bexcel\b|\bxlsx\b|报表|汇总表|工作簿|多\s*sheet)",
+        flags=re.IGNORECASE,
+    )
+    _GENERATION_RE = re.compile(
+        r"(生成|创建|新建|制作|整理成|整理为|写入|填入|输出|导出(?:成|为)?|返回|做(?:成|个|一份)?)",
+        flags=re.IGNORECASE,
+    )
+    _READ_RE = re.compile(
+        r"(读取|阅读|查看|打开|解析|提取|\bread\b|\bopen\b|\bparse\b|\bextract\b)",
+        flags=re.IGNORECASE,
+    )
+    _ANALYSIS_RE = re.compile(
+        r"(分析|总结|\banaly[sz]e\b)",
+        flags=re.IGNORECASE,
+    )
+    _CONVERSION_RE = re.compile(
+        r"(导出(?:成|为)?\s*pdf|"
+        r"(?:转换|转成|转为|转到).*(?:pdf|word|docx|ppt|pptx)|"
+        r"(?:pdf|word|docx|ppt|pptx).*(?:转换|转成|转为|转到)|"
+        r"\bconvert\b)",
+        flags=re.IGNORECASE,
+    )
+    _DETAIL_RE = re.compile(
+        r"(create_workbook|write_rows|export_workbook|start_row|多\s*sheet)",
+        flags=re.IGNORECASE,
+    )
+
+    @classmethod
+    def detect(
+        cls,
+        *,
+        request_text: str,
+        workbook_follow_up_re: re.Pattern[str],
+    ) -> WorkbookGuideDecision:
+        if not request_text:
+            return WorkbookGuideDecision(inject_core=False, inject_detail=False)
+
+        mentions_tool_call = bool(cls._TOOL_CALL_RE.search(request_text))
+        mentions_follow_up_id = bool(workbook_follow_up_re.search(request_text))
+        mentions_subject = bool(cls._SUBJECT_RE.search(request_text))
+        requests_generation = bool(cls._GENERATION_RE.search(request_text))
+        requests_read = bool(cls._READ_RE.search(request_text))
+        requests_analysis = bool(cls._ANALYSIS_RE.search(request_text))
+        requests_conversion = bool(cls._CONVERSION_RE.search(request_text))
+        inject_core = (
+            mentions_tool_call
+            or mentions_follow_up_id
+            or (
+                mentions_subject
+                and requests_generation
+                and not (requests_read or requests_analysis or requests_conversion)
+            )
+        )
+        inject_detail = bool(cls._DETAIL_RE.search(request_text))
+        return WorkbookGuideDecision(
+            inject_core=inject_core,
+            inject_detail=inject_detail,
+        )
+
+
+__all__ = [
+    "FollowUpNoticeHelper",
+    "FollowUpNoticeRule",
+    "WorkbookGuideDecision",
+    "WorkbookGuideMatcher",
+]

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -373,19 +373,34 @@ class RequestHookService:
 
         raw_sheet_names = summary.get("sheet_names")
         sheet_names = (
-            [str(name) for name in raw_sheet_names if str(name)]
+            [
+                normalized_name
+                for name in raw_sheet_names
+                if name is not None
+                and (normalized_name := str(name).strip())
+            ]
             if isinstance(raw_sheet_names, list)
             else []
         )
         raw_latest_sheets = summary.get("latest_written_sheets")
         latest_written_sheets = (
-            [str(name) for name in raw_latest_sheets if str(name)]
+            [
+                normalized_name
+                for name in raw_latest_sheets
+                if name is not None
+                and (normalized_name := str(name).strip())
+            ]
             if isinstance(raw_latest_sheets, list)
             else []
         )
         raw_next_actions = summary.get("next_allowed_actions")
         next_allowed_actions = (
-            [str(action) for action in raw_next_actions if str(action)]
+            [
+                normalized_action
+                for action in raw_next_actions
+                if action is not None
+                and (normalized_action := str(action).strip())
+            ]
             if isinstance(raw_next_actions, list)
             else []
         )

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -1,6 +1,5 @@
 import re
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,82 +23,13 @@ from ..internal_hooks import (
     run_tool_exposure_hooks,
 )
 from .prompt_context_service import PromptContextService, PromptSection
+from .request_follow_up import (
+    FollowUpNoticeStrategy,
+    IdentifierDescriptor,
+    build_identifier_descriptor,
+    extract_identifier_from_text,
+)
 from .upload_types import UploadInfo
-
-
-@dataclass(frozen=True, slots=True)
-class _IdentifierDescriptor:
-    token_name: str
-    group_name: str
-    follow_up_re: re.Pattern[str]
-    explicit_capture_re: re.Pattern[str]
-    bare_capture_re: re.Pattern[str]
-    bare_validator_name: str
-
-
-@dataclass(frozen=True, slots=True)
-class _FollowUpNoticeStrategy:
-    identifier: _IdentifierDescriptor
-    lookup_attr_name: str
-    section_builder_name: str
-    missing_section_builder_name: str
-    payload_builder_name: str
-    log_label: str
-
-
-def _build_identifier_token_pattern(token_name: str) -> str:
-    return rf"(?<![A-Za-z0-9_]){re.escape(token_name)}(?![A-Za-z0-9_])"
-
-
-def _compile_identifier_token_regex(token_name: str) -> re.Pattern[str]:
-    return re.compile(_build_identifier_token_pattern(token_name), flags=re.IGNORECASE)
-
-
-def _compile_identifier_explicit_capture_regex(
-    token_name: str,
-    group_name: str,
-) -> re.Pattern[str]:
-    return re.compile(
-        _build_identifier_token_pattern(token_name)
-        + rf"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<{group_name}>[A-Za-z0-9_-]+)[`\"']?",
-        flags=re.IGNORECASE,
-    )
-
-
-def _compile_identifier_bare_capture_regex(
-    token_name: str,
-    group_name: str,
-) -> re.Pattern[str]:
-    return re.compile(
-        _build_identifier_token_pattern(token_name)
-        + rf"\s+[`\"']?(?P<{group_name}>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
-        flags=re.IGNORECASE,
-    )
-
-
-def _extract_identifier_from_text(
-    *,
-    request_text: str,
-    explicit_capture_re: re.Pattern[str],
-    bare_capture_re: re.Pattern[str],
-    group_name: str,
-    is_valid_bare_id: Callable[[str], bool],
-) -> str:
-    if not request_text:
-        return ""
-
-    explicit_match = explicit_capture_re.search(request_text)
-    if explicit_match:
-        return str(explicit_match.group(group_name) or "").strip()
-
-    bare_match = bare_capture_re.search(request_text)
-    if not bare_match:
-        return ""
-
-    candidate = str(bare_match.group(group_name) or "").strip()
-    if is_valid_bare_id(candidate):
-        return candidate
-    return ""
 
 
 def _normalize_string_list(value: object) -> list[str]:
@@ -116,7 +46,6 @@ class RequestHookService:
     _WORKBOOK_TOOL_NAMES = frozenset(
         {"create_workbook", "write_rows", "export_workbook"}
     )
-    _DOCUMENT_ID_TOKEN_RE = _build_identifier_token_pattern("document_id")
     _DOCUMENT_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _DOCUMENT_ID_DOC_PREFIX_RE = re.compile(
         r"doc-[A-Za-z0-9_-]+",
@@ -137,16 +66,6 @@ class RequestHookService:
         r"(business_report|project_review|executive_brief|accent_color|document_style)",
         flags=re.IGNORECASE,
     )
-    _DOCUMENT_ID_FOLLOW_UP_RE = _compile_identifier_token_regex("document_id")
-    _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = _compile_identifier_explicit_capture_regex(
-        "document_id",
-        "document_id",
-    )
-    _DOCUMENT_ID_BARE_CAPTURE_RE = _compile_identifier_bare_capture_regex(
-        "document_id",
-        "document_id",
-    )
-    _WORKBOOK_ID_TOKEN_RE = _build_identifier_token_pattern("workbook_id")
     _WORKBOOK_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _WORKBOOK_ID_PREFIX_RE = re.compile(
         r"(?:wb|workbook)-[A-Za-z0-9_-]+",
@@ -176,32 +95,15 @@ class RequestHookService:
         r"(create_workbook|write_rows|export_workbook|start_row|多\s*sheet)",
         flags=re.IGNORECASE,
     )
-    _WORKBOOK_ID_FOLLOW_UP_RE = _compile_identifier_token_regex("workbook_id")
-    _WORKBOOK_ID_EXPLICIT_CAPTURE_RE = _compile_identifier_explicit_capture_regex(
-        "workbook_id",
-        "workbook_id",
-    )
-    _WORKBOOK_ID_BARE_CAPTURE_RE = _compile_identifier_bare_capture_regex(
-        "workbook_id",
-        "workbook_id",
-    )
-    _DOCUMENT_IDENTIFIER = _IdentifierDescriptor(
+    _DOCUMENT_IDENTIFIER = build_identifier_descriptor(
         token_name="document_id",
-        group_name="document_id",
-        follow_up_re=_DOCUMENT_ID_FOLLOW_UP_RE,
-        explicit_capture_re=_DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
-        bare_capture_re=_DOCUMENT_ID_BARE_CAPTURE_RE,
         bare_validator_name="_looks_like_bare_document_id",
     )
-    _WORKBOOK_IDENTIFIER = _IdentifierDescriptor(
+    _WORKBOOK_IDENTIFIER = build_identifier_descriptor(
         token_name="workbook_id",
-        group_name="workbook_id",
-        follow_up_re=_WORKBOOK_ID_FOLLOW_UP_RE,
-        explicit_capture_re=_WORKBOOK_ID_EXPLICIT_CAPTURE_RE,
-        bare_capture_re=_WORKBOOK_ID_BARE_CAPTURE_RE,
         bare_validator_name="_looks_like_bare_workbook_id",
     )
-    _DOCUMENT_FOLLOW_UP_STRATEGY = _FollowUpNoticeStrategy(
+    _DOCUMENT_FOLLOW_UP_STRATEGY = FollowUpNoticeStrategy(
         identifier=_DOCUMENT_IDENTIFIER,
         lookup_attr_name="_lookup_document_summary",
         section_builder_name="build_document_follow_up_section",
@@ -209,7 +111,7 @@ class RequestHookService:
         payload_builder_name="_build_document_follow_up_payload",
         log_label="文档",
     )
-    _WORKBOOK_FOLLOW_UP_STRATEGY = _FollowUpNoticeStrategy(
+    _WORKBOOK_FOLLOW_UP_STRATEGY = FollowUpNoticeStrategy(
         identifier=_WORKBOOK_IDENTIFIER,
         lookup_attr_name="_lookup_workbook_summary",
         section_builder_name="build_workbook_follow_up_section",
@@ -375,7 +277,7 @@ class RequestHookService:
         *,
         request_text: str,
         exposed_tool_names: set[str],
-        strategy: _FollowUpNoticeStrategy,
+        strategy: FollowUpNoticeStrategy,
         availability_checker: Callable[..., bool] | None,
     ) -> bool:
         if availability_checker is not None and not availability_checker(
@@ -484,7 +386,7 @@ class RequestHookService:
             return False
         if cls._WORKBOOK_TOOL_CALL_HINT_RE.search(request_text):
             return True
-        if cls._WORKBOOK_ID_FOLLOW_UP_RE.search(request_text):
+        if cls._WORKBOOK_IDENTIFIER.follow_up_re.search(request_text):
             return True
         if not cls._WORKBOOK_SUBJECT_HINT_RE.search(request_text):
             return False
@@ -523,7 +425,7 @@ class RequestHookService:
         cls,
         *,
         request_text: str,
-        descriptor: _IdentifierDescriptor,
+        descriptor: IdentifierDescriptor,
     ) -> bool:
         if not request_text:
             return False
@@ -548,9 +450,9 @@ class RequestHookService:
         cls,
         *,
         request_text: str,
-        descriptor: _IdentifierDescriptor,
+        descriptor: IdentifierDescriptor,
     ) -> str:
-        return _extract_identifier_from_text(
+        return extract_identifier_from_text(
             request_text=request_text,
             explicit_capture_re=descriptor.explicit_capture_re,
             bare_capture_re=descriptor.bare_capture_re,
@@ -600,7 +502,7 @@ class RequestHookService:
         self,
         *,
         request_text: str,
-        strategy: _FollowUpNoticeStrategy,
+        strategy: FollowUpNoticeStrategy,
     ) -> PromptSection | None:
         identifier_value = self._extract_identifier(
             request_text=request_text,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -61,8 +61,40 @@ class RequestHookService:
         + r"\s+[`\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
         flags=re.IGNORECASE,
     )
+    _WORKBOOK_ID_TOKEN_RE = r"(?<![A-Za-z0-9_])workbook_id(?![A-Za-z0-9_])"
+    _WORKBOOK_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
+    _WORKBOOK_ID_PREFIX_RE = re.compile(
+        r"(?:wb|workbook)-[A-Za-z0-9_-]+",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_WORKFLOW_HINT_RE = re.compile(
+        r"(create_workbook|write_rows|export_workbook|"
+        r"\bexcel\b|\bxlsx\b|报表|汇总表|多\s*sheet|工作簿|"
+        r"生成\s*(?:excel|xlsx|报表|汇总表)|整理成\s*(?:excel|xlsx|报表|汇总表))",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_DETAIL_HINT_RE = re.compile(
+        r"(create_workbook|write_rows|export_workbook|start_row|多\s*sheet)",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_ID_FOLLOW_UP_RE = re.compile(
+        _WORKBOOK_ID_TOKEN_RE,
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_ID_EXPLICIT_CAPTURE_RE = re.compile(
+        _WORKBOOK_ID_TOKEN_RE
+        + r"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<workbook_id>[A-Za-z0-9_-]+)[`\"']?",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_ID_BARE_CAPTURE_RE = re.compile(
+        _WORKBOOK_ID_TOKEN_RE
+        + r"\s+[`\"']?(?P<workbook_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
+        flags=re.IGNORECASE,
+    )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
     _DOCUMENT_DETAIL_NOTICE_KEY = "document_detail_guide"
+    _WORKBOOK_CORE_NOTICE_KEY = "workbook_core_guide"
+    _WORKBOOK_DETAIL_NOTICE_KEY = "workbook_detail_guide"
 
     def __init__(
         self,
@@ -77,6 +109,7 @@ class RequestHookService:
         allow_external_input_files: bool,
         prompt_context_service: PromptContextService | None = None,
         lookup_document_summary: Callable[[str], dict[str, object] | None] | None = None,
+        lookup_workbook_summary: Callable[[str], dict[str, object] | None] | None = None,
     ) -> None:
         self._auto_block_execution_tools = auto_block_execution_tools
         self._get_cached_upload_infos = get_cached_upload_infos
@@ -84,6 +117,7 @@ class RequestHookService:
         self._store_uploaded_file = store_uploaded_file
         self._consume_session_notice_once = consume_session_notice_once
         self._lookup_document_summary = lookup_document_summary
+        self._lookup_workbook_summary = lookup_workbook_summary
         self.prompt_context_service = prompt_context_service or PromptContextService(
             allow_external_input_files=allow_external_input_files
         )
@@ -122,6 +156,11 @@ class RequestHookService:
             return context
 
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
+        if self._is_workbook_follow_up(request_text=request_text):
+            section = self._build_workbook_follow_up_section(request_text=request_text)
+            if section is not None:
+                self._append_notice_section(context, section)
+                return context
         if self._is_document_follow_up(request_text=request_text):
             section = self._build_document_follow_up_section(request_text=request_text)
             if section is not None:
@@ -133,7 +172,18 @@ class RequestHookService:
         should_inject_detail = self._should_inject_document_tool_detail(
             request_text=request_text
         )
-        if not should_inject_core and not should_inject_detail:
+        should_inject_workbook_core = self._should_inject_workbook_tool_guide(
+            request_text=request_text
+        )
+        should_inject_workbook_detail = self._should_inject_workbook_tool_detail(
+            request_text=request_text
+        )
+        if (
+            not should_inject_core
+            and not should_inject_detail
+            and not should_inject_workbook_core
+            and not should_inject_workbook_detail
+        ):
             return context
 
         if should_inject_core and self._consume_session_notice_once(
@@ -149,6 +199,20 @@ class RequestHookService:
             self._append_notice_section(
                 context,
                 self.prompt_context_service.build_document_tool_detail_section(),
+            )
+        if should_inject_workbook_core and self._consume_session_notice_once(
+            context.event, self._WORKBOOK_CORE_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_workbook_tool_guide_section(),
+            )
+        if should_inject_workbook_detail and self._consume_session_notice_once(
+            context.event, self._WORKBOOK_DETAIL_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_workbook_tool_detail_section(),
             )
         return context
 
@@ -179,10 +243,32 @@ class RequestHookService:
         return bool(cls._DOCUMENT_DETAIL_HINT_RE.search(request_text))
 
     @classmethod
+    def _should_inject_workbook_tool_guide(cls, *, request_text: str) -> bool:
+        if not request_text:
+            return False
+        return bool(cls._WORKBOOK_WORKFLOW_HINT_RE.search(request_text))
+
+    @classmethod
+    def _should_inject_workbook_tool_detail(
+        cls,
+        *,
+        request_text: str,
+    ) -> bool:
+        if not request_text:
+            return False
+        return bool(cls._WORKBOOK_DETAIL_HINT_RE.search(request_text))
+
+    @classmethod
     def _is_document_follow_up(cls, *, request_text: str) -> bool:
         if not request_text:
             return False
         return bool(cls._DOCUMENT_ID_FOLLOW_UP_RE.search(request_text))
+
+    @classmethod
+    def _is_workbook_follow_up(cls, *, request_text: str) -> bool:
+        if not request_text:
+            return False
+        return bool(cls._WORKBOOK_ID_FOLLOW_UP_RE.search(request_text))
 
     @classmethod
     def _extract_document_id(cls, *, request_text: str) -> str:
@@ -200,12 +286,36 @@ class RequestHookService:
         return ""
 
     @classmethod
+    def _extract_workbook_id(cls, *, request_text: str) -> str:
+        if not request_text:
+            return ""
+        explicit_match = cls._WORKBOOK_ID_EXPLICIT_CAPTURE_RE.search(request_text)
+        if explicit_match:
+            return str(explicit_match.group("workbook_id") or "").strip()
+
+        bare_match = cls._WORKBOOK_ID_BARE_CAPTURE_RE.search(request_text)
+        if bare_match:
+            candidate = str(bare_match.group("workbook_id") or "").strip()
+            if cls._looks_like_bare_workbook_id(candidate):
+                return candidate
+        return ""
+
+    @classmethod
     def _looks_like_bare_document_id(cls, candidate: str) -> bool:
         if not candidate:
             return False
         return bool(
             cls._DOCUMENT_ID_HEX_RE.fullmatch(candidate)
             or cls._DOCUMENT_ID_DOC_PREFIX_RE.fullmatch(candidate)
+        )
+
+    @classmethod
+    def _looks_like_bare_workbook_id(cls, candidate: str) -> bool:
+        if not candidate:
+            return False
+        return bool(
+            cls._WORKBOOK_ID_HEX_RE.fullmatch(candidate)
+            or cls._WORKBOOK_ID_PREFIX_RE.fullmatch(candidate)
         )
 
     def _build_document_follow_up_section(
@@ -235,6 +345,57 @@ class RequestHookService:
             document_id=document_id,
             status=str(summary.get("status") or ""),
             block_count=int(summary.get("block_count") or 0),
+        )
+
+    def _build_workbook_follow_up_section(
+        self,
+        *,
+        request_text: str,
+    ) -> PromptSection | None:
+        workbook_id = self._extract_workbook_id(request_text=request_text)
+        if not workbook_id:
+            return None
+        if self._lookup_workbook_summary is None:
+            return None
+        try:
+            summary = self._lookup_workbook_summary(workbook_id)
+        except KeyError:
+            summary = None
+        except Exception as exc:
+            logger.exception(
+                f"[文件管理] 查询工作簿会话摘要失败 workbook_id={workbook_id}: {exc}"
+            )
+            raise
+        if not isinstance(summary, dict):
+            return self.prompt_context_service.build_workbook_follow_up_missing_section(
+                workbook_id=workbook_id
+            )
+
+        raw_sheet_names = summary.get("sheet_names")
+        sheet_names = (
+            [str(name) for name in raw_sheet_names if str(name)]
+            if isinstance(raw_sheet_names, list)
+            else []
+        )
+        raw_latest_sheets = summary.get("latest_written_sheets")
+        latest_written_sheets = (
+            [str(name) for name in raw_latest_sheets if str(name)]
+            if isinstance(raw_latest_sheets, list)
+            else []
+        )
+        raw_next_actions = summary.get("next_allowed_actions")
+        next_allowed_actions = (
+            [str(action) for action in raw_next_actions if str(action)]
+            if isinstance(raw_next_actions, list)
+            else []
+        )
+        return self.prompt_context_service.build_workbook_follow_up_section(
+            workbook_id=workbook_id,
+            status=str(summary.get("status") or ""),
+            sheet_names=sheet_names,
+            sheet_count=int(summary.get("sheet_count") or 0),
+            latest_written_sheets=latest_written_sheets,
+            next_allowed_actions=next_allowed_actions,
         )
 
     @staticmethod

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -343,10 +343,15 @@ class RequestHookService:
         request_text: str,
         exposed_tool_names: set[str],
     ) -> bool:
+        workbook_availability_checker = (
+            self._has_workbook_tools_available
+            if context.explicit_tool_name is None
+            else self._has_full_workbook_toolset_available
+        )
         follow_up_rules = (
             (
                 self._WORKBOOK_FOLLOW_UP_STRATEGY,
-                self._has_workbook_tools_available,
+                workbook_availability_checker,
             ),
             (
                 self._DOCUMENT_FOLLOW_UP_STRATEGY,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -596,7 +596,16 @@ class RequestHookService:
             and context.request.func_tool
             and context.explicit_tool_name
         ):
-            for tool_name in FILE_TOOLS:
+            exposed_file_tool_names = self._get_exposed_tool_names(
+                context.request.func_tool
+            ).intersection(FILE_TOOLS)
+            if context.explicit_tool_name not in exposed_file_tool_names:
+                logger.info(
+                    "[文件管理] 检测到用户显式指定工具 %s，但该工具当前未暴露，跳过工具收窄",
+                    context.explicit_tool_name,
+                )
+                return context
+            for tool_name in exposed_file_tool_names:
                 if tool_name != context.explicit_tool_name:
                     context.request.func_tool.remove_tool(tool_name)
             logger.info(

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -25,11 +25,76 @@ from .prompt_context_service import PromptContextService, PromptSection
 from .upload_types import UploadInfo
 
 
+def _build_identifier_token_pattern(token_name: str) -> str:
+    return rf"(?<![A-Za-z0-9_]){re.escape(token_name)}(?![A-Za-z0-9_])"
+
+
+def _compile_identifier_token_regex(token_name: str) -> re.Pattern[str]:
+    return re.compile(_build_identifier_token_pattern(token_name), flags=re.IGNORECASE)
+
+
+def _compile_identifier_explicit_capture_regex(
+    token_name: str,
+    group_name: str,
+) -> re.Pattern[str]:
+    return re.compile(
+        _build_identifier_token_pattern(token_name)
+        + rf"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<{group_name}>[A-Za-z0-9_-]+)[`\"']?",
+        flags=re.IGNORECASE,
+    )
+
+
+def _compile_identifier_bare_capture_regex(
+    token_name: str,
+    group_name: str,
+) -> re.Pattern[str]:
+    return re.compile(
+        _build_identifier_token_pattern(token_name)
+        + rf"\s+[`\"']?(?P<{group_name}>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
+        flags=re.IGNORECASE,
+    )
+
+
+def _extract_identifier_from_text(
+    *,
+    request_text: str,
+    explicit_capture_re: re.Pattern[str],
+    bare_capture_re: re.Pattern[str],
+    group_name: str,
+    is_valid_bare_id: Callable[[str], bool],
+) -> str:
+    if not request_text:
+        return ""
+
+    explicit_match = explicit_capture_re.search(request_text)
+    if explicit_match:
+        return str(explicit_match.group(group_name) or "").strip()
+
+    bare_match = bare_capture_re.search(request_text)
+    if not bare_match:
+        return ""
+
+    candidate = str(bare_match.group(group_name) or "").strip()
+    if is_valid_bare_id(candidate):
+        return candidate
+    return ""
+
+
+def _normalize_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [
+        normalized_value
+        for item in value
+        if item is not None and (normalized_value := str(item).strip())
+    ]
+
+
 class RequestHookService:
     _WORKBOOK_TOOL_NAMES = frozenset(
         {"create_workbook", "write_rows", "export_workbook"}
     )
-    _DOCUMENT_ID_TOKEN_RE = r"(?<![A-Za-z0-9_])document_id(?![A-Za-z0-9_])"
+    _DOCUMENT_ID_TOKEN_RE = _build_identifier_token_pattern("document_id")
     _DOCUMENT_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _DOCUMENT_ID_DOC_PREFIX_RE = re.compile(
         r"doc-[A-Za-z0-9_-]+",
@@ -50,49 +115,53 @@ class RequestHookService:
         r"(business_report|project_review|executive_brief|accent_color|document_style)",
         flags=re.IGNORECASE,
     )
-    _DOCUMENT_ID_FOLLOW_UP_RE = re.compile(
-        _DOCUMENT_ID_TOKEN_RE,
-        flags=re.IGNORECASE,
+    _DOCUMENT_ID_FOLLOW_UP_RE = _compile_identifier_token_regex("document_id")
+    _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = _compile_identifier_explicit_capture_regex(
+        "document_id",
+        "document_id",
     )
-    _DOCUMENT_ID_EXPLICIT_CAPTURE_RE = re.compile(
-        _DOCUMENT_ID_TOKEN_RE
-        + r"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<document_id>[A-Za-z0-9_-]+)[`\"']?",
-        flags=re.IGNORECASE,
+    _DOCUMENT_ID_BARE_CAPTURE_RE = _compile_identifier_bare_capture_regex(
+        "document_id",
+        "document_id",
     )
-    _DOCUMENT_ID_BARE_CAPTURE_RE = re.compile(
-        _DOCUMENT_ID_TOKEN_RE
-        + r"\s+[`\"']?(?P<document_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_ID_TOKEN_RE = r"(?<![A-Za-z0-9_])workbook_id(?![A-Za-z0-9_])"
+    _WORKBOOK_ID_TOKEN_RE = _build_identifier_token_pattern("workbook_id")
     _WORKBOOK_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _WORKBOOK_ID_PREFIX_RE = re.compile(
         r"(?:wb|workbook)-[A-Za-z0-9_-]+",
         flags=re.IGNORECASE,
     )
-    _WORKBOOK_WORKFLOW_HINT_RE = re.compile(
-        r"(create_workbook|write_rows|export_workbook|"
-        r"\bexcel\b|\bxlsx\b|报表|汇总表|多\s*sheet|工作簿|"
-        r"生成\s*(?:excel|xlsx|报表|汇总表)|整理成\s*(?:excel|xlsx|报表|汇总表))",
+    _WORKBOOK_TOOL_CALL_HINT_RE = re.compile(
+        r"(create_workbook|write_rows|export_workbook)",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_SUBJECT_HINT_RE = re.compile(
+        r"(\bexcel\b|\bxlsx\b|报表|汇总表|工作簿|多\s*sheet)",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_GENERATION_HINT_RE = re.compile(
+        r"(生成|创建|新建|制作|整理成|整理为|写入|填入|输出|导出(?:成|为)?|返回|做(?:成|个|一份)?)",
+        flags=re.IGNORECASE,
+    )
+    _WORKBOOK_NON_GENERATION_HINT_RE = re.compile(
+        r"(读取|阅读|查看|打开|解析|提取|分析|总结|"
+        r"导出(?:成|为)\s*pdf|"
+        r"(?:转换|转成|转为|转到).*(?:pdf|word|docx|ppt|pptx)|"
+        r"(?:pdf|word|docx|ppt|pptx).*(?:转换|转成|转为|转到)|"
+        r"\bread\b|\bopen\b|\bparse\b|\bextract\b|\banaly[sz]e\b|\bconvert\b)",
         flags=re.IGNORECASE,
     )
     _WORKBOOK_DETAIL_HINT_RE = re.compile(
         r"(create_workbook|write_rows|export_workbook|start_row|多\s*sheet)",
         flags=re.IGNORECASE,
     )
-    _WORKBOOK_ID_FOLLOW_UP_RE = re.compile(
-        _WORKBOOK_ID_TOKEN_RE,
-        flags=re.IGNORECASE,
+    _WORKBOOK_ID_FOLLOW_UP_RE = _compile_identifier_token_regex("workbook_id")
+    _WORKBOOK_ID_EXPLICIT_CAPTURE_RE = _compile_identifier_explicit_capture_regex(
+        "workbook_id",
+        "workbook_id",
     )
-    _WORKBOOK_ID_EXPLICIT_CAPTURE_RE = re.compile(
-        _WORKBOOK_ID_TOKEN_RE
-        + r"(?:\s*[:=：]\s*|\s*(?:为|是)\s*|\s+is\s+)[`\"']?(?P<workbook_id>[A-Za-z0-9_-]+)[`\"']?",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_ID_BARE_CAPTURE_RE = re.compile(
-        _WORKBOOK_ID_TOKEN_RE
-        + r"\s+[`\"']?(?P<workbook_id>[A-Za-z0-9_-]*[\d_-][A-Za-z0-9_-]*)[`\"']?",
-        flags=re.IGNORECASE,
+    _WORKBOOK_ID_BARE_CAPTURE_RE = _compile_identifier_bare_capture_regex(
+        "workbook_id",
+        "workbook_id",
     )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
     _DOCUMENT_DETAIL_NOTICE_KEY = "document_detail_guide"
@@ -160,82 +229,22 @@ class RequestHookService:
 
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
         exposed_tool_names = self._get_exposed_tool_names(context.request.func_tool)
-        workbook_follow_up_available = self._has_workbook_tools_available(
-            exposed_tool_names=exposed_tool_names
-        )
-        workbook_workflow_guide_available = (
-            self._has_full_workbook_toolset_available(
-                exposed_tool_names=exposed_tool_names
-            )
-        )
-        if workbook_follow_up_available and self._is_workbook_follow_up(
-            request_text=request_text
-        ):
-            section = self._build_workbook_follow_up_section(request_text=request_text)
-            if section is not None:
-                self._append_notice_section(context, section)
-                return context
-        if self._is_document_follow_up(request_text=request_text):
-            section = self._build_document_follow_up_section(request_text=request_text)
-            if section is not None:
-                self._append_notice_section(context, section)
-                return context
-        should_inject_core = self._should_inject_document_tool_guide(
-            request_text=request_text
-        )
-        should_inject_detail = self._should_inject_document_tool_detail(
-            request_text=request_text
-        )
-        should_inject_workbook_core = self._should_inject_workbook_tool_guide(
-            request_text=request_text
-        )
-        should_inject_workbook_detail = self._should_inject_workbook_tool_detail(
-            request_text=request_text
-        )
-        if (
-            not should_inject_core
-            and not should_inject_detail
-            and not should_inject_workbook_core
-            and not should_inject_workbook_detail
+        if self._append_follow_up_notice_if_needed(
+            context,
+            request_text=request_text,
+            exposed_tool_names=exposed_tool_names,
         ):
             return context
 
-        if should_inject_core and self._consume_session_notice_once(
-            context.event, self._DOCUMENT_CORE_NOTICE_KEY
-        ):
-            self._append_notice_section(
-                context,
-                self.prompt_context_service.build_document_tool_guide_section(),
-            )
-        if should_inject_detail and self._consume_session_notice_once(
-            context.event, self._DOCUMENT_DETAIL_NOTICE_KEY
-        ):
-            self._append_notice_section(
-                context,
-                self.prompt_context_service.build_document_tool_detail_section(),
-            )
-        if (
-            workbook_workflow_guide_available
-            and should_inject_workbook_core
-            and self._consume_session_notice_once(
-            context.event, self._WORKBOOK_CORE_NOTICE_KEY
-            )
-        ):
-            self._append_notice_section(
-                context,
-                self.prompt_context_service.build_workbook_tool_guide_section(),
-            )
-        if (
-            workbook_workflow_guide_available
-            and should_inject_workbook_detail
-            and self._consume_session_notice_once(
-            context.event, self._WORKBOOK_DETAIL_NOTICE_KEY
-            )
-        ):
-            self._append_notice_section(
-                context,
-                self.prompt_context_service.build_workbook_tool_detail_section(),
-            )
+        self._append_document_tool_guides(
+            context,
+            request_text=request_text,
+        )
+        self._append_workbook_tool_guides(
+            context,
+            request_text=request_text,
+            exposed_tool_names=exposed_tool_names,
+        )
         return context
 
     @classmethod
@@ -267,6 +276,123 @@ class RequestHookService:
     ) -> bool:
         return cls._WORKBOOK_TOOL_NAMES.issubset(exposed_tool_names)
 
+    def _append_follow_up_notice_if_needed(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+        exposed_tool_names: set[str],
+    ) -> bool:
+        if self._append_workbook_follow_up_notice(
+            context,
+            request_text=request_text,
+            exposed_tool_names=exposed_tool_names,
+        ):
+            return True
+        return self._append_document_follow_up_notice(
+            context,
+            request_text=request_text,
+        )
+
+    def _append_workbook_follow_up_notice(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+        exposed_tool_names: set[str],
+    ) -> bool:
+        if not self._has_workbook_tools_available(exposed_tool_names=exposed_tool_names):
+            return False
+        if not self._is_workbook_follow_up(request_text=request_text):
+            return False
+
+        section = self._build_workbook_follow_up_section(request_text=request_text)
+        if section is None:
+            return False
+
+        self._append_notice_section(context, section)
+        return True
+
+    def _append_document_follow_up_notice(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+    ) -> bool:
+        if not self._is_document_follow_up(request_text=request_text):
+            return False
+
+        section = self._build_document_follow_up_section(request_text=request_text)
+        if section is None:
+            return False
+
+        self._append_notice_section(context, section)
+        return True
+
+    def _append_document_tool_guides(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+    ) -> None:
+        should_inject_core = self._should_inject_document_tool_guide(
+            request_text=request_text
+        )
+        should_inject_detail = self._should_inject_document_tool_detail(
+            request_text=request_text
+        )
+
+        if should_inject_core and self._consume_session_notice_once(
+            context.event, self._DOCUMENT_CORE_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_document_tool_guide_section(),
+            )
+        if should_inject_detail and self._consume_session_notice_once(
+            context.event, self._DOCUMENT_DETAIL_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_document_tool_detail_section(),
+            )
+
+    def _append_workbook_tool_guides(
+        self,
+        context: NoticeBuildContext,
+        *,
+        request_text: str,
+        exposed_tool_names: set[str],
+    ) -> None:
+        if not self._has_full_workbook_toolset_available(
+            exposed_tool_names=exposed_tool_names
+        ):
+            return
+
+        should_inject_core = self._should_inject_workbook_tool_guide(
+            request_text=request_text
+        )
+        should_inject_detail = self._should_inject_workbook_tool_detail(
+            request_text=request_text
+        )
+        if not should_inject_core and not should_inject_detail:
+            return
+
+        if should_inject_core and self._consume_session_notice_once(
+            context.event, self._WORKBOOK_CORE_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_workbook_tool_guide_section(),
+            )
+        if should_inject_detail and self._consume_session_notice_once(
+            context.event, self._WORKBOOK_DETAIL_NOTICE_KEY
+        ):
+            self._append_notice_section(
+                context,
+                self.prompt_context_service.build_workbook_tool_detail_section(),
+            )
+
     @classmethod
     def _should_inject_document_tool_guide(cls, *, request_text: str) -> bool:
         if not request_text:
@@ -287,7 +413,15 @@ class RequestHookService:
     def _should_inject_workbook_tool_guide(cls, *, request_text: str) -> bool:
         if not request_text:
             return False
-        return bool(cls._WORKBOOK_WORKFLOW_HINT_RE.search(request_text))
+        if cls._WORKBOOK_TOOL_CALL_HINT_RE.search(request_text):
+            return True
+        if cls._WORKBOOK_ID_FOLLOW_UP_RE.search(request_text):
+            return True
+        if not cls._WORKBOOK_SUBJECT_HINT_RE.search(request_text):
+            return False
+        if not cls._WORKBOOK_GENERATION_HINT_RE.search(request_text):
+            return False
+        return not cls._WORKBOOK_NON_GENERATION_HINT_RE.search(request_text)
 
     @classmethod
     def _should_inject_workbook_tool_detail(
@@ -313,33 +447,23 @@ class RequestHookService:
 
     @classmethod
     def _extract_document_id(cls, *, request_text: str) -> str:
-        if not request_text:
-            return ""
-        explicit_match = cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE.search(request_text)
-        if explicit_match:
-            return str(explicit_match.group("document_id") or "").strip()
-
-        bare_match = cls._DOCUMENT_ID_BARE_CAPTURE_RE.search(request_text)
-        if bare_match:
-            candidate = str(bare_match.group("document_id") or "").strip()
-            if cls._looks_like_bare_document_id(candidate):
-                return candidate
-        return ""
+        return _extract_identifier_from_text(
+            request_text=request_text,
+            explicit_capture_re=cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
+            bare_capture_re=cls._DOCUMENT_ID_BARE_CAPTURE_RE,
+            group_name="document_id",
+            is_valid_bare_id=cls._looks_like_bare_document_id,
+        )
 
     @classmethod
     def _extract_workbook_id(cls, *, request_text: str) -> str:
-        if not request_text:
-            return ""
-        explicit_match = cls._WORKBOOK_ID_EXPLICIT_CAPTURE_RE.search(request_text)
-        if explicit_match:
-            return str(explicit_match.group("workbook_id") or "").strip()
-
-        bare_match = cls._WORKBOOK_ID_BARE_CAPTURE_RE.search(request_text)
-        if bare_match:
-            candidate = str(bare_match.group("workbook_id") or "").strip()
-            if cls._looks_like_bare_workbook_id(candidate):
-                return candidate
-        return ""
+        return _extract_identifier_from_text(
+            request_text=request_text,
+            explicit_capture_re=cls._WORKBOOK_ID_EXPLICIT_CAPTURE_RE,
+            bare_capture_re=cls._WORKBOOK_ID_BARE_CAPTURE_RE,
+            group_name="workbook_id",
+            is_valid_bare_id=cls._looks_like_bare_workbook_id,
+        )
 
     @classmethod
     def _looks_like_bare_document_id(cls, candidate: str) -> bool:
@@ -411,47 +535,17 @@ class RequestHookService:
             return self.prompt_context_service.build_workbook_follow_up_missing_section(
                 workbook_id=workbook_id
             )
-
-        raw_sheet_names = summary.get("sheet_names")
-        sheet_names = (
-            [
-                normalized_name
-                for name in raw_sheet_names
-                if name is not None
-                and (normalized_name := str(name).strip())
-            ]
-            if isinstance(raw_sheet_names, list)
-            else []
-        )
-        raw_latest_sheets = summary.get("latest_written_sheets")
-        latest_written_sheets = (
-            [
-                normalized_name
-                for name in raw_latest_sheets
-                if name is not None
-                and (normalized_name := str(name).strip())
-            ]
-            if isinstance(raw_latest_sheets, list)
-            else []
-        )
-        raw_next_actions = summary.get("next_allowed_actions")
-        next_allowed_actions = (
-            [
-                normalized_action
-                for action in raw_next_actions
-                if action is not None
-                and (normalized_action := str(action).strip())
-            ]
-            if isinstance(raw_next_actions, list)
-            else []
-        )
         return self.prompt_context_service.build_workbook_follow_up_section(
             workbook_id=workbook_id,
             status=str(summary.get("status") or ""),
-            sheet_names=sheet_names,
+            sheet_names=_normalize_string_list(summary.get("sheet_names")),
             sheet_count=int(summary.get("sheet_count") or 0),
-            latest_written_sheets=latest_written_sheets,
-            next_allowed_actions=next_allowed_actions,
+            latest_written_sheets=_normalize_string_list(
+                summary.get("latest_written_sheets")
+            ),
+            next_allowed_actions=_normalize_string_list(
+                summary.get("next_allowed_actions")
+            ),
         )
 
     @staticmethod

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -1,6 +1,8 @@
 import re
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import astrbot.api.message_components as Comp
 from astrbot.api import logger
@@ -23,6 +25,26 @@ from ..internal_hooks import (
 )
 from .prompt_context_service import PromptContextService, PromptSection
 from .upload_types import UploadInfo
+
+
+@dataclass(frozen=True, slots=True)
+class _IdentifierDescriptor:
+    token_name: str
+    group_name: str
+    follow_up_re: re.Pattern[str]
+    explicit_capture_re: re.Pattern[str]
+    bare_capture_re: re.Pattern[str]
+    bare_validator_name: str
+
+
+@dataclass(frozen=True, slots=True)
+class _FollowUpNoticeStrategy:
+    identifier: _IdentifierDescriptor
+    lookup_attr_name: str
+    section_builder_name: str
+    missing_section_builder_name: str
+    payload_builder_name: str
+    log_label: str
 
 
 def _build_identifier_token_pattern(token_name: str) -> str:
@@ -163,6 +185,38 @@ class RequestHookService:
         "workbook_id",
         "workbook_id",
     )
+    _DOCUMENT_IDENTIFIER = _IdentifierDescriptor(
+        token_name="document_id",
+        group_name="document_id",
+        follow_up_re=_DOCUMENT_ID_FOLLOW_UP_RE,
+        explicit_capture_re=_DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
+        bare_capture_re=_DOCUMENT_ID_BARE_CAPTURE_RE,
+        bare_validator_name="_looks_like_bare_document_id",
+    )
+    _WORKBOOK_IDENTIFIER = _IdentifierDescriptor(
+        token_name="workbook_id",
+        group_name="workbook_id",
+        follow_up_re=_WORKBOOK_ID_FOLLOW_UP_RE,
+        explicit_capture_re=_WORKBOOK_ID_EXPLICIT_CAPTURE_RE,
+        bare_capture_re=_WORKBOOK_ID_BARE_CAPTURE_RE,
+        bare_validator_name="_looks_like_bare_workbook_id",
+    )
+    _DOCUMENT_FOLLOW_UP_STRATEGY = _FollowUpNoticeStrategy(
+        identifier=_DOCUMENT_IDENTIFIER,
+        lookup_attr_name="_lookup_document_summary",
+        section_builder_name="build_document_follow_up_section",
+        missing_section_builder_name="build_document_follow_up_missing_section",
+        payload_builder_name="_build_document_follow_up_payload",
+        log_label="文档",
+    )
+    _WORKBOOK_FOLLOW_UP_STRATEGY = _FollowUpNoticeStrategy(
+        identifier=_WORKBOOK_IDENTIFIER,
+        lookup_attr_name="_lookup_workbook_summary",
+        section_builder_name="build_workbook_follow_up_section",
+        missing_section_builder_name="build_workbook_follow_up_missing_section",
+        payload_builder_name="_build_workbook_follow_up_payload",
+        log_label="工作簿",
+    )
     _DOCUMENT_CORE_NOTICE_KEY = "document_core_guide"
     _DOCUMENT_DETAIL_NOTICE_KEY = "document_detail_guide"
     _WORKBOOK_CORE_NOTICE_KEY = "workbook_core_guide"
@@ -194,7 +248,7 @@ class RequestHookService:
             allow_external_input_files=allow_external_input_files
         )
         self._notice_hooks = [
-            self.append_document_tool_guide_notice,
+            self.append_office_tool_guide_notice,
             self.append_uploaded_file_notices,
         ]
         self._tool_exposure_hooks = [
@@ -220,7 +274,7 @@ class RequestHookService:
     ) -> NoticeBuildContext:
         return await run_notice_hooks(self._notice_hooks, context)
 
-    async def append_document_tool_guide_notice(
+    async def append_office_tool_guide_notice(
         self,
         context: NoticeBuildContext,
     ) -> NoticeBuildContext:
@@ -246,6 +300,12 @@ class RequestHookService:
             exposed_tool_names=exposed_tool_names,
         )
         return context
+
+    async def append_document_tool_guide_notice(
+        self,
+        context: NoticeBuildContext,
+    ) -> NoticeBuildContext:
+        return await self.append_office_tool_guide_notice(context)
 
     @classmethod
     def _extract_prompt_text(cls, prompt: str) -> str:
@@ -283,46 +343,50 @@ class RequestHookService:
         request_text: str,
         exposed_tool_names: set[str],
     ) -> bool:
-        if self._append_workbook_follow_up_notice(
-            context,
-            request_text=request_text,
-            exposed_tool_names=exposed_tool_names,
-        ):
-            return True
-        return self._append_document_follow_up_notice(
-            context,
-            request_text=request_text,
+        follow_up_rules = (
+            (
+                self._WORKBOOK_FOLLOW_UP_STRATEGY,
+                self._has_workbook_tools_available,
+            ),
+            (
+                self._DOCUMENT_FOLLOW_UP_STRATEGY,
+                None,
+            ),
         )
+        for strategy, availability_checker in follow_up_rules:
+            if self._append_follow_up_notice(
+                context,
+                request_text=request_text,
+                exposed_tool_names=exposed_tool_names,
+                strategy=strategy,
+                availability_checker=availability_checker,
+            ):
+                return True
+        return False
 
-    def _append_workbook_follow_up_notice(
+    def _append_follow_up_notice(
         self,
         context: NoticeBuildContext,
         *,
         request_text: str,
         exposed_tool_names: set[str],
+        strategy: _FollowUpNoticeStrategy,
+        availability_checker: Callable[..., bool] | None,
     ) -> bool:
-        if not self._has_workbook_tools_available(exposed_tool_names=exposed_tool_names):
+        if availability_checker is not None and not availability_checker(
+            exposed_tool_names=exposed_tool_names
+        ):
             return False
-        if not self._is_workbook_follow_up(request_text=request_text):
-            return False
-
-        section = self._build_workbook_follow_up_section(request_text=request_text)
-        if section is None:
-            return False
-
-        self._append_notice_section(context, section)
-        return True
-
-    def _append_document_follow_up_notice(
-        self,
-        context: NoticeBuildContext,
-        *,
-        request_text: str,
-    ) -> bool:
-        if not self._is_document_follow_up(request_text=request_text):
+        if not self._is_follow_up_request(
+            request_text=request_text,
+            descriptor=strategy.identifier,
+        ):
             return False
 
-        section = self._build_document_follow_up_section(request_text=request_text)
+        section = self._build_follow_up_section(
+            request_text=request_text,
+            strategy=strategy,
+        )
         if section is None:
             return False
 
@@ -435,34 +499,58 @@ class RequestHookService:
 
     @classmethod
     def _is_document_follow_up(cls, *, request_text: str) -> bool:
-        if not request_text:
-            return False
-        return bool(cls._DOCUMENT_ID_FOLLOW_UP_RE.search(request_text))
+        return cls._is_follow_up_request(
+            request_text=request_text,
+            descriptor=cls._DOCUMENT_IDENTIFIER,
+        )
 
     @classmethod
     def _is_workbook_follow_up(cls, *, request_text: str) -> bool:
         if not request_text:
             return False
-        return bool(cls._WORKBOOK_ID_FOLLOW_UP_RE.search(request_text))
+        return cls._is_follow_up_request(
+            request_text=request_text,
+            descriptor=cls._WORKBOOK_IDENTIFIER,
+        )
+
+    @classmethod
+    def _is_follow_up_request(
+        cls,
+        *,
+        request_text: str,
+        descriptor: _IdentifierDescriptor,
+    ) -> bool:
+        if not request_text:
+            return False
+        return bool(descriptor.follow_up_re.search(request_text))
 
     @classmethod
     def _extract_document_id(cls, *, request_text: str) -> str:
-        return _extract_identifier_from_text(
+        return cls._extract_identifier(
             request_text=request_text,
-            explicit_capture_re=cls._DOCUMENT_ID_EXPLICIT_CAPTURE_RE,
-            bare_capture_re=cls._DOCUMENT_ID_BARE_CAPTURE_RE,
-            group_name="document_id",
-            is_valid_bare_id=cls._looks_like_bare_document_id,
+            descriptor=cls._DOCUMENT_IDENTIFIER,
         )
 
     @classmethod
     def _extract_workbook_id(cls, *, request_text: str) -> str:
+        return cls._extract_identifier(
+            request_text=request_text,
+            descriptor=cls._WORKBOOK_IDENTIFIER,
+        )
+
+    @classmethod
+    def _extract_identifier(
+        cls,
+        *,
+        request_text: str,
+        descriptor: _IdentifierDescriptor,
+    ) -> str:
         return _extract_identifier_from_text(
             request_text=request_text,
-            explicit_capture_re=cls._WORKBOOK_ID_EXPLICIT_CAPTURE_RE,
-            bare_capture_re=cls._WORKBOOK_ID_BARE_CAPTURE_RE,
-            group_name="workbook_id",
-            is_valid_bare_id=cls._looks_like_bare_workbook_id,
+            explicit_capture_re=descriptor.explicit_capture_re,
+            bare_capture_re=descriptor.bare_capture_re,
+            group_name=descriptor.group_name,
+            is_valid_bare_id=getattr(cls, descriptor.bare_validator_name),
         )
 
     @classmethod
@@ -488,28 +576,9 @@ class RequestHookService:
         *,
         request_text: str,
     ) -> PromptSection | None:
-        document_id = self._extract_document_id(request_text=request_text)
-        if not document_id:
-            return None
-        if self._lookup_document_summary is None:
-            return None
-        try:
-            summary = self._lookup_document_summary(document_id)
-        except KeyError:
-            summary = None
-        except Exception as exc:
-            logger.exception(
-                f"[文件管理] 查询文档会话摘要失败 document_id={document_id}: {exc}"
-            )
-            raise
-        if not isinstance(summary, dict):
-            return self.prompt_context_service.build_document_follow_up_missing_section(
-                document_id=document_id
-            )
-        return self.prompt_context_service.build_document_follow_up_section(
-            document_id=document_id,
-            status=str(summary.get("status") or ""),
-            block_count=int(summary.get("block_count") or 0),
+        return self._build_follow_up_section(
+            request_text=request_text,
+            strategy=self._DOCUMENT_FOLLOW_UP_STRATEGY,
         )
 
     def _build_workbook_follow_up_section(
@@ -517,36 +586,90 @@ class RequestHookService:
         *,
         request_text: str,
     ) -> PromptSection | None:
-        workbook_id = self._extract_workbook_id(request_text=request_text)
-        if not workbook_id:
+        return self._build_follow_up_section(
+            request_text=request_text,
+            strategy=self._WORKBOOK_FOLLOW_UP_STRATEGY,
+        )
+
+    def _build_follow_up_section(
+        self,
+        *,
+        request_text: str,
+        strategy: _FollowUpNoticeStrategy,
+    ) -> PromptSection | None:
+        identifier_value = self._extract_identifier(
+            request_text=request_text,
+            descriptor=strategy.identifier,
+        )
+        if not identifier_value:
             return None
-        if self._lookup_workbook_summary is None:
+
+        lookup_summary = getattr(self, strategy.lookup_attr_name)
+        if lookup_summary is None:
             return None
+
         try:
-            summary = self._lookup_workbook_summary(workbook_id)
+            summary = lookup_summary(identifier_value)
         except KeyError:
             summary = None
         except Exception as exc:
             logger.exception(
-                f"[文件管理] 查询工作簿会话摘要失败 workbook_id={workbook_id}: {exc}"
+                "[文件管理] 查询%s会话摘要失败 %s=%s: %s"
+                % (
+                    strategy.log_label,
+                    strategy.identifier.token_name,
+                    identifier_value,
+                    exc,
+                )
             )
             raise
+
         if not isinstance(summary, dict):
-            return self.prompt_context_service.build_workbook_follow_up_missing_section(
-                workbook_id=workbook_id
+            missing_builder = getattr(
+                self.prompt_context_service,
+                strategy.missing_section_builder_name,
             )
-        return self.prompt_context_service.build_workbook_follow_up_section(
-            workbook_id=workbook_id,
-            status=str(summary.get("status") or ""),
-            sheet_names=_normalize_string_list(summary.get("sheet_names")),
-            sheet_count=int(summary.get("sheet_count") or 0),
-            latest_written_sheets=_normalize_string_list(
+            return missing_builder(**{strategy.identifier.token_name: identifier_value})
+
+        section_builder = getattr(
+            self.prompt_context_service,
+            strategy.section_builder_name,
+        )
+        payload_builder = getattr(self, strategy.payload_builder_name)
+        return section_builder(
+            **payload_builder(identifier_value=identifier_value, summary=summary)
+        )
+
+    @staticmethod
+    def _build_document_follow_up_payload(
+        *,
+        identifier_value: str,
+        summary: dict[str, object],
+    ) -> dict[str, Any]:
+        return {
+            "document_id": identifier_value,
+            "status": str(summary.get("status") or ""),
+            "block_count": int(summary.get("block_count") or 0),
+        }
+
+    @staticmethod
+    def _build_workbook_follow_up_payload(
+        *,
+        identifier_value: str,
+        summary: dict[str, object],
+    ) -> dict[str, Any]:
+        return {
+            "workbook_id": identifier_value,
+            "status": str(summary.get("status") or ""),
+            "sheet_names": _normalize_string_list(summary.get("sheet_names")),
+            "sheet_count": int(summary.get("sheet_count") or 0),
+            "latest_written_sheets": _normalize_string_list(
                 summary.get("latest_written_sheets")
             ),
-            next_allowed_actions=_normalize_string_list(
+            "next_allowed_actions": _normalize_string_list(
                 summary.get("next_allowed_actions")
             ),
-        )
+        }
 
     @staticmethod
     def _append_notice_section(

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -26,6 +26,9 @@ from .upload_types import UploadInfo
 
 
 class RequestHookService:
+    _WORKBOOK_TOOL_NAMES = frozenset(
+        {"create_workbook", "write_rows", "export_workbook"}
+    )
     _DOCUMENT_ID_TOKEN_RE = r"(?<![A-Za-z0-9_])document_id(?![A-Za-z0-9_])"
     _DOCUMENT_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _DOCUMENT_ID_DOC_PREFIX_RE = re.compile(
@@ -156,7 +159,13 @@ class RequestHookService:
             return context
 
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
-        if self._is_workbook_follow_up(request_text=request_text):
+        exposed_tool_names = self._get_exposed_tool_names(context.request.func_tool)
+        workbook_tools_available = self._has_workbook_tools_available(
+            exposed_tool_names=exposed_tool_names
+        )
+        if workbook_tools_available and self._is_workbook_follow_up(
+            request_text=request_text
+        ):
             section = self._build_workbook_follow_up_section(request_text=request_text)
             if section is not None:
                 self._append_notice_section(context, section)
@@ -200,15 +209,23 @@ class RequestHookService:
                 context,
                 self.prompt_context_service.build_document_tool_detail_section(),
             )
-        if should_inject_workbook_core and self._consume_session_notice_once(
+        if (
+            workbook_tools_available
+            and should_inject_workbook_core
+            and self._consume_session_notice_once(
             context.event, self._WORKBOOK_CORE_NOTICE_KEY
+            )
         ):
             self._append_notice_section(
                 context,
                 self.prompt_context_service.build_workbook_tool_guide_section(),
             )
-        if should_inject_workbook_detail and self._consume_session_notice_once(
+        if (
+            workbook_tools_available
+            and should_inject_workbook_detail
+            and self._consume_session_notice_once(
             context.event, self._WORKBOOK_DETAIL_NOTICE_KEY
+            )
         ):
             self._append_notice_section(
                 context,
@@ -225,6 +242,17 @@ class RequestHookService:
         if match:
             return match.group("instruction").strip()
         return stripped_prompt
+
+    @classmethod
+    def _get_exposed_tool_names(cls, func_tool) -> set[str]:
+        names = getattr(func_tool, "names", None)
+        if not callable(names):
+            return set()
+        return {str(name) for name in names() if name}
+
+    @classmethod
+    def _has_workbook_tools_available(cls, *, exposed_tool_names: set[str]) -> bool:
+        return bool(cls._WORKBOOK_TOOL_NAMES.intersection(exposed_tool_names))
 
     @classmethod
     def _should_inject_document_tool_guide(cls, *, request_text: str) -> bool:

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -160,10 +160,15 @@ class RequestHookService:
 
         request_text = self._extract_prompt_text(str(context.request.prompt or ""))
         exposed_tool_names = self._get_exposed_tool_names(context.request.func_tool)
-        workbook_tools_available = self._has_workbook_tools_available(
+        workbook_follow_up_available = self._has_workbook_tools_available(
             exposed_tool_names=exposed_tool_names
         )
-        if workbook_tools_available and self._is_workbook_follow_up(
+        workbook_workflow_guide_available = (
+            self._has_full_workbook_toolset_available(
+                exposed_tool_names=exposed_tool_names
+            )
+        )
+        if workbook_follow_up_available and self._is_workbook_follow_up(
             request_text=request_text
         ):
             section = self._build_workbook_follow_up_section(request_text=request_text)
@@ -210,7 +215,7 @@ class RequestHookService:
                 self.prompt_context_service.build_document_tool_detail_section(),
             )
         if (
-            workbook_tools_available
+            workbook_workflow_guide_available
             and should_inject_workbook_core
             and self._consume_session_notice_once(
             context.event, self._WORKBOOK_CORE_NOTICE_KEY
@@ -221,7 +226,7 @@ class RequestHookService:
                 self.prompt_context_service.build_workbook_tool_guide_section(),
             )
         if (
-            workbook_tools_available
+            workbook_workflow_guide_available
             and should_inject_workbook_detail
             and self._consume_session_notice_once(
             context.event, self._WORKBOOK_DETAIL_NOTICE_KEY
@@ -253,6 +258,14 @@ class RequestHookService:
     @classmethod
     def _has_workbook_tools_available(cls, *, exposed_tool_names: set[str]) -> bool:
         return bool(cls._WORKBOOK_TOOL_NAMES.intersection(exposed_tool_names))
+
+    @classmethod
+    def _has_full_workbook_toolset_available(
+        cls,
+        *,
+        exposed_tool_names: set[str],
+    ) -> bool:
+        return cls._WORKBOOK_TOOL_NAMES.issubset(exposed_tool_names)
 
     @classmethod
     def _should_inject_document_tool_guide(cls, *, request_text: str) -> bool:

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -29,6 +29,11 @@ from .request_follow_up import (
     build_identifier_descriptor,
     extract_identifier_from_text,
 )
+from .request_hook_notice_helpers import (
+    FollowUpNoticeHelper,
+    FollowUpNoticeRule,
+    WorkbookGuideMatcher,
+)
 from .upload_types import UploadInfo
 
 
@@ -69,30 +74,6 @@ class RequestHookService:
     _WORKBOOK_ID_HEX_RE = re.compile(r"[0-9a-f]{32}", flags=re.IGNORECASE)
     _WORKBOOK_ID_PREFIX_RE = re.compile(
         r"(?:wb|workbook)-[A-Za-z0-9_-]+",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_TOOL_CALL_HINT_RE = re.compile(
-        r"(create_workbook|write_rows|export_workbook)",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_SUBJECT_HINT_RE = re.compile(
-        r"(\bexcel\b|\bxlsx\b|报表|汇总表|工作簿|多\s*sheet)",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_GENERATION_HINT_RE = re.compile(
-        r"(生成|创建|新建|制作|整理成|整理为|写入|填入|输出|导出(?:成|为)?|返回|做(?:成|个|一份)?)",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_NON_GENERATION_HINT_RE = re.compile(
-        r"(读取|阅读|查看|打开|解析|提取|分析|总结|"
-        r"导出(?:成|为)\s*pdf|"
-        r"(?:转换|转成|转为|转到).*(?:pdf|word|docx|ppt|pptx)|"
-        r"(?:pdf|word|docx|ppt|pptx).*(?:转换|转成|转为|转到)|"
-        r"\bread\b|\bopen\b|\bparse\b|\bextract\b|\banaly[sz]e\b|\bconvert\b)",
-        flags=re.IGNORECASE,
-    )
-    _WORKBOOK_DETAIL_HINT_RE = re.compile(
-        r"(create_workbook|write_rows|export_workbook|start_row|多\s*sheet)",
         flags=re.IGNORECASE,
     )
     _DOCUMENT_IDENTIFIER = build_identifier_descriptor(
@@ -148,6 +129,11 @@ class RequestHookService:
         self._lookup_workbook_summary = lookup_workbook_summary
         self.prompt_context_service = prompt_context_service or PromptContextService(
             allow_external_input_files=allow_external_input_files
+        )
+        self._follow_up_notice_helper = FollowUpNoticeHelper(
+            is_follow_up_request=self._is_follow_up_request,
+            build_follow_up_section=self._build_follow_up_section,
+            append_notice_section=self._append_notice_section,
         )
         self._notice_hooks = [
             self.append_office_tool_guide_notice,
@@ -251,54 +237,20 @@ class RequestHookService:
             else self._has_full_workbook_toolset_available
         )
         follow_up_rules = (
-            (
-                self._WORKBOOK_FOLLOW_UP_STRATEGY,
-                workbook_availability_checker,
+            FollowUpNoticeRule(
+                strategy=self._WORKBOOK_FOLLOW_UP_STRATEGY,
+                availability_checker=lambda names: workbook_availability_checker(
+                    exposed_tool_names=names
+                ),
             ),
-            (
-                self._DOCUMENT_FOLLOW_UP_STRATEGY,
-                None,
-            ),
+            FollowUpNoticeRule(strategy=self._DOCUMENT_FOLLOW_UP_STRATEGY),
         )
-        for strategy, availability_checker in follow_up_rules:
-            if self._append_follow_up_notice(
-                context,
-                request_text=request_text,
-                exposed_tool_names=exposed_tool_names,
-                strategy=strategy,
-                availability_checker=availability_checker,
-            ):
-                return True
-        return False
-
-    def _append_follow_up_notice(
-        self,
-        context: NoticeBuildContext,
-        *,
-        request_text: str,
-        exposed_tool_names: set[str],
-        strategy: FollowUpNoticeStrategy,
-        availability_checker: Callable[..., bool] | None,
-    ) -> bool:
-        if availability_checker is not None and not availability_checker(
-            exposed_tool_names=exposed_tool_names
-        ):
-            return False
-        if not self._is_follow_up_request(
+        return self._follow_up_notice_helper.append_first_matching_notice(
+            context,
             request_text=request_text,
-            descriptor=strategy.identifier,
-        ):
-            return False
-
-        section = self._build_follow_up_section(
-            request_text=request_text,
-            strategy=strategy,
+            exposed_tool_names=exposed_tool_names,
+            rules=follow_up_rules,
         )
-        if section is None:
-            return False
-
-        self._append_notice_section(context, section)
-        return True
 
     def _append_document_tool_guides(
         self,
@@ -340,12 +292,12 @@ class RequestHookService:
         ):
             return
 
-        should_inject_core = self._should_inject_workbook_tool_guide(
-            request_text=request_text
+        workbook_guide_decision = WorkbookGuideMatcher.detect(
+            request_text=request_text,
+            workbook_follow_up_re=self._WORKBOOK_IDENTIFIER.follow_up_re,
         )
-        should_inject_detail = self._should_inject_workbook_tool_detail(
-            request_text=request_text
-        )
+        should_inject_core = workbook_guide_decision.inject_core
+        should_inject_detail = workbook_guide_decision.inject_detail
         if not should_inject_core and not should_inject_detail:
             return
 
@@ -379,30 +331,6 @@ class RequestHookService:
         if not request_text:
             return False
         return bool(cls._DOCUMENT_DETAIL_HINT_RE.search(request_text))
-
-    @classmethod
-    def _should_inject_workbook_tool_guide(cls, *, request_text: str) -> bool:
-        if not request_text:
-            return False
-        if cls._WORKBOOK_TOOL_CALL_HINT_RE.search(request_text):
-            return True
-        if cls._WORKBOOK_IDENTIFIER.follow_up_re.search(request_text):
-            return True
-        if not cls._WORKBOOK_SUBJECT_HINT_RE.search(request_text):
-            return False
-        if not cls._WORKBOOK_GENERATION_HINT_RE.search(request_text):
-            return False
-        return not cls._WORKBOOK_NON_GENERATION_HINT_RE.search(request_text)
-
-    @classmethod
-    def _should_inject_workbook_tool_detail(
-        cls,
-        *,
-        request_text: str,
-    ) -> bool:
-        if not request_text:
-            return False
-        return bool(cls._WORKBOOK_DETAIL_HINT_RE.search(request_text))
 
     @classmethod
     def _is_document_follow_up(cls, *, request_text: str) -> bool:

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -8,6 +8,10 @@ from astrbot.api import logger
 from astrbot.api.star import StarTools
 
 from ..agent_tools import build_document_toolset
+try:
+    from ..agent_tools import build_workbook_toolset
+except ImportError:  # pragma: no cover - workbook toolset may be introduced incrementally
+    build_workbook_toolset = None
 from ..app.runtime import (
     AdminUsersResolver,
     FileProcessingServices,
@@ -123,11 +127,16 @@ def build_plugin_runtime(
         render_backend_config=document_render_backend_config,
         default_document_style=default_document_style,
     )
+    workbook_toolset = _build_workbook_toolset(
+        workspace_dir=plugin_data_path,
+        after_export=handle_exported_document_tool,
+    )
     request_pipeline_services = _build_request_pipeline_services(
         settings=settings,
         upload_session_service=upload_session_service,
         access_policy_service=access_policy_service,
         document_toolset=document_toolset,
+        workbook_toolset=workbook_toolset,
         extract_upload_source=extract_upload_source,
         store_uploaded_file=store_uploaded_file,
     )
@@ -180,6 +189,7 @@ def build_plugin_runtime(
         access_policy_service=access_policy_service,
         upload_session_service=upload_session_service,
         document_toolset=document_toolset,
+        workbook_toolset=workbook_toolset,
         llm_request_policy=request_pipeline_services.llm_request_policy,
         prompt_context_service=request_pipeline_services.prompt_context_service,
         delivery_service=delivery_service,
@@ -229,9 +239,10 @@ def _build_request_pipeline_services(
     upload_session_service: UploadSessionService,
     access_policy_service: AccessPolicyService,
     document_toolset,
+    workbook_toolset,
     extract_upload_source,
     store_uploaded_file,
-    ) -> RequestPipelineServices:
+) -> RequestPipelineServices:
     prompt_context_service = PromptContextService(
         allow_external_input_files=settings.allow_external_input_files
     )
@@ -245,9 +256,11 @@ def _build_request_pipeline_services(
         allow_external_input_files=settings.allow_external_input_files,
         prompt_context_service=prompt_context_service,
         lookup_document_summary=_build_document_summary_lookup(document_toolset),
+        lookup_workbook_summary=_build_workbook_summary_lookup(workbook_toolset),
     )
     llm_request_policy = LLMRequestPolicy(
         document_toolset=document_toolset,
+        workbook_toolset=workbook_toolset,
         require_at_in_group=settings.require_at_in_group,
         is_group_feature_enabled=access_policy_service.is_group_feature_enabled,
         check_permission=access_policy_service.check_permission,
@@ -268,6 +281,29 @@ def _build_document_summary_lookup(document_toolset):
     if not callable(build_prompt_summary):
         logger.warning(
             "[文件管理] document_store.build_prompt_summary 不可用，文档跟进提示将退化为普通工具指南"
+        )
+        return None
+    return build_prompt_summary
+
+
+def _build_workbook_toolset(*, workspace_dir: Path, after_export):
+    if build_workbook_toolset is None:
+        logger.info("[文件管理] build_workbook_toolset 不可用，跳过 workbook 原语工具挂载")
+        return None
+    return build_workbook_toolset(
+        workspace_dir=workspace_dir,
+        after_export=after_export,
+    )
+
+
+def _build_workbook_summary_lookup(workbook_toolset):
+    if workbook_toolset is None:
+        return None
+    workbook_store = getattr(workbook_toolset, "workbook_store", None)
+    build_prompt_summary = getattr(workbook_store, "build_prompt_summary", None)
+    if not callable(build_prompt_summary):
+        logger.warning(
+            "[文件管理] workbook_store.build_prompt_summary 不可用，工作簿跟进提示将退化为普通工具指南"
         )
         return None
     return build_prompt_summary

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -290,10 +290,14 @@ def _build_workbook_toolset(*, workspace_dir: Path, after_export):
     if build_workbook_toolset is None:
         logger.info("[文件管理] build_workbook_toolset 不可用，跳过 workbook 原语工具挂载")
         return None
-    return build_workbook_toolset(
-        workspace_dir=workspace_dir,
-        after_export=after_export,
-    )
+    try:
+        return build_workbook_toolset(
+            workspace_dir=workspace_dir,
+            after_export=after_export,
+        )
+    except ImportError as exc:
+        logger.warning(f"[文件管理] workbook 原语工具依赖不可用，跳过挂载: {exc}")
+        return None
 
 
 def _build_workbook_summary_lookup(workbook_toolset):

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -2825,7 +2825,7 @@ async def test_mcp_write_rows_rejects_oversized_row_window():
 async def test_mcp_registers_only_document_tools_when_workbook_store_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.setattr(mcp_server_module, "WorkbookSessionStore", None)
+    monkeypatch.setattr(mcp_server_module, "_load_workbook_session_store", lambda: None)
 
     server = create_server()
     tools = await server.list_tools()
@@ -2840,6 +2840,44 @@ async def test_mcp_registers_only_document_tools_when_workbook_store_is_unavaila
     assert "create_workbook" not in server.instructions
 
 
+def test_mcp_workbook_loader_logs_import_error_and_disables_support(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _raise_import_error(_module_name: str):
+        raise ModuleNotFoundError("missing workbook deps")
+
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        _raise_import_error,
+    )
+
+    with patch.object(mcp_server_module.logger, "warning") as warning_mock:
+        result = mcp_server_module._load_workbook_session_store()
+
+    assert result is None
+    warning_mock.assert_called_once()
+
+
+def test_mcp_workbook_loader_reraises_non_import_errors(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def _raise_runtime_error(_module_name: str):
+        raise NameError("boom")
+
+    monkeypatch.setattr(
+        mcp_server_module.importlib,
+        "import_module",
+        _raise_runtime_error,
+    )
+
+    with patch.object(mcp_server_module.logger, "warning") as warning_mock:
+        with pytest.raises(NameError, match="boom"):
+            mcp_server_module._load_workbook_session_store()
+
+    warning_mock.assert_not_called()
+
+
 def test_mcp_create_server_constructs_workbook_store_once(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -2851,7 +2889,9 @@ def test_mcp_create_server_constructs_workbook_store_once(
 
     register_mock = MagicMock()
     monkeypatch.setattr(
-        mcp_server_module, "WorkbookSessionStore", StubWorkbookSessionStore
+        mcp_server_module,
+        "_load_workbook_session_store",
+        lambda: StubWorkbookSessionStore,
     )
     monkeypatch.setattr(mcp_server_module, "register_workbook_tools", register_mock)
 

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -184,6 +184,29 @@ async def test_write_rows_tool_returns_targeted_retry_message_for_validation_err
 
 
 @pytest.mark.asyncio
+async def test_write_rows_tool_preserves_invalid_zero_start_row(
+    workspace_root: Path,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = WriteRowsTool(store=store)
+
+    result = json.loads(
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["value"]],
+            start_row=0,
+        )
+    )
+
+    assert result["success"] is False
+    assert "only fix invalid fields" in result["message"]
+    assert "greater than or equal to 1" in result["message"]
+
+
+@pytest.mark.asyncio
 async def test_write_rows_tool_returns_neutral_message_for_state_errors(
     workspace_root: Path,
 ):

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -83,6 +83,7 @@ from astrbot_plugin_office_assistant.domain.document.contracts import (
     normalize_create_document_kwargs,
     normalize_raw_block_payloads,
 )
+import astrbot_plugin_office_assistant.mcp_server.server as mcp_server_module
 from astrbot_plugin_office_assistant.mcp_server.server import (
     create_server,
 )
@@ -2620,6 +2621,44 @@ async def test_mcp_registers_document_and_workbook_tools():
     assert add_blocks_items["type"] == "object"
     assert add_blocks_items["additionalProperties"] is True
     assert write_rows_tool.inputSchema["required"] == ["workbook_id", "sheet", "rows"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_registers_only_document_tools_when_workbook_store_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(mcp_server_module, "WorkbookSessionStore", None)
+
+    server = create_server()
+    tools = await server.list_tools()
+
+    assert [tool.name for tool in tools] == [
+        "create_document",
+        "add_blocks",
+        "finalize_document",
+        "export_document",
+    ]
+
+
+def test_mcp_create_server_constructs_workbook_store_once(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    constructed_workspaces: list[Path | None] = []
+
+    class StubWorkbookSessionStore:
+        def __init__(self, workspace_dir=None):
+            constructed_workspaces.append(workspace_dir)
+
+    register_mock = MagicMock()
+    monkeypatch.setattr(
+        mcp_server_module, "WorkbookSessionStore", StubWorkbookSessionStore
+    )
+    monkeypatch.setattr(mcp_server_module, "register_workbook_tools", register_mock)
+
+    create_server()
+
+    assert constructed_workspaces == [None]
+    register_mock.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -97,16 +97,13 @@ from astrbot_plugin_office_assistant.mcp_server.server import (
 )
 from astrbot_plugin_office_assistant.tools.mcp_adapter import (
     register_document_tools_from_registry,
-    register_workbook_tools_from_registry,
 )
 from astrbot_plugin_office_assistant.tools.astrbot_adapter import (
     build_document_toolset_from_registry,
-    build_workbook_toolset_from_registry,
 )
 from astrbot_plugin_office_assistant.tools.registry import (
     DocumentToolSpec,
     get_document_tool_specs,
-    get_workbook_tool_specs,
 )
 from pydantic import ValidationError
 
@@ -348,22 +345,6 @@ def test_astrbot_toolset_preserves_document_tool_registry_order():
     ]
 
 
-def test_workbook_tool_registry_keeps_workbook_tool_order():
-    assert [spec.name for spec in get_workbook_tool_specs()] == [
-        "create_workbook",
-        "write_rows",
-        "export_workbook",
-    ]
-
-
-def test_astrbot_toolset_preserves_workbook_tool_registry_order():
-    toolset = build_workbook_toolset_from_registry()
-
-    assert [tool.name for tool in toolset.tools] == [
-        spec.name for spec in get_workbook_tool_specs()
-    ]
-
-
 def test_build_document_toolset_defaults_to_node_only_for_word():
     toolset = build_document_toolset()
     export_tool = next(tool for tool in toolset.tools if tool.name == "export_document")
@@ -517,38 +498,6 @@ def test_mcp_document_tool_registration_matches_registry_order(
     )
 
     assert registered_names == [spec.name for spec in get_document_tool_specs()]
-
-
-def test_mcp_workbook_tool_registration_matches_registry_order(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    registered_names: list[str] = []
-
-    def _make_registrar(name: str):
-        def _record(*_args, **_kwargs):
-            registered_names.append(name)
-
-        return _record
-
-    monkeypatch.setattr(
-        "astrbot_plugin_office_assistant.mcp_server.tools.create_workbook.register_create_workbook_tool",
-        _make_registrar("create_workbook"),
-    )
-    monkeypatch.setattr(
-        "astrbot_plugin_office_assistant.mcp_server.tools.write_rows.register_write_rows_tool",
-        _make_registrar("write_rows"),
-    )
-    monkeypatch.setattr(
-        "astrbot_plugin_office_assistant.mcp_server.tools.export_workbook.register_export_workbook_tool",
-        _make_registrar("export_workbook"),
-    )
-
-    register_workbook_tools_from_registry(
-        server=MagicMock(),
-        store=MagicMock(),
-    )
-
-    assert registered_names == [spec.name for spec in get_workbook_tool_specs()]
 
 
 def test_mcp_document_tool_registration_passes_export_hooks(

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -19,6 +19,7 @@ from astrbot_plugin_office_assistant.agent_tools import (
     build_document_toolset,
     build_workbook_toolset,
 )
+from astrbot_plugin_office_assistant.agent_tools.workbook_tools import WriteRowsTool
 from astrbot_plugin_office_assistant.agent_tools.document_tools import (
     CreateDocumentTool,
 )
@@ -31,6 +32,12 @@ from astrbot_plugin_office_assistant.document_core.macros.summary_card import (
 )
 from astrbot_plugin_office_assistant.domain.document.session_store import (
     DocumentSessionStore,
+)
+from astrbot_plugin_office_assistant.domain.workbook.contracts import (
+    CreateWorkbookRequest,
+)
+from astrbot_plugin_office_assistant.domain.workbook.session_store import (
+    WorkbookSessionStore,
 )
 from astrbot_plugin_office_assistant.domain.document.export_pipeline import (
     export_document_via_pipeline,
@@ -152,6 +159,51 @@ def test_build_workbook_toolset_uses_shared_store_and_default_workspace():
         / "workbooks"
     )
     assert stores[0].workspace_dir == expected_workspace
+
+
+@pytest.mark.asyncio
+async def test_write_rows_tool_returns_targeted_retry_message_for_validation_errors(
+    workspace_root: Path,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = WriteRowsTool(store=store)
+
+    result = json.loads(
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["=SUM(A1:A2)"]],
+        )
+    )
+
+    assert result["success"] is False
+    assert "only fix invalid fields" in result["message"]
+    assert "Original error" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_write_rows_tool_returns_neutral_message_for_state_errors(
+    workspace_root: Path,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    workbook.status = "exported"
+    tool = WriteRowsTool(store=store)
+
+    result = json.loads(
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["value"]],
+        )
+    )
+
+    assert result["success"] is False
+    assert result["message"].startswith("write_rows failed:")
+    assert "only fix invalid fields" not in result["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -17,6 +17,7 @@ import pytest
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 from astrbot_plugin_office_assistant.agent_tools import (
     build_document_toolset,
+    build_workbook_toolset,
 )
 from astrbot_plugin_office_assistant.agent_tools.document_tools import (
     CreateDocumentTool,
@@ -87,13 +88,16 @@ from astrbot_plugin_office_assistant.mcp_server.server import (
 )
 from astrbot_plugin_office_assistant.tools.mcp_adapter import (
     register_document_tools_from_registry,
+    register_workbook_tools_from_registry,
 )
 from astrbot_plugin_office_assistant.tools.astrbot_adapter import (
     build_document_toolset_from_registry,
+    build_workbook_toolset_from_registry,
 )
 from astrbot_plugin_office_assistant.tools.registry import (
     DocumentToolSpec,
     get_document_tool_specs,
+    get_workbook_tool_specs,
 )
 from pydantic import ValidationError
 
@@ -123,6 +127,28 @@ def test_build_document_toolset_uses_shared_store_and_default_workspace():
         Path(get_astrbot_plugin_data_path())
         / "astrbot_plugin_office_assistant"
         / "documents"
+    )
+    assert stores[0].workspace_dir == expected_workspace
+
+
+def test_build_workbook_toolset_uses_shared_store_and_default_workspace():
+    toolset = build_workbook_toolset()
+    tool_names = [tool.name for tool in toolset.tools]
+
+    assert tool_names == [
+        "create_workbook",
+        "write_rows",
+        "export_workbook",
+    ]
+
+    stores = [tool.store for tool in toolset.tools if hasattr(tool, "store")]
+    assert len(stores) == len(tool_names)
+    assert len({id(store) for store in stores}) == 1
+
+    expected_workspace = (
+        Path(get_astrbot_plugin_data_path())
+        / "astrbot_plugin_office_assistant"
+        / "workbooks"
     )
     assert stores[0].workspace_dir == expected_workspace
 
@@ -219,6 +245,22 @@ def test_astrbot_toolset_preserves_document_tool_registry_order():
 
     assert [tool.name for tool in toolset.tools] == [
         spec.name for spec in get_document_tool_specs()
+    ]
+
+
+def test_workbook_tool_registry_keeps_workbook_tool_order():
+    assert [spec.name for spec in get_workbook_tool_specs()] == [
+        "create_workbook",
+        "write_rows",
+        "export_workbook",
+    ]
+
+
+def test_astrbot_toolset_preserves_workbook_tool_registry_order():
+    toolset = build_workbook_toolset_from_registry()
+
+    assert [tool.name for tool in toolset.tools] == [
+        spec.name for spec in get_workbook_tool_specs()
     ]
 
 
@@ -375,6 +417,38 @@ def test_mcp_document_tool_registration_matches_registry_order(
     )
 
     assert registered_names == [spec.name for spec in get_document_tool_specs()]
+
+
+def test_mcp_workbook_tool_registration_matches_registry_order(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    registered_names: list[str] = []
+
+    def _make_registrar(name: str):
+        def _record(*_args, **_kwargs):
+            registered_names.append(name)
+
+        return _record
+
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.mcp_server.tools.create_workbook.register_create_workbook_tool",
+        _make_registrar("create_workbook"),
+    )
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.mcp_server.tools.write_rows.register_write_rows_tool",
+        _make_registrar("write_rows"),
+    )
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.mcp_server.tools.export_workbook.register_export_workbook_tool",
+        _make_registrar("export_workbook"),
+    )
+
+    register_workbook_tools_from_registry(
+        server=MagicMock(),
+        store=MagicMock(),
+    )
+
+    assert registered_names == [spec.name for spec in get_workbook_tool_specs()]
 
 
 def test_mcp_document_tool_registration_passes_export_hooks(
@@ -2523,7 +2597,7 @@ async def test_document_toolset_runs_before_export_hooks(workspace_root: Path):
 
 
 @pytest.mark.asyncio
-async def test_mcp_registers_only_core_document_tools():
+async def test_mcp_registers_document_and_workbook_tools():
     server = create_server()
     tools = await server.list_tools()
     tool_names = [tool.name for tool in tools]
@@ -2533,14 +2607,19 @@ async def test_mcp_registers_only_core_document_tools():
         "add_blocks",
         "finalize_document",
         "export_document",
+        "create_workbook",
+        "write_rows",
+        "export_workbook",
     ]
 
     add_blocks_tool = next(tool for tool in tools if tool.name == "add_blocks")
+    write_rows_tool = next(tool for tool in tools if tool.name == "write_rows")
 
     assert add_blocks_tool.inputSchema["required"] == ["document_id", "blocks"]
     add_blocks_items = add_blocks_tool.inputSchema["properties"]["blocks"]["items"]
     assert add_blocks_items["type"] == "object"
     assert add_blocks_items["additionalProperties"] is True
+    assert write_rows_tool.inputSchema["required"] == ["workbook_id", "sheet", "rows"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -19,7 +19,11 @@ from astrbot_plugin_office_assistant.agent_tools import (
     build_document_toolset,
     build_workbook_toolset,
 )
-from astrbot_plugin_office_assistant.agent_tools.workbook_tools import WriteRowsTool
+from astrbot_plugin_office_assistant.agent_tools.workbook_tools import (
+    CreateWorkbookTool,
+    ExportWorkbookTool,
+    WriteRowsTool,
+)
 from astrbot_plugin_office_assistant.agent_tools.document_tools import (
     CreateDocumentTool,
 )
@@ -182,6 +186,34 @@ async def test_write_rows_tool_returns_targeted_retry_message_for_validation_err
 
 
 @pytest.mark.asyncio
+async def test_create_workbook_tool_wraps_expected_store_errors(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    tool = CreateWorkbookTool(store=store)
+    monkeypatch.setattr(store, "create_workbook", MagicMock(side_effect=OSError("disk full")))
+
+    result = json.loads(await tool.call(None, filename="rows.xlsx"))
+
+    assert result["success"] is False
+    assert result["message"] == "create_workbook failed: disk full"
+
+
+@pytest.mark.asyncio
+async def test_create_workbook_tool_reraises_unexpected_store_errors(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    tool = CreateWorkbookTool(store=store)
+    monkeypatch.setattr(store, "create_workbook", MagicMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await tool.call(None, filename="rows.xlsx")
+
+
+@pytest.mark.asyncio
 async def test_write_rows_tool_preserves_invalid_zero_start_row(
     workspace_root: Path,
 ):
@@ -248,6 +280,63 @@ async def test_write_rows_tool_returns_neutral_message_for_state_errors(
     assert result["success"] is False
     assert result["message"].startswith("write_rows failed:")
     assert "only fix invalid fields" not in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_write_rows_tool_reraises_unexpected_store_errors(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = WriteRowsTool(store=store)
+    monkeypatch.setattr(store, "write_rows", MagicMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["value"]],
+        )
+
+
+@pytest.mark.asyncio
+async def test_export_workbook_tool_wraps_expected_validation_errors(
+    workspace_root: Path,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = ExportWorkbookTool(store=store)
+
+    result = json.loads(
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            output_name="C:/temp/final.xlsx",
+        )
+    )
+
+    assert result["success"] is False
+    assert result["message"].startswith("export_workbook failed:")
+    assert "must not be an absolute path" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_export_workbook_tool_reraises_unexpected_store_errors(
+    workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = ExportWorkbookTool(store=store)
+    monkeypatch.setattr(store, "export_workbook", MagicMock(side_effect=RuntimeError("boom")))
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -2676,6 +2676,44 @@ async def test_mcp_registers_document_and_workbook_tools():
 
 
 @pytest.mark.asyncio
+async def test_mcp_write_rows_returns_structured_failure_for_unknown_workbook():
+    server = create_server()
+
+    _, payload = await server.call_tool(
+        "write_rows",
+        {
+            "workbook_id": "wb-missing",
+            "sheet": "Data",
+            "rows": [["value"]],
+        },
+    )
+
+    assert payload["success"] is False
+    assert payload["message"].startswith("write_rows failed:")
+
+
+@pytest.mark.asyncio
+async def test_mcp_write_rows_returns_structured_failure_for_validation_errors():
+    server = create_server()
+    _, created_payload = await server.call_tool(
+        "create_workbook",
+        {"filename": "validation.xlsx"},
+    )
+
+    _, payload = await server.call_tool(
+        "write_rows",
+        {
+            "workbook_id": created_payload["workbook"]["workbook_id"],
+            "sheet": "Data",
+            "rows": [["=SUM(A1:A2)"]],
+        },
+    )
+
+    assert payload["success"] is False
+    assert "only fix invalid fields" in payload["message"]
+
+
+@pytest.mark.asyncio
 async def test_mcp_registers_only_document_tools_when_workbook_store_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -2728,6 +2728,8 @@ async def test_mcp_registers_only_document_tools_when_workbook_store_is_unavaila
         "finalize_document",
         "export_document",
     ]
+    assert "Excel" not in server.instructions
+    assert "create_workbook" not in server.instructions
 
 
 def test_mcp_create_server_constructs_workbook_store_once(

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -35,6 +35,7 @@ from astrbot_plugin_office_assistant.domain.document.session_store import (
 )
 from astrbot_plugin_office_assistant.domain.workbook.contracts import (
     CreateWorkbookRequest,
+    MAX_WORKBOOK_ROW_INDEX,
 )
 from astrbot_plugin_office_assistant.domain.workbook.session_store import (
     WorkbookSessionStore,
@@ -204,6 +205,29 @@ async def test_write_rows_tool_preserves_invalid_zero_start_row(
     assert result["success"] is False
     assert "only fix invalid fields" in result["message"]
     assert "greater than or equal to 1" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_write_rows_tool_rejects_oversized_start_row(
+    workspace_root: Path,
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+    tool = WriteRowsTool(store=store)
+
+    result = json.loads(
+        await tool.call(
+            None,
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["value"]],
+            start_row=MAX_WORKBOOK_ROW_INDEX + 1,
+        )
+    )
+
+    assert result["success"] is False
+    assert "only fix invalid fields" in result["message"]
+    assert "less than or equal to" in result["message"]
 
 
 @pytest.mark.asyncio
@@ -2734,6 +2758,29 @@ async def test_mcp_write_rows_returns_structured_failure_for_validation_errors()
 
     assert payload["success"] is False
     assert "only fix invalid fields" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_mcp_write_rows_rejects_oversized_row_window():
+    server = create_server()
+    _, created_payload = await server.call_tool(
+        "create_workbook",
+        {"filename": "validation.xlsx"},
+    )
+
+    _, payload = await server.call_tool(
+        "write_rows",
+        {
+            "workbook_id": created_payload["workbook"]["workbook_id"],
+            "sheet": "Data",
+            "rows": [["value"], ["overflow"]],
+            "start_row": MAX_WORKBOOK_ROW_INDEX,
+        },
+    )
+
+    assert payload["success"] is False
+    assert "only fix invalid fields" in payload["message"]
+    assert "final written row must not exceed" in payload["message"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -7,6 +7,9 @@ from astrbot_plugin_office_assistant.constants import DOC_COMMAND_TRIGGER_EVENT_
 from astrbot_plugin_office_assistant.domain.document.contracts import (
     CreateDocumentRequest,
 )
+from astrbot_plugin_office_assistant.domain.workbook.contracts import (
+    CreateWorkbookRequest,
+)
 from astrbot_plugin_office_assistant.internal_hooks import (
     NoticeBuildContext,
     ToolExposureContext,
@@ -163,6 +166,78 @@ async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
         assert "文件工具使用指南" not in req.prompt
         assert "当前文档状态摘要" not in req.prompt
         assert "文件工具细节指南" not in req.prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_injects_workbook_tools_per_request():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        req = ProviderRequest(
+            prompt="请生成一个 Excel 汇总表，分多 sheet 输出给我。",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("astrbot_execute_shell"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "astrbot_execute_shell" not in tool_names
+        assert {
+            "create_workbook",
+            "write_rows",
+            "export_workbook",
+        }.issubset(tool_names)
+        assert "Excel 原语工具使用指南" in req.prompt
+        assert "create_workbook" in req.prompt
+        assert "write_rows" in req.prompt
+        assert "export_workbook" in req.prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_keeps_workbook_id_follow_up_prompt_lightweight():
+    context = MagicMock()
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        req = ProviderRequest(
+            prompt='继续补充 workbook_id="wb-1" 的数据',
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("create_workbook"),
+                ]
+            ),
+        )
+        workbook_store = plugin._runtime.workbook_toolset.workbook_store
+        workbook = workbook_store.create_workbook(
+            CreateWorkbookRequest(filename="sales-summary.xlsx")
+        )
+
+        req.prompt = f'继续补充 workbook_id="{workbook.workbook_id}" 的数据'
+
+        await plugin.before_llm_chat(event, req)
+
+        assert "Excel 原语工具使用指南" not in req.system_prompt
+        assert "Excel 原语工具使用指南" not in req.prompt
+        assert "当前工作簿阶段" in req.prompt
+        assert "`create_workbook` → `write_rows`" not in req.prompt
     finally:
         await plugin.terminate()
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2363,6 +2363,36 @@ async def test_request_hook_service_injects_workbook_core_and_detail_notices():
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_guide_when_workbook_tools_are_unavailable():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请用 create_workbook 和 write_rows 生成 xlsx 报表，多 sheet，start_row=2",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("existing_tool")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_lookup_disabled():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -2392,6 +2422,44 @@ async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_l
     assert context.section_names == [SECTION_STATIC_WORKBOOK_TOOLS]
     assert "create_workbook" in context.notices[0]
     assert "export_workbook" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_follow_up_when_workbook_tools_are_unavailable():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=lambda workbook_id: {
+            "workbook_id": workbook_id,
+            "status": "draft",
+            "sheet_names": ["Sheet1"],
+            "sheet_count": 1,
+            "latest_written_sheets": ["Sheet1"],
+            "next_allowed_actions": ["write_rows"],
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='继续补充 workbook_id="wb-11" 的数据',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("existing_tool")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
 
 
 def test_prompt_context_service_orders_notice_sections_by_stability():

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1581,6 +1581,45 @@ async def test_request_hook_service_injects_workbook_follow_up_notice_for_draft(
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_filters_none_values_from_workbook_follow_up_notice():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=lambda workbook_id: {
+            "workbook_id": workbook_id,
+            "status": "draft",
+            "sheet_names": [None, "总表", "   "],
+            "sheet_count": 1,
+            "latest_written_sheets": [None, "华东"],
+            "next_allowed_actions": [None, "write_rows", " "],
+        },
+    )
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt='继续补充 workbook_id="wb-2" 的数据',
+            system_prompt="base",
+            func_tool=ToolSet([_tool("write_rows")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        notices=[],
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert "None" not in context.notices[0]
+    assert "总表" in context.notices[0]
+    assert "华东" in context.notices[0]
+    assert "write_rows" in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_workbook_follow_up_notice_for_missing_summary():
     service = RequestHookService(
         auto_block_execution_tools=True,

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2345,7 +2345,13 @@ async def test_request_hook_service_injects_workbook_core_and_detail_notices():
             request=ProviderRequest(
                 prompt="请用 create_workbook 和 write_rows 生成 xlsx 报表，多 sheet，start_row=2",
                 system_prompt="base",
-                func_tool=ToolSet([_tool("create_workbook")]),
+                func_tool=ToolSet(
+                    [
+                        _tool("create_workbook"),
+                        _tool("write_rows"),
+                        _tool("export_workbook"),
+                    ]
+                ),
             ),
             should_expose=True,
             can_process_upload=True,
@@ -2410,7 +2416,13 @@ async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_l
             request=ProviderRequest(
                 prompt='请返回 workbook_id 并导出 workbook_id="wb-11" 的 xlsx',
                 system_prompt="base",
-                func_tool=ToolSet([_tool("export_workbook")]),
+                func_tool=ToolSet(
+                    [
+                        _tool("create_workbook"),
+                        _tool("write_rows"),
+                        _tool("export_workbook"),
+                    ]
+                ),
             ),
             should_expose=True,
             can_process_upload=True,
@@ -2422,6 +2434,37 @@ async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_l
     assert context.section_names == [SECTION_STATIC_WORKBOOK_TOOLS]
     assert "create_workbook" in context.notices[0]
     assert "export_workbook" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_guide_for_partial_workbook_toolset():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='请返回 workbook_id 并导出 workbook_id="wb-11" 的 xlsx',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_workbook")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1220,6 +1220,45 @@ async def test_request_hook_service_builds_default_tool_hooks():
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_skips_explicit_restriction_for_unavailable_workbook_tool():
+    request = ProviderRequest(
+        prompt="请调用 create_workbook",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_file"),
+                _tool("create_document"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=_build_event(),
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name="create_workbook",
+    )
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_file" in tool_names
+    assert "create_document" in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+    assert "create_workbook" not in tool_names
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_merges_multiple_uploaded_files_into_one_notice():
     request = ProviderRequest(
         prompt="根据上传文件整理内容",

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -47,6 +47,7 @@ from astrbot_plugin_office_assistant.services import (
 )
 from astrbot_plugin_office_assistant.services.runtime_builder import (
     _build_document_summary_lookup,
+    _build_workbook_toolset,
     _build_workbook_summary_lookup,
 )
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
@@ -2065,6 +2066,27 @@ def test_runtime_builder_uses_workbook_summary_lookup_when_available():
 
     assert lookup is build_prompt_summary
     assert lookup("wb-1") == {"status": "draft"}
+
+
+def test_runtime_builder_skips_workbook_toolset_when_builder_raises_import_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.services.runtime_builder.build_workbook_toolset",
+        MagicMock(side_effect=ModuleNotFoundError("missing workbook dependency")),
+    )
+
+    with patch(
+        "astrbot_plugin_office_assistant.services.runtime_builder.logger.warning"
+    ) as mock_warning:
+        toolset = _build_workbook_toolset(
+            workspace_dir=Path.cwd(),
+            after_export=AsyncMock(),
+        )
+
+    assert toolset is None
+    mock_warning.assert_called_once()
+    assert "workbook 原语工具依赖不可用" in mock_warning.call_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2438,6 +2438,78 @@ async def test_request_hook_service_skips_workbook_guide_when_workbook_tools_are
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_guide_for_reading_xlsx_requests():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请读取这个 xlsx 文件并告诉我内容",
+                system_prompt="base",
+                func_tool=ToolSet(
+                    [
+                        _tool("create_workbook"),
+                        _tool("write_rows"),
+                        _tool("export_workbook"),
+                    ]
+                ),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_guide_for_xlsx_to_pdf_conversion_requests():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请把这个 xlsx 导出成 PDF",
+                system_prompt="base",
+                func_tool=ToolSet(
+                    [
+                        _tool("create_workbook"),
+                        _tool("write_rows"),
+                        _tool("export_workbook"),
+                    ]
+                ),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_lookup_disabled():
     service = RequestHookService(
         auto_block_execution_tools=True,

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2616,6 +2616,44 @@ async def test_request_hook_service_skips_workbook_follow_up_when_workbook_tools
     assert context.notices == []
 
 
+@pytest.mark.asyncio
+async def test_request_hook_service_skips_workbook_follow_up_for_partial_workbook_toolset():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=lambda workbook_id: {
+            "workbook_id": workbook_id,
+            "status": "draft",
+            "sheet_names": ["Sheet1"],
+            "sheet_count": 1,
+            "latest_written_sheets": ["Sheet1"],
+            "next_allowed_actions": ["write_rows"],
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='继续补充 workbook_id="wb-11" 的数据',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_workbook")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name="export_workbook",
+            notices=[],
+        )
+    )
+
+    assert context.section_names == []
+    assert context.notices == []
+
+
 def test_prompt_context_service_orders_notice_sections_by_stability():
     service = PromptContextService(allow_external_input_files=False)
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -47,12 +47,16 @@ from astrbot_plugin_office_assistant.services import (
 )
 from astrbot_plugin_office_assistant.services.runtime_builder import (
     _build_document_summary_lookup,
+    _build_workbook_summary_lookup,
 )
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+    SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
     SECTION_SCENE_UPLOADED_CONTEXT,
     SECTION_STATIC_DOCUMENT_TOOLS,
     SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
+    SECTION_STATIC_WORKBOOK_TOOLS,
+    SECTION_STATIC_WORKBOOK_TOOLS_DETAIL,
     PromptContextService,
 )
 from astrbot_plugin_office_assistant.utils import (
@@ -471,6 +475,37 @@ async def test_llm_request_policy_handles_events_without_get_extra():
 
     assert "read_file" not in set(request.func_tool.names())
     assert "当前聊天不可使用文件/Office/PDF 相关功能" in request.system_prompt
+
+
+@pytest.mark.asyncio
+async def test_llm_request_policy_exposes_document_and_workbook_toolsets_together():
+    event = _build_event(
+        sender_id="1474436119298048127",
+        message_type=MessageType.FRIEND_MESSAGE,
+    )
+    request = ProviderRequest(
+        prompt="请生成 Excel 报表",
+        system_prompt="base",
+        func_tool=ToolSet([_tool("existing_tool")]),
+    )
+    policy = LLMRequestPolicy(
+        document_toolset=ToolSet([_tool("create_document")]),
+        workbook_toolset=ToolSet([_tool("create_workbook"), _tool("write_rows")]),
+        require_at_in_group=True,
+        is_group_feature_enabled=lambda _event: True,
+        check_permission=lambda _event: True,
+        is_bot_mentioned=lambda _event: True,
+        notice_hooks=[],
+        tool_exposure_hooks=[],
+    )
+
+    await policy.apply(event, request)
+
+    tool_names = set(request.func_tool.names())
+    assert "create_document" in tool_names
+    assert "create_workbook" in tool_names
+    assert "write_rows" in tool_names
+    assert "existing_tool" in tool_names
 
 
 def test_build_plugin_runtime_returns_temp_workspace_and_services():
@@ -1505,6 +1540,121 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_draft(
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_workbook_follow_up_notice_for_draft():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=lambda workbook_id: {
+            "workbook_id": workbook_id,
+            "status": "draft",
+            "sheet_names": ["总表", "华东"],
+            "sheet_count": 2,
+            "latest_written_sheets": ["华东"],
+            "next_allowed_actions": ["write_rows", "export_workbook"],
+        },
+    )
+    context = NoticeBuildContext(
+        event=_build_event(),
+        request=ProviderRequest(
+            prompt='继续补充 workbook_id="wb-1" 的数据',
+            system_prompt="base",
+            func_tool=ToolSet([_tool("create_workbook")]),
+        ),
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+        notices=[],
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert context.section_names == [SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP]
+    assert "当前 `workbook_id=wb-1` 仍是 draft" in context.notices[0]
+    assert "继续调用 `write_rows`" in context.notices[0]
+    assert context.system_notices == []
+    assert context.system_section_names == []
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_workbook_follow_up_notice_for_missing_summary():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=lambda _workbook_id: None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='继续处理 workbook_id="wb-missing"',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("write_rows")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP]
+    assert "没有找到 `workbook_id=wb-missing` 对应的工作簿会话" in context.notices[0]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_prioritizes_workbook_follow_up_when_workbook_id_present():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 1,
+        },
+        lookup_workbook_summary=lambda workbook_id: {
+            "workbook_id": workbook_id,
+            "status": "draft",
+            "sheet_names": ["Sheet1"],
+            "sheet_count": 1,
+            "latest_written_sheets": ["Sheet1"],
+            "next_allowed_actions": ["write_rows"],
+        },
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='document_id="doc-7"，同时继续 workbook_id="wb-7"',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("write_rows")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP]
+    assert "workbook_id=wb-7" in context.notices[0]
+    assert "document_id=doc-7" not in context.notices[0]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_space_separated_document_id():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -1893,6 +2043,30 @@ def test_runtime_builder_uses_document_summary_lookup_when_available():
     assert lookup("doc-1") == {"status": "draft"}
 
 
+def test_runtime_builder_returns_none_when_workbook_summary_lookup_is_unavailable():
+    workbook_toolset = SimpleNamespace(workbook_store=SimpleNamespace())
+
+    with patch(
+        "astrbot_plugin_office_assistant.services.runtime_builder.logger.warning"
+    ) as mock_warning:
+        lookup = _build_workbook_summary_lookup(workbook_toolset)
+
+    assert lookup is None
+    mock_warning.assert_called_once()
+
+
+def test_runtime_builder_uses_workbook_summary_lookup_when_available():
+    build_prompt_summary = MagicMock(return_value={"status": "draft"})
+    workbook_toolset = SimpleNamespace(
+        workbook_store=SimpleNamespace(build_prompt_summary=build_prompt_summary)
+    )
+
+    lookup = _build_workbook_summary_lookup(workbook_toolset)
+
+    assert lookup is build_prompt_summary
+    assert lookup("wb-1") == {"status": "draft"}
+
+
 @pytest.mark.asyncio
 async def test_request_hook_service_reraises_unexpected_summary_lookup_errors():
     service = RequestHookService(
@@ -1949,6 +2123,30 @@ def test_prompt_context_service_orders_dynamic_document_notice_after_scene_notic
         SECTION_STATIC_DOCUMENT_TOOLS,
         SECTION_SCENE_UPLOADED_CONTEXT,
         SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+    ]
+    assert ordered_notices == ["static", "scene", "dynamic"]
+
+
+def test_prompt_context_service_orders_dynamic_workbook_notice_after_scene_notice():
+    service = PromptContextService(allow_external_input_files=False)
+
+    ordered_names, ordered_notices = service.order_notice_sections(
+        section_names=[
+            SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
+            SECTION_SCENE_UPLOADED_CONTEXT,
+            SECTION_STATIC_WORKBOOK_TOOLS,
+        ],
+        notices=[
+            "dynamic",
+            "scene",
+            "static",
+        ],
+    )
+
+    assert ordered_names == [
+        SECTION_STATIC_WORKBOOK_TOOLS,
+        SECTION_SCENE_UPLOADED_CONTEXT,
+        SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
     ]
     assert ordered_notices == ["static", "scene", "dynamic"]
 
@@ -2067,6 +2265,72 @@ async def test_request_hook_service_allows_detail_notice_without_core_when_only_
     )
 
     assert context.section_names == [SECTION_STATIC_DOCUMENT_TOOLS_DETAIL]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_injects_workbook_core_and_detail_notices():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请用 create_workbook 和 write_rows 生成 xlsx 报表，多 sheet，start_row=2",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("create_workbook")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_WORKBOOK_TOOLS,
+        SECTION_STATIC_WORKBOOK_TOOLS_DETAIL,
+    ]
+    assert "create_workbook" in context.notices[0]
+    assert "write_rows" in context.notices[0]
+    assert "create_office_file" in context.notices[1]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_lookup_disabled():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+        lookup_workbook_summary=None,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt='请返回 workbook_id 并导出 workbook_id="wb-11" 的 xlsx',
+                system_prompt="base",
+                func_tool=ToolSet([_tool("export_workbook")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [SECTION_STATIC_WORKBOOK_TOOLS]
+    assert "create_workbook" in context.notices[0]
+    assert "export_workbook" in context.notices[0]
 
 
 def test_prompt_context_service_orders_notice_sections_by_stability():

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -208,6 +208,39 @@ def test_export_rejects_output_path_outside_workspace(workspace_root: Path):
         store.export_workbook(escaped_request)
 
 
+def test_prepare_export_path_keeps_workbook_exports_inside_workspace(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+
+    _, output_path = store.prepare_export_path(
+        ExportWorkbookRequest(
+            workbook_id=workbook.workbook_id,
+            output_name="reports/q1/final-report",
+        )
+    )
+
+    assert output_path == (workspace_root / "reports" / "q1" / "final-report.xlsx").resolve()
+
+    _, windows_style_output_path = store.prepare_export_path(
+        ExportWorkbookRequest(
+            workbook_id=workbook.workbook_id,
+            output_name=r"reports\windows\final-report",
+        )
+    )
+
+    assert (
+        windows_style_output_path
+        == (workspace_root / "reports" / "windows" / "final-report.xlsx").resolve()
+    )
+
+    escaped_request = ExportWorkbookRequest.model_construct(
+        workbook_id=workbook.workbook_id,
+        output_name="../outside/final-report.xlsx",
+    )
+    with pytest.raises(ValueError, match="escape the workbook workspace"):
+        store.prepare_export_path(escaped_request)
+
+
 def test_exporter_writes_values_and_header_style(workspace_root: Path):
     store = WorkbookSessionStore(workspace_dir=workspace_root)
     workbook = store.create_workbook(CreateWorkbookRequest(filename="styled.xlsx"))
@@ -480,6 +513,7 @@ def test_create_workbook_keeps_new_draft_when_store_is_capped_by_exporting_workb
     export_started = Event()
     release_export = Event()
     create_finished = Event()
+    export_error: list[Exception] = []
     create_error: list[Exception] = []
     created_workbook_ids: list[str] = []
 
@@ -563,6 +597,79 @@ def test_export_workbook_resets_status_after_export_failure(
 
     loaded = store.require_workbook(workbook.workbook_id)
     assert loaded.output_path == ""
+
+
+def test_failed_export_prunes_store_back_to_cap(
+    workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root, max_workbooks=1)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    export_started = Event()
+    release_export = Event()
+    create_finished = Event()
+    export_error: list[Exception] = []
+    create_error: list[Exception] = []
+    created_workbook_ids: list[str] = []
+
+    def fake_export(_workbook_model, _output_path):
+        export_started.set()
+        release_export.wait(timeout=5)
+        raise RuntimeError("disk full")
+
+    def run_export():
+        try:
+            store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+        except Exception as exc:  # pragma: no cover - asserted via captured error
+            export_error.append(exc)
+
+    def run_create_and_write():
+        try:
+            other = store.create_workbook(CreateWorkbookRequest(filename="other.xlsx"))
+            created_workbook_ids.append(other.workbook_id)
+            store.write_rows(
+                WriteRowsRequest(
+                    workbook_id=other.workbook_id,
+                    sheet="Data",
+                    rows=[["value"]],
+                )
+            )
+        except Exception as exc:  # pragma: no cover - asserted via captured error
+            create_error.append(exc)
+        finally:
+            create_finished.set()
+
+    monkeypatch.setattr(workbook_session_store_module, "export_workbook_to_xlsx", fake_export)
+
+    export_thread = Thread(target=run_export)
+    create_thread = Thread(target=run_create_and_write)
+
+    export_thread.start()
+    assert export_started.wait(timeout=5)
+
+    create_thread.start()
+    assert create_finished.wait(timeout=0.2)
+    assert create_error == []
+    assert created_workbook_ids == ["wb-2"]
+    assert store.get_workbook(created_workbook_ids[0]) is not None
+
+    release_export.set()
+    export_thread.join(timeout=5)
+    create_thread.join(timeout=5)
+
+    assert len(export_error) == 1
+    assert "disk full" in str(export_error[0])
+    failed_summary = store.build_prompt_summary(workbook.workbook_id)
+    assert failed_summary["status"] == "draft"
+    assert failed_summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
+    assert store.get_workbook(created_workbook_ids[0]) is None
 
 
 def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -335,7 +335,7 @@ def test_exported_workbook_compacts_rows_but_keeps_summary(workspace_root: Path)
     assert summary["sheet_count"] == 1
 
 
-def test_export_workbook_blocks_concurrent_writes_until_export_finishes(
+def test_export_workbook_rejects_same_workbook_writes_without_waiting_for_export(
     workspace_root: Path, monkeypatch: pytest.MonkeyPatch
 ):
     store = WorkbookSessionStore(workspace_dir=workspace_root)
@@ -387,7 +387,7 @@ def test_export_workbook_blocks_concurrent_writes_until_export_finishes(
     assert export_started.wait(timeout=5)
     write_thread.start()
 
-    assert not write_finished.wait(timeout=0.2)
+    assert write_finished.wait(timeout=0.2)
 
     release_export.set()
     export_thread.join(timeout=5)
@@ -395,6 +395,102 @@ def test_export_workbook_blocks_concurrent_writes_until_export_finishes(
 
     assert len(write_error) == 1
     assert "status is draft" in str(write_error[0])
+
+
+def test_export_workbook_allows_other_workbook_operations_while_writing_file(
+    workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    export_started = Event()
+    release_export = Event()
+    other_finished = Event()
+    other_error: list[Exception] = []
+    other_workbook_ids: list[str] = []
+
+    def fake_export(workbook_model, output_path):
+        export_started.set()
+        release_export.wait(timeout=5)
+        output_path.write_text("xlsx", encoding="utf-8")
+        return output_path
+
+    def run_export():
+        store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    def run_other_workbook_ops():
+        try:
+            other = store.create_workbook(CreateWorkbookRequest(filename="other.xlsx"))
+            other_workbook_ids.append(other.workbook_id)
+            store.write_rows(
+                WriteRowsRequest(
+                    workbook_id=other.workbook_id,
+                    sheet="Data",
+                    rows=[["value"]],
+                )
+            )
+        except Exception as exc:  # pragma: no cover - asserted via captured error
+            other_error.append(exc)
+        finally:
+            other_finished.set()
+
+    monkeypatch.setattr(workbook_session_store_module, "export_workbook_to_xlsx", fake_export)
+
+    export_thread = Thread(target=run_export)
+    other_thread = Thread(target=run_other_workbook_ops)
+
+    export_thread.start()
+    assert export_started.wait(timeout=5)
+    assert store.build_prompt_summary(workbook.workbook_id)["status"] == "exporting"
+
+    other_thread.start()
+    assert other_finished.wait(timeout=0.2)
+
+    release_export.set()
+    export_thread.join(timeout=5)
+    other_thread.join(timeout=5)
+
+    assert other_error == []
+    assert other_workbook_ids == ["wb-2"]
+    other_summary = store.build_prompt_summary(other_workbook_ids[0])
+    assert other_summary["status"] == "draft"
+    assert other_summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
+
+
+def test_export_workbook_resets_status_after_export_failure(
+    workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    def fake_export(_workbook_model, _output_path):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(workbook_session_store_module, "export_workbook_to_xlsx", fake_export)
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    summary = store.build_prompt_summary(workbook.workbook_id)
+    assert summary["status"] == "draft"
+    assert summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
+
+    loaded = store.require_workbook(workbook.workbook_id)
+    assert loaded.output_path == ""
 
 
 def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1,0 +1,204 @@
+from pathlib import Path
+
+import pytest
+from openpyxl import load_workbook
+from pydantic import ValidationError
+
+from astrbot_plugin_office_assistant.domain.workbook.contracts import (
+    CreateWorkbookRequest,
+    ExportWorkbookRequest,
+    WriteRowsRequest,
+    build_workbook_summary,
+)
+from astrbot_plugin_office_assistant.domain.workbook.session_store import (
+    WorkbookSessionStore,
+)
+
+
+def test_create_workbook_returns_draft_summary(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(
+        CreateWorkbookRequest(
+            session_id="pytest-session",
+            filename="sales-report",
+        )
+    )
+
+    summary = store.build_prompt_summary(workbook.workbook_id)
+
+    assert workbook.workbook_id == "wb-1"
+    assert workbook.metadata.title == "sales-report"
+    assert workbook.metadata.preferred_filename == "sales-report.xlsx"
+    assert summary == {
+        "workbook_id": workbook.workbook_id,
+        "title": "sales-report",
+        "status": "draft",
+        "sheet_names": [],
+        "sheet_count": 0,
+        "latest_written_sheets": [],
+        "next_allowed_actions": ["write_rows", "export_workbook"],
+    }
+
+
+def test_write_rows_creates_sheet_and_overwrites_range(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Summary",
+            rows=[
+                ["name", "amount"],
+                ["A", 10],
+            ],
+            start_row=1,
+        )
+    )
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Summary",
+            rows=[
+                ["A", 99],
+                ["B", 35],
+            ],
+            start_row=2,
+        )
+    )
+
+    loaded = store.require_workbook(workbook.workbook_id)
+    worksheet = loaded.get_sheet("Summary")
+    assert worksheet is not None
+    assert worksheet.rows == [
+        ["name", "amount"],
+        ["A", 99],
+        ["B", 35],
+    ]
+
+    prompt_summary = store.build_prompt_summary(workbook.workbook_id)
+    assert prompt_summary["sheet_names"] == ["Summary"]
+    assert prompt_summary["latest_written_sheets"] == ["Summary"]
+
+
+def test_write_rows_rejects_non_primitive_cell_values():
+    with pytest.raises(ValidationError):
+        WriteRowsRequest(
+            workbook_id="wb-1",
+            sheet="Data",
+            rows=[[{"invalid": True}]],  # type: ignore[list-item]
+            start_row=1,
+        )
+
+
+def test_write_rows_rejects_formula_cells():
+    with pytest.raises(ValidationError, match="not supported"):
+        WriteRowsRequest(
+            workbook_id="wb-1",
+            sheet="Data",
+            rows=[["=SUM(A1:A2)"]],
+            start_row=1,
+        )
+
+
+def test_export_request_rejects_absolute_output_name():
+    with pytest.raises(ValidationError, match="must not be an absolute path"):
+        ExportWorkbookRequest(
+            workbook_id="wb-1",
+            output_name="C:/temp/final.xlsx",
+        )
+
+
+def test_exporter_writes_values_and_header_style(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="styled.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Sales",
+            rows=[
+                ["name", "amount"],
+                ["A", 123.5],
+            ],
+        )
+    )
+
+    exported_workbook, output_path = store.export_workbook(
+        ExportWorkbookRequest(
+            workbook_id=workbook.workbook_id,
+            output_name="styled-output.xlsx",
+        )
+    )
+
+    loaded = load_workbook(output_path)
+    sheet = loaded["Sales"]
+
+    assert exported_workbook.status.value == "exported"
+    assert output_path.name == "styled-output.xlsx"
+    assert sheet["A1"].value == "name"
+    assert sheet["B2"].value == 123.5
+    assert sheet["A1"].font.bold is True
+    assert sheet["A1"].fill.patternType == "solid"
+    assert (sheet["A1"].fill.fgColor.rgb or "").endswith("D9D9D9")
+    assert sheet["A1"].alignment.horizontal == "left"
+    assert sheet["A1"].alignment.vertical == "center"
+    assert sheet["A2"].alignment.horizontal == "left"
+    assert sheet["A2"].font.bold is False
+
+
+def test_exported_workbook_disallows_more_writes_or_reexport(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+    store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    with pytest.raises(ValueError, match="status is draft"):
+        store.write_rows(
+            WriteRowsRequest(
+                workbook_id=workbook.workbook_id,
+                sheet="Data",
+                rows=[["v2"]],
+                start_row=3,
+            )
+        )
+
+    with pytest.raises(ValueError, match="status is draft"):
+        store.export_workbook(
+            ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+        )
+
+    summary = store.build_prompt_summary(workbook.workbook_id)
+    assert summary["status"] == "exported"
+    assert summary["next_allowed_actions"] == []
+
+
+def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="book.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="One",
+            rows=[["c1"], ["v1"]],
+        )
+    )
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Two",
+            rows=[["c1"], ["v2"]],
+        )
+    )
+
+    summary = build_workbook_summary(store.require_workbook(workbook.workbook_id))
+
+    assert summary.workbook_id == workbook.workbook_id
+    assert summary.sheet_count == 2
+    assert summary.sheet_names == ["One", "Two"]
+    assert summary.latest_written_sheets == ["One", "Two"]

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -84,6 +84,37 @@ def test_write_rows_creates_sheet_and_overwrites_range(workspace_root: Path):
     assert prompt_summary["latest_written_sheets"] == ["Summary"]
 
 
+def test_write_rows_reuses_sheet_with_case_insensitive_name(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="rows.xlsx"))
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Sales",
+            rows=[["name", "amount"]],
+            start_row=1,
+        )
+    )
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="sales",
+            rows=[["A", 10]],
+            start_row=2,
+        )
+    )
+
+    loaded = store.require_workbook(workbook.workbook_id)
+    assert len(loaded.worksheets) == 1
+    assert loaded.worksheets[0].name == "Sales"
+    assert loaded.worksheets[0].rows == [["name", "amount"], ["A", 10]]
+
+    prompt_summary = store.build_prompt_summary(workbook.workbook_id)
+    assert prompt_summary["sheet_names"] == ["Sales"]
+    assert prompt_summary["latest_written_sheets"] == ["Sales"]
+
+
 def test_write_rows_rejects_non_primitive_cell_values():
     with pytest.raises(ValidationError):
         WriteRowsRequest(
@@ -314,3 +345,32 @@ def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):
     assert summary.sheet_count == 2
     assert summary.sheet_names == ["One", "Two"]
     assert summary.latest_written_sheets == ["One", "Two"]
+
+
+def test_case_insensitive_sheet_lookup_preserves_exported_sheet_name(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="book.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Sales",
+            rows=[["name"], ["A"]],
+        )
+    )
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="sales",
+            rows=[["B"]],
+            start_row=3,
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+
+    assert loaded.sheetnames == ["Sales"]
+    sheet = loaded["Sales"]
+    assert sheet["A3"].value == "B"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -20,6 +20,7 @@ def test_create_workbook_returns_draft_summary(workspace_root: Path):
     workbook = store.create_workbook(
         CreateWorkbookRequest(
             session_id="pytest-session",
+            title="季度销量汇总",
             filename="sales-report",
         )
     )
@@ -27,11 +28,11 @@ def test_create_workbook_returns_draft_summary(workspace_root: Path):
     summary = store.build_prompt_summary(workbook.workbook_id)
 
     assert workbook.workbook_id == "wb-1"
-    assert workbook.metadata.title == "sales-report"
+    assert workbook.metadata.title == "季度销量汇总"
     assert workbook.metadata.preferred_filename == "sales-report.xlsx"
     assert summary == {
         "workbook_id": workbook.workbook_id,
-        "title": "sales-report",
+        "title": "季度销量汇总",
         "status": "draft",
         "sheet_names": [],
         "sheet_count": 0,
@@ -107,6 +108,18 @@ def test_export_request_rejects_absolute_output_name():
             workbook_id="wb-1",
             output_name="C:/temp/final.xlsx",
         )
+
+
+def test_export_rejects_output_path_outside_workspace(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    escaped_request = ExportWorkbookRequest.model_construct(
+        workbook_id=workbook.workbook_id,
+        output_name="../evil.xlsx",
+    )
+
+    with pytest.raises(ValueError, match="escape the workbook workspace"):
+        store.export_workbook(escaped_request)
 
 
 def test_exporter_writes_values_and_header_style(workspace_root: Path):

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from astrbot_plugin_office_assistant.domain.workbook.contracts import (
     CreateWorkbookRequest,
     ExportWorkbookRequest,
+    MAX_WORKBOOK_ROW_INDEX,
     WriteRowsRequest,
     build_workbook_summary,
 )
@@ -156,6 +157,26 @@ def test_write_rows_rejects_formula_cells():
             sheet="Data",
             rows=[["=SUM(A1:A2)"]],
             start_row=1,
+        )
+
+
+def test_write_rows_rejects_start_row_beyond_limit():
+    with pytest.raises(ValidationError, match="less than or equal to"):
+        WriteRowsRequest(
+            workbook_id="wb-1",
+            sheet="Data",
+            rows=[["value"]],
+            start_row=MAX_WORKBOOK_ROW_INDEX + 1,
+        )
+
+
+def test_write_rows_rejects_final_row_beyond_limit():
+    with pytest.raises(ValidationError, match="final written row must not exceed"):
+        WriteRowsRequest(
+            workbook_id="wb-1",
+            sheet="Data",
+            rows=[["value"], ["overflow"]],
+            start_row=MAX_WORKBOOK_ROW_INDEX,
         )
 
 

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -464,6 +464,78 @@ def test_export_workbook_allows_other_workbook_operations_while_writing_file(
     assert other_summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
 
 
+def test_create_workbook_keeps_new_draft_when_store_is_capped_by_exporting_workbook(
+    workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root, max_workbooks=1)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    export_started = Event()
+    release_export = Event()
+    create_finished = Event()
+    create_error: list[Exception] = []
+    created_workbook_ids: list[str] = []
+
+    def fake_export(workbook_model, output_path):
+        export_started.set()
+        release_export.wait(timeout=5)
+        output_path.write_text("xlsx", encoding="utf-8")
+        return output_path
+
+    def run_export():
+        store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    def run_create_and_write():
+        try:
+            other = store.create_workbook(CreateWorkbookRequest(filename="other.xlsx"))
+            created_workbook_ids.append(other.workbook_id)
+            store.write_rows(
+                WriteRowsRequest(
+                    workbook_id=other.workbook_id,
+                    sheet="Data",
+                    rows=[["value"]],
+                )
+            )
+        except Exception as exc:  # pragma: no cover - asserted via captured error
+            create_error.append(exc)
+        finally:
+            create_finished.set()
+
+    monkeypatch.setattr(workbook_session_store_module, "export_workbook_to_xlsx", fake_export)
+
+    export_thread = Thread(target=run_export)
+    create_thread = Thread(target=run_create_and_write)
+
+    export_thread.start()
+    assert export_started.wait(timeout=5)
+
+    create_thread.start()
+    assert create_finished.wait(timeout=0.2)
+
+    assert create_error == []
+    assert created_workbook_ids == ["wb-2"]
+    created_summary = store.build_prompt_summary(created_workbook_ids[0])
+    assert created_summary["status"] == "draft"
+    assert created_summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
+
+    release_export.set()
+    export_thread.join(timeout=5)
+    create_thread.join(timeout=5)
+
+    assert store.get_workbook(workbook.workbook_id) is None
+    assert store.get_workbook(created_workbook_ids[0]) is not None
+    created_summary = store.build_prompt_summary(created_workbook_ids[0])
+    assert created_summary["status"] == "draft"
+    assert created_summary["next_allowed_actions"] == ["write_rows", "export_workbook"]
+
+
 def test_export_workbook_resets_status_after_export_failure(
     workspace_root: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Event, Thread
 
@@ -41,6 +42,29 @@ def test_create_workbook_returns_draft_summary(workspace_root: Path):
         "latest_written_sheets": [],
         "next_allowed_actions": ["write_rows", "export_workbook"],
     }
+
+
+def test_workbook_session_store_evicts_oldest_workbooks_when_capped():
+    store = WorkbookSessionStore(max_workbooks=2)
+    first = store.create_workbook(CreateWorkbookRequest(title="first"))
+    second = store.create_workbook(CreateWorkbookRequest(title="second"))
+    third = store.create_workbook(CreateWorkbookRequest(title="third"))
+
+    assert store.get_workbook(first.workbook_id) is None
+    assert store.get_workbook(second.workbook_id) is not None
+    assert store.get_workbook(third.workbook_id) is not None
+
+
+def test_workbook_session_store_evicts_expired_workbooks_by_ttl():
+    store = WorkbookSessionStore(ttl=timedelta(seconds=1))
+    expired = store.create_workbook(CreateWorkbookRequest(title="expired"))
+    fresh = store.create_workbook(CreateWorkbookRequest(title="fresh"))
+
+    expired.metadata.updated_at = datetime.now(timezone.utc) - timedelta(seconds=5)
+    fresh.metadata.updated_at = datetime.now(timezone.utc)
+
+    assert store.get_workbook(expired.workbook_id) is None
+    assert store.get_workbook(fresh.workbook_id) is not None
 
 
 def test_write_rows_creates_sheet_and_overwrites_range(workspace_root: Path):
@@ -257,6 +281,29 @@ def test_exported_workbook_disallows_more_writes_or_reexport(workspace_root: Pat
     summary = store.build_prompt_summary(workbook.workbook_id)
     assert summary["status"] == "exported"
     assert summary["next_allowed_actions"] == []
+
+
+def test_exported_workbook_compacts_rows_but_keeps_summary(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="compact.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    exported_workbook = store.require_workbook(workbook.workbook_id)
+    assert exported_workbook.worksheets[0].name == "Data"
+    assert exported_workbook.worksheets[0].rows == []
+
+    summary = store.build_prompt_summary(workbook.workbook_id)
+    assert summary["status"] == "exported"
+    assert summary["sheet_names"] == ["Data"]
+    assert summary["sheet_count"] == 1
 
 
 def test_export_workbook_blocks_concurrent_writes_until_export_finishes(

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -519,6 +519,41 @@ def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):
     assert summary.latest_written_sheets == ["One", "Two"]
 
 
+def test_prompt_summary_reuses_shared_workbook_summary_fields(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(
+        CreateWorkbookRequest(
+            session_id="pytest-session",
+            title="季度汇总",
+            filename="book.xlsx",
+        )
+    )
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="总表",
+            rows=[["列1"], ["值1"]],
+        )
+    )
+
+    workbook_summary = build_workbook_summary(
+        store.require_workbook(workbook.workbook_id)
+    ).model_dump()
+    prompt_summary = store.build_prompt_summary(workbook.workbook_id)
+
+    shared_keys = (
+        "workbook_id",
+        "title",
+        "status",
+        "sheet_names",
+        "sheet_count",
+        "latest_written_sheets",
+    )
+    assert {key: prompt_summary[key] for key in shared_keys} == {
+        key: workbook_summary[key] for key in shared_keys
+    }
+
+
 def test_case_insensitive_sheet_lookup_preserves_exported_sheet_name(workspace_root: Path):
     store = WorkbookSessionStore(workspace_dir=workspace_root)
     workbook = store.create_workbook(CreateWorkbookRequest(filename="book.xlsx"))

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from threading import Event, Thread
 
 import pytest
 from openpyxl import load_workbook
@@ -13,6 +14,7 @@ from astrbot_plugin_office_assistant.domain.workbook.contracts import (
 from astrbot_plugin_office_assistant.domain.workbook.session_store import (
     WorkbookSessionStore,
 )
+import astrbot_plugin_office_assistant.domain.workbook.session_store as workbook_session_store_module
 
 
 def test_create_workbook_returns_draft_summary(workspace_root: Path):
@@ -159,6 +161,41 @@ def test_exporter_writes_values_and_header_style(workspace_root: Path):
     assert sheet["A2"].font.bold is False
 
 
+def test_exporter_applies_worksheet_options(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="options.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Sales",
+            rows=[
+                ["name", "amount"],
+                ["A", 123.5],
+            ],
+        )
+    )
+    worksheet = store.require_workbook(workbook.workbook_id).get_sheet("Sales")
+    assert worksheet is not None
+    worksheet.options.freeze_panes = "B2"
+    worksheet.options.column_widths = {"A": 20.0, "B": 15.5}
+    worksheet.options.autofilter = True
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(
+            workbook_id=workbook.workbook_id,
+            output_name="options-output.xlsx",
+        )
+    )
+
+    loaded = load_workbook(output_path)
+    sheet = loaded["Sales"]
+
+    assert sheet.freeze_panes == "B2"
+    assert sheet.column_dimensions["A"].width == pytest.approx(20.0)
+    assert sheet.column_dimensions["B"].width == pytest.approx(15.5)
+    assert sheet.auto_filter.ref == "A1:B2"
+
+
 def test_exported_workbook_disallows_more_writes_or_reexport(workspace_root: Path):
     store = WorkbookSessionStore(workspace_dir=workspace_root)
     workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
@@ -189,6 +226,68 @@ def test_exported_workbook_disallows_more_writes_or_reexport(workspace_root: Pat
     summary = store.build_prompt_summary(workbook.workbook_id)
     assert summary["status"] == "exported"
     assert summary["next_allowed_actions"] == []
+
+
+def test_export_workbook_blocks_concurrent_writes_until_export_finishes(
+    workspace_root: Path, monkeypatch: pytest.MonkeyPatch
+):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="status.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["h1"], ["v1"]],
+        )
+    )
+
+    export_started = Event()
+    release_export = Event()
+    write_finished = Event()
+    write_error: list[Exception] = []
+
+    def fake_export(workbook_model, output_path):
+        export_started.set()
+        assert not write_finished.is_set()
+        release_export.wait(timeout=5)
+        output_path.write_text("xlsx", encoding="utf-8")
+        return output_path
+
+    def run_export():
+        store.export_workbook(ExportWorkbookRequest(workbook_id=workbook.workbook_id))
+
+    def run_write():
+        try:
+            store.write_rows(
+                WriteRowsRequest(
+                    workbook_id=workbook.workbook_id,
+                    sheet="Data",
+                    rows=[["v2"]],
+                    start_row=3,
+                )
+            )
+        except Exception as exc:  # pragma: no cover - asserted via captured error
+            write_error.append(exc)
+        finally:
+            write_finished.set()
+
+    monkeypatch.setattr(workbook_session_store_module, "export_workbook_to_xlsx", fake_export)
+
+    export_thread = Thread(target=run_export)
+    write_thread = Thread(target=run_write)
+
+    export_thread.start()
+    assert export_started.wait(timeout=5)
+    write_thread.start()
+
+    assert not write_finished.wait(timeout=0.2)
+
+    release_export.set()
+    export_thread.join(timeout=5)
+    write_thread.join(timeout=5)
+
+    assert len(write_error) == 1
+    assert "status is draft" in str(write_error[0])
 
 
 def test_build_workbook_summary_includes_sheet_names(workspace_root: Path):

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -159,11 +159,19 @@ def test_write_rows_rejects_formula_cells():
         )
 
 
-def test_export_request_rejects_absolute_output_name():
+@pytest.mark.parametrize(
+    "output_name",
+    [
+        "C:/temp/final.xlsx",
+        "/tmp/final.xlsx",
+        "~/final.xlsx",
+    ],
+)
+def test_export_request_rejects_absolute_output_name(output_name: str):
     with pytest.raises(ValidationError, match="must not be an absolute path"):
         ExportWorkbookRequest(
             workbook_id="wb-1",
-            output_name="C:/temp/final.xlsx",
+            output_name=output_name,
         )
 
 

--- a/tests/test_workbook_tool_registry.py
+++ b/tests/test_workbook_tool_registry.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from astrbot_plugin_office_assistant.agent_tools import build_workbook_toolset
+from astrbot_plugin_office_assistant.tools.astrbot_adapter import (
+    build_workbook_toolset_from_registry,
+)
+from astrbot_plugin_office_assistant.tools.mcp_adapter import (
+    register_workbook_tools_from_registry,
+)
+from astrbot_plugin_office_assistant.tools.registry import (
+    WorkbookToolSpec,
+    get_document_tool_specs,
+    get_workbook_tool_specs,
+)
+
+
+def test_workbook_tool_registry_keeps_workbook_tool_order():
+    assert [spec.name for spec in get_workbook_tool_specs()] == [
+        "create_workbook",
+        "write_rows",
+        "export_workbook",
+    ]
+
+
+def test_document_tool_registry_keeps_document_tool_order_after_workbook_extension():
+    assert [spec.name for spec in get_document_tool_specs()] == [
+        "create_document",
+        "add_blocks",
+        "finalize_document",
+        "export_document",
+    ]
+
+
+def test_astrbot_workbook_toolset_preserves_registry_order(
+    monkeypatch,
+):
+    fake_store = object()
+    captured_after_export = {}
+
+    def _factory(name: str):
+        def _build(store, after_export):
+            captured_after_export[name] = after_export
+            return SimpleNamespace(name=name, store=store)
+
+        return _build
+
+    specs = (
+        WorkbookToolSpec(
+            name="create_workbook",
+            astrbot_factory=_factory("create_workbook"),
+            mcp_registrar=lambda *_args, **_kwargs: None,
+        ),
+        WorkbookToolSpec(
+            name="write_rows",
+            astrbot_factory=_factory("write_rows"),
+            mcp_registrar=lambda *_args, **_kwargs: None,
+        ),
+        WorkbookToolSpec(
+            name="export_workbook",
+            astrbot_factory=_factory("export_workbook"),
+            mcp_registrar=lambda *_args, **_kwargs: None,
+        ),
+    )
+
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.tools.astrbot_adapter.build_workbook_store",
+        lambda workspace_dir=None: fake_store,
+    )
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.tools.astrbot_adapter.get_workbook_tool_specs",
+        lambda: specs,
+    )
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.tools.astrbot_adapter.WorkbookToolSet",
+        lambda tools, *, workbook_store: SimpleNamespace(
+            tools=list(tools), workbook_store=workbook_store
+        ),
+    )
+
+    async def _after_export(_context, _path):
+        return None
+
+    toolset = build_workbook_toolset_from_registry(after_export=_after_export)
+
+    assert [tool.name for tool in toolset.tools] == [spec.name for spec in specs]
+    assert toolset.workbook_store is fake_store
+    assert captured_after_export["export_workbook"] is _after_export
+
+
+def test_agent_factory_build_workbook_toolset_delegates_to_adapter(
+    monkeypatch,
+):
+    fake_toolset = SimpleNamespace(tools=[])
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.agent_tools.factory.build_workbook_toolset_from_registry",
+        lambda workspace_dir=None, after_export=None: fake_toolset,
+    )
+    result = build_workbook_toolset()
+    assert result is fake_toolset
+
+
+def test_mcp_workbook_tool_registration_matches_registry_order(
+    monkeypatch,
+):
+    registered_names: list[str] = []
+
+    def _make_registrar(name: str):
+        def _record(*_args, **_kwargs):
+            registered_names.append(name)
+
+        return _record
+
+    specs = (
+        WorkbookToolSpec(
+            name="create_workbook",
+            astrbot_factory=lambda *_args, **_kwargs: None,
+            mcp_registrar=_make_registrar("create_workbook"),
+        ),
+        WorkbookToolSpec(
+            name="write_rows",
+            astrbot_factory=lambda *_args, **_kwargs: None,
+            mcp_registrar=_make_registrar("write_rows"),
+        ),
+        WorkbookToolSpec(
+            name="export_workbook",
+            astrbot_factory=lambda *_args, **_kwargs: None,
+            mcp_registrar=_make_registrar("export_workbook"),
+        ),
+    )
+    monkeypatch.setattr(
+        "astrbot_plugin_office_assistant.tools.mcp_adapter.get_workbook_tool_specs",
+        lambda: specs,
+    )
+
+    register_workbook_tools_from_registry(
+        server=SimpleNamespace(),
+        store=SimpleNamespace(),
+    )
+
+    assert registered_names == [spec.name for spec in specs]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,3 +1,13 @@
-from .registry import DocumentToolSpec, get_document_tool_specs
+from .registry import (
+    DocumentToolSpec,
+    WorkbookToolSpec,
+    get_document_tool_specs,
+    get_workbook_tool_specs,
+)
 
-__all__ = ["DocumentToolSpec", "get_document_tool_specs"]
+__all__ = [
+    "DocumentToolSpec",
+    "WorkbookToolSpec",
+    "get_document_tool_specs",
+    "get_workbook_tool_specs",
+]

--- a/tools/astrbot_adapter.py
+++ b/tools/astrbot_adapter.py
@@ -11,12 +11,17 @@ from ..domain.document.render_backends import DocumentRenderBackendConfig
 from .registry import (
     AfterExportCallback,
     AstrBotDocumentTool,
+    AstrBotWorkbookTool,
+    WorkbookAfterExportCallback,
     build_document_store,
+    build_workbook_store,
     get_document_tool_specs,
+    get_workbook_tool_specs,
 )
 
 if TYPE_CHECKING:
     from ..domain.document.session_store import DocumentSessionStore
+    from ..domain.workbook.session_store import WorkbookSessionStore
 
 
 class DocumentToolSet(ToolSet):
@@ -30,6 +35,19 @@ class DocumentToolSet(ToolSet):
     ) -> None:
         super().__init__(list(tools))
         self.document_store = document_store
+
+
+class WorkbookToolSet(ToolSet):
+    workbook_store: WorkbookSessionStore
+
+    def __init__(
+        self,
+        tools: Sequence[AstrBotWorkbookTool],
+        *,
+        workbook_store: WorkbookSessionStore,
+    ) -> None:
+        super().__init__(list(tools))
+        self.workbook_store = workbook_store
 
 
 def build_document_toolset_from_registry(
@@ -58,3 +76,18 @@ def build_document_toolset_from_registry(
         for spec in get_document_tool_specs()
     ]
     return DocumentToolSet(tools, document_store=store)
+
+
+def build_workbook_toolset_from_registry(
+    workspace_dir: Path | None = None,
+    after_export: WorkbookAfterExportCallback | None = None,
+) -> WorkbookToolSet:
+    store = build_workbook_store(workspace_dir=workspace_dir)
+    tools = [
+        spec.astrbot_factory(
+            store,
+            after_export,
+        )
+        for spec in get_workbook_tool_specs()
+    ]
+    return WorkbookToolSet(tools, workbook_store=store)

--- a/tools/mcp_adapter.py
+++ b/tools/mcp_adapter.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING
 from mcp.server.fastmcp import FastMCP
 
 from ..domain.document.hooks import AfterExportHook, BeforeExportHook
-from .registry import get_document_tool_specs
+from .registry import get_document_tool_specs, get_workbook_tool_specs
 
 if TYPE_CHECKING:
     from ..domain.document.session_store import DocumentSessionStore
+    from ..domain.workbook.session_store import WorkbookSessionStore
 
 
 def register_document_tools_from_registry(
@@ -27,3 +28,11 @@ def register_document_tools_from_registry(
             resolved_before_export_hooks,
             resolved_after_export_hooks,
         )
+
+
+def register_workbook_tools_from_registry(
+    server: FastMCP,
+    store: WorkbookSessionStore,
+) -> None:
+    for spec in get_workbook_tool_specs():
+        spec.mcp_registrar(server, store)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -20,9 +20,14 @@ from ..domain.document.session_store import attach_document_style_defaults
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
+    from ..domain.workbook.session_store import WorkbookSessionStore
 
 
 class AstrBotDocumentTool(Protocol):
+    name: str
+
+
+class AstrBotWorkbookTool(Protocol):
     name: str
 
 
@@ -43,12 +48,28 @@ McpToolRegistrar = Callable[
     None,
 ]
 
+WorkbookAfterExportCallback = Callable[
+    [ContextWrapper[AstrAgentContext], str], Awaitable[str | None]
+]
+AstrBotWorkbookToolFactory = Callable[
+    ["WorkbookSessionStore", WorkbookAfterExportCallback | None],
+    AstrBotWorkbookTool,
+]
+WorkbookMcpToolRegistrar = Callable[["FastMCP", "WorkbookSessionStore"], None]
+
 
 @dataclass(frozen=True)
 class DocumentToolSpec:
     name: str
     astrbot_factory: AstrBotToolFactory
     mcp_registrar: McpToolRegistrar
+
+
+@dataclass(frozen=True)
+class WorkbookToolSpec:
+    name: str
+    astrbot_factory: AstrBotWorkbookToolFactory
+    mcp_registrar: WorkbookMcpToolRegistrar
 
 
 def _build_create_document_tool(
@@ -163,6 +184,60 @@ def _register_export_document_tool(
     )
 
 
+def _build_create_workbook_tool(
+    store: "WorkbookSessionStore",
+    _after_export: WorkbookAfterExportCallback | None,
+) -> AstrBotWorkbookTool:
+    from ..agent_tools.workbook_tools import CreateWorkbookTool
+
+    return CreateWorkbookTool(store=store)
+
+
+def _build_write_rows_tool(
+    store: "WorkbookSessionStore",
+    _after_export: WorkbookAfterExportCallback | None,
+) -> AstrBotWorkbookTool:
+    from ..agent_tools.workbook_tools import WriteRowsTool
+
+    return WriteRowsTool(store=store)
+
+
+def _build_export_workbook_tool(
+    store: "WorkbookSessionStore",
+    after_export: WorkbookAfterExportCallback | None,
+) -> AstrBotWorkbookTool:
+    from ..agent_tools.workbook_tools import ExportWorkbookTool
+
+    return ExportWorkbookTool(store=store, after_export=after_export)
+
+
+def _register_create_workbook_tool(
+    server: FastMCP,
+    store: "WorkbookSessionStore",
+) -> None:
+    from ..mcp_server.tools.create_workbook import register_create_workbook_tool
+
+    register_create_workbook_tool(server, store)
+
+
+def _register_write_rows_tool(
+    server: FastMCP,
+    store: "WorkbookSessionStore",
+) -> None:
+    from ..mcp_server.tools.write_rows import register_write_rows_tool
+
+    register_write_rows_tool(server, store)
+
+
+def _register_export_workbook_tool(
+    server: FastMCP,
+    store: "WorkbookSessionStore",
+) -> None:
+    from ..mcp_server.tools.export_workbook import register_export_workbook_tool
+
+    register_export_workbook_tool(server, store)
+
+
 _DOCUMENT_TOOL_SPECS: tuple[DocumentToolSpec, ...] = (
     DocumentToolSpec(
         name="create_document",
@@ -186,9 +261,31 @@ _DOCUMENT_TOOL_SPECS: tuple[DocumentToolSpec, ...] = (
     ),
 )
 
+_WORKBOOK_TOOL_SPECS: tuple[WorkbookToolSpec, ...] = (
+    WorkbookToolSpec(
+        name="create_workbook",
+        astrbot_factory=_build_create_workbook_tool,
+        mcp_registrar=_register_create_workbook_tool,
+    ),
+    WorkbookToolSpec(
+        name="write_rows",
+        astrbot_factory=_build_write_rows_tool,
+        mcp_registrar=_register_write_rows_tool,
+    ),
+    WorkbookToolSpec(
+        name="export_workbook",
+        astrbot_factory=_build_export_workbook_tool,
+        mcp_registrar=_register_export_workbook_tool,
+    ),
+)
+
 
 def get_document_tool_specs() -> tuple[DocumentToolSpec, ...]:
     return _DOCUMENT_TOOL_SPECS
+
+
+def get_workbook_tool_specs() -> tuple[WorkbookToolSpec, ...]:
+    return _WORKBOOK_TOOL_SPECS
 
 
 def build_document_store(
@@ -204,3 +301,12 @@ def build_document_store(
     )
     attach_document_style_defaults(store, default_document_style)
     return store
+
+
+def build_workbook_store(
+    workspace_dir: Path | None = None,
+) -> "WorkbookSessionStore":
+    # Lazy import keeps the document-only path free from workbook dependencies.
+    from ..domain.workbook.session_store import WorkbookSessionStore
+
+    return WorkbookSessionStore(workspace_dir=workspace_dir)


### PR DESCRIPTION
## 概述

新增一条独立的结构化 Excel 原语工作流，支持 `create_workbook -> write_rows -> export_workbook`。这次改动把 workbook 域模型、工具注册、运行时挂载、提示词和 follow-up 提示全部单独接好，避免继续把 Excel 能力塞进现有的 Word 流程里。

## 改动类型

- [ ] Bug 修复
- [x] 新功能
- [x] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 新增 `domain/workbook/`，把 workbook 会话、sheet 数据、导出规则和工具契约独立成一套实现，后续扩展公式、图表或脚本能力时不用再改 Word 域模型。
- 新增 `agent_tools/workbook_tools.py` 和对应 MCP tools，让 AstrBot 路径和 MCP 路径都能走同一套 workbook store 与导出逻辑，减少重复实现。
- 调整 `tools/registry.py`、`tools/astrbot_adapter.py`、`tools/mcp_adapter.py`、`services/runtime_builder.py`，让结构化工具不再只有单一 document toolset，而是支持 document / workbook 并行挂载。
- 新增 `prompts/static/workbook_tools.py`，并把 workbook follow-up 摘要单独接入 `PromptContextService` / `RequestHookService`，保证 `workbook_id` 请求只命中 Excel 提示，不和 `document_id` 串线。
- 更新测试，把 workbook 域层、工具注册、service follow-up 和 MCP 工具暴露都补上，同时修正旧的 MCP 工具列表断言。

## 影响范围

- 结构化 Excel 生成流程
- MCP 工具列表与调用路径
- LLM 工具暴露策略
- follow-up 提示注入逻辑
- 现有 Word 工具注册与 prompt 排序逻辑

## 测试情况

- [ ] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [x] 手动验证了核心场景

<details>
<summary>手动测试记录（可选）</summary>

已执行：

- `pytest tests/test_workbook_domain.py -q`
- `pytest tests/test_workbook_tool_registry.py -q`
- `pytest tests/test_office_assistant_agent_tools.py -q -k "test_mcp_registers_document_and_workbook_tools or workbook"`

结果：

- `tests/test_workbook_domain.py`：8 passed
- `tests/test_workbook_tool_registry.py`：5 passed
- workbook 相关 agent tools / MCP 用例：5 passed

另外补跑并确认了旧的 MCP 工具列表测试已经更新，不再假设只暴露 Word 工具。
</details>

## 备注

- 一期只支持 `.xlsx`，不包含公式、图表、条件格式、数据验证、合并单元格。
- `create_office_file` 旧入口保留，没有改写成 workbook 原语入口。
- 当前没有跑全量 `pytest`，这次主要验证的是 workbook 主链和相关回归用例。

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

新功能：
- 新增独立的工作簿领域模型和会话存储，以支持结构化 Excel 生成，提供 `create_workbook`、`write_rows` 和 `export_workbook` 能力。
- 通过共享的工作簿存储和一致的工具注册顺序，将工作簿工具同时暴露给 AstrBot 和 MCP 运行时。
- 基于 `workbook_id` 提供工作簿特定的提示指引和后续通知，包括根据状态感知的下一步操作建议。

增强：
- 扩展 LLM 请求策略和插件运行时，在保持概念上区分的前提下，同时挂载文档与工作簿工具集。
- 更新提示上下文的排序方式，将静态和动态的工作簿通知与现有文档和上传板块进行集成。
- 调整 MCP 服务器说明和工具注册，使 Word 和 Excel 结构化工作流都能被声明，并可依据工作簿支持情况有条件地启用。

测试：
- 添加工作簿领域测试，覆盖校验规则、写入/导出行为以及摘要构建。
- 添加注册表、适配器和 MCP 测试，确保工作簿工具共享存储、保持注册顺序，并能与文档工具正确共存。
- 扩展服务层和 LLM 前测试，以验证工作簿后续逻辑、提示注入以及文档/工作簿组合工具的对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

</details>

新功能：
- 添加专用的工作簿领域模型和会话存储，以支持结构化 Excel 生成工作流。
- 为 AstrBot 和 MCP 运行时同时暴露 `create_workbook`、`write_rows` 和 `export_workbook` 工具，并共享统一的工作簿存储。
- 注入针对工作簿的提示指引与后续操作提示，包括基于 `workbook_id` 的状态摘要和下一步行动建议。

增强项：
- 扩展 LLM 请求策略和插件运行时，以同时挂载文档和工作簿工具集，并在工具暴露时同时展示二者。
- 更新提示上下文的排序逻辑，使工作簿的静态与动态提示可以与现有的文档和上传区段顺畅集成。
- 优化 Office MCP 服务器说明文档，以涵盖 Word 和 Excel 的结构化工作流。

测试：
- 添加工作簿领域测试，覆盖校验、会话生命周期、导出行为和提示摘要。
- 添加注册表和适配器测试，以确保工作簿工具的顺序、共享存储的使用，以及正确的 MCP/AstrBot 注册。
- 扩展服务层和 LLM 前置测试，覆盖工作簿后续逻辑、工作簿/工具指引注入，以及文档/工作簿工具的联合暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

新功能：
- 新增独立的工作簿领域模型和会话存储，以支持结构化 Excel 生成，提供 `create_workbook`、`write_rows` 和 `export_workbook` 能力。
- 通过共享的工作簿存储和一致的工具注册顺序，将工作簿工具同时暴露给 AstrBot 和 MCP 运行时。
- 基于 `workbook_id` 提供工作簿特定的提示指引和后续通知，包括根据状态感知的下一步操作建议。

增强：
- 扩展 LLM 请求策略和插件运行时，在保持概念上区分的前提下，同时挂载文档与工作簿工具集。
- 更新提示上下文的排序方式，将静态和动态的工作簿通知与现有文档和上传板块进行集成。
- 调整 MCP 服务器说明和工具注册，使 Word 和 Excel 结构化工作流都能被声明，并可依据工作簿支持情况有条件地启用。

测试：
- 添加工作簿领域测试，覆盖校验规则、写入/导出行为以及摘要构建。
- 添加注册表、适配器和 MCP 测试，确保工作簿工具共享存储、保持注册顺序，并能与文档工具正确共存。
- 扩展服务层和 LLM 前测试，以验证工作簿后续逻辑、提示注入以及文档/工作簿组合工具的对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

新功能：
- 新增独立的工作簿领域模型和会话存储，以支持结构化 Excel 生成，提供 `create_workbook`、`write_rows` 和 `export_workbook` 能力。
- 通过共享的工作簿存储和一致的工具注册顺序，将工作簿工具同时暴露给 AstrBot 和 MCP 运行时。
- 基于 `workbook_id` 提供工作簿特定的提示指引和后续通知，包括根据状态感知的下一步操作建议。

增强：
- 扩展 LLM 请求策略和插件运行时，在保持概念上区分的前提下，同时挂载文档与工作簿工具集。
- 更新提示上下文的排序方式，将静态和动态的工作簿通知与现有文档和上传板块进行集成。
- 调整 MCP 服务器说明和工具注册，使 Word 和 Excel 结构化工作流都能被声明，并可依据工作簿支持情况有条件地启用。

测试：
- 添加工作簿领域测试，覆盖校验规则、写入/导出行为以及摘要构建。
- 添加注册表、适配器和 MCP 测试，确保工作簿工具共享存储、保持注册顺序，并能与文档工具正确共存。
- 扩展服务层和 LLM 前测试，以验证工作簿后续逻辑、提示注入以及文档/工作簿组合工具的对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

</details>

新功能：
- 添加专用的工作簿领域模型和会话存储，以支持结构化 Excel 生成工作流。
- 为 AstrBot 和 MCP 运行时同时暴露 `create_workbook`、`write_rows` 和 `export_workbook` 工具，并共享统一的工作簿存储。
- 注入针对工作簿的提示指引与后续操作提示，包括基于 `workbook_id` 的状态摘要和下一步行动建议。

增强项：
- 扩展 LLM 请求策略和插件运行时，以同时挂载文档和工作簿工具集，并在工具暴露时同时展示二者。
- 更新提示上下文的排序逻辑，使工作簿的静态与动态提示可以与现有的文档和上传区段顺畅集成。
- 优化 Office MCP 服务器说明文档，以涵盖 Word 和 Excel 的结构化工作流。

测试：
- 添加工作簿领域测试，覆盖校验、会话生命周期、导出行为和提示摘要。
- 添加注册表和适配器测试，以确保工作簿工具的顺序、共享存储的使用，以及正确的 MCP/AstrBot 注册。
- 扩展服务层和 LLM 前置测试，覆盖工作簿后续逻辑、工作簿/工具指引注入，以及文档/工作簿工具的联合暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

新功能：
- 新增独立的工作簿领域模型和会话存储，以支持结构化 Excel 生成，提供 `create_workbook`、`write_rows` 和 `export_workbook` 能力。
- 通过共享的工作簿存储和一致的工具注册顺序，将工作簿工具同时暴露给 AstrBot 和 MCP 运行时。
- 基于 `workbook_id` 提供工作簿特定的提示指引和后续通知，包括根据状态感知的下一步操作建议。

增强：
- 扩展 LLM 请求策略和插件运行时，在保持概念上区分的前提下，同时挂载文档与工作簿工具集。
- 更新提示上下文的排序方式，将静态和动态的工作簿通知与现有文档和上传板块进行集成。
- 调整 MCP 服务器说明和工具注册，使 Word 和 Excel 结构化工作流都能被声明，并可依据工作簿支持情况有条件地启用。

测试：
- 添加工作簿领域测试，覆盖校验规则、写入/导出行为以及摘要构建。
- 添加注册表、适配器和 MCP 测试，确保工作簿工具共享存储、保持注册顺序，并能与文档工具正确共存。
- 扩展服务层和 LLM 前测试，以验证工作簿后续逻辑、提示注入以及文档/工作簿组合工具的对外暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在现有文档工具的基础上，引入专门的结构化 Excel 工作簿工作流，包括领域模型、agent/MCP 工具、运行时接线，以及针对工作簿会话的提示集成。

新功能：
- 新增独立的工作簿领域，包括模型、会话存储、契约（contracts）和导出器，通过 `create_workbook`、`write_rows` 和 `export_workbook` 支持结构化 Excel 流程。
- 通过共享的注册表和工具集将工作簿工具同时暴露给 AstrBot 和 MCP 运行时，使文档工具和工作簿工具可以并行挂载。
- 提供基于 `workbook_id` 的工作簿专用提示片段和后续提示信息，包括草稿/已导出状态以及下一步允许的操作。

增强：
- 扩展 LLM 请求策略和插件运行时，将文档工具和工作簿工具集同时注入到请求中，并在存在 `workbook_id` 时驱动面向工作簿的后续引导。
- 更新提示上下文的排序和静态提示，将工作簿工具指南和动态工作簿后续提示与现有的文档与上传部分集成在一起。
- 为工作簿工具挂载和摘要查找增加防护，以便在没有工作簿依赖的部署中优雅地跳过工作簿支持，同时保持文档流程不受影响。

测试：
- 添加全面的工作簿领域测试，覆盖校验、工作表处理、导出行为、并发锁，以及提示摘要构造。
- 添加注册表、AstrBot 适配器和 MCP 适配器测试，确保工作簿工具共享单一存储、保持注册表顺序，并在两个运行时中正确注册。
- 扩展服务级和集成级测试，用于请求钩子、LLM 请求策略、`before_llm_chat` 行为和 MCP 服务器，验证工作簿提示注入、工具暴露以及错误信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated structured Excel workbook workflow alongside existing document tools, including domain models, agent/MCP tools, runtime wiring, and prompt integration for workbook sessions.

New Features:
- Add a standalone workbook domain with models, session store, contracts, and exporter to support structured Excel flows via create_workbook, write_rows, and export_workbook.
- Expose workbook tools to both AstrBot and MCP runtimes through shared registries and toolsets, enabling concurrent document and workbook tool mounting.
- Provide workbook-specific prompt sections and follow-up notices keyed by workbook_id, including draft/exported status and next allowed actions.

Enhancements:
- Extend LLM request policy and plugin runtime to inject both document and workbook toolsets into requests and to drive workbook-aware follow-up guidance when workbook_id is present.
- Update prompt context ordering and static notices to integrate workbook tool guides and dynamic workbook follow-ups alongside existing document and upload sections.
- Guard workbook tool mounting and summary lookup so deployments without workbook dependencies gracefully skip workbook support while keeping document flows intact.

Tests:
- Add comprehensive workbook domain tests covering validation, sheet handling, export behavior, concurrency locking, and prompt summary construction.
- Add registry, AstrBot adapter, and MCP adapter tests to ensure workbook tools share a single store, preserve registry order, and register correctly in both runtimes.
- Extend service- and integration-level tests for request hooks, LLM request policy, before_llm_chat behavior, and MCP server to validate workbook prompt injection, tool exposure, and error messaging.

</details>

</details>

</details>

</details>

</details>

</details>