### PR TITLE
feat: align Excel script execution with AstrBot runtime modes

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -68,6 +68,12 @@ SUFFIX_TO_OFFICE_TYPE = {v: k for k, v in OFFICE_EXTENSIONS.items()} | {
     ".ppt": OfficeType.POWERPOINT,
 }
 
+EXCEL_SUFFIXES = frozenset(
+    suffix
+    for suffix, office_type in SUFFIX_TO_OFFICE_TYPE.items()
+    if office_type is OfficeType.EXCEL
+)
+
 # 所有可读取的 Office 格式（新旧）
 ALL_OFFICE_SUFFIXES = frozenset(SUFFIX_TO_OFFICE_TYPE.keys())
 

--- a/prompts/scenes/uploaded_file.py
+++ b/prompts/scenes/uploaded_file.py
@@ -1,7 +1,7 @@
+from ...constants import EXCEL_SUFFIXES
 from ...services.upload_types import UploadInfo
 
 MAX_DETAILED_UPLOAD_INFOS = 3
-_EXCEL_SUFFIXES = frozenset({".xlsx", ".xls"})
 
 
 def format_minimal_upload_file_info(info: UploadInfo) -> str:
@@ -116,7 +116,7 @@ def _display_upload_name(info: UploadInfo) -> str:
 def _preferred_read_tool(upload_infos: list[UploadInfo]) -> str:
     readable_infos = [info for info in upload_infos if info.get("is_supported")]
     if readable_infos and all(
-        str(info.get("file_suffix", "")).lower() in _EXCEL_SUFFIXES
+        str(info.get("file_suffix", "")).lower() in EXCEL_SUFFIXES
         for info in readable_infos
     ):
         return "read_workbook"

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -79,7 +79,7 @@ class ExcelIntentRouter:
     )
     _FILENAME_RE = re.compile(r"([^\s'\"`]+?\.(?:xlsx|xls))", flags=re.IGNORECASE)
     _OUTPUT_FILENAME_PREFIX_RE = re.compile(
-        r"(文件名(?:叫|为)?|命名(?:为)?|保存(?:为|到)?|另存为|输出(?:成|为|到)?|"
+        r"(文件名(?:叫|为)?|命名(?:为)?|保存(?:为|到)|另存为|输出(?:成|为|到)|"
         r"导出(?:成|为)|生成|创建|新建|写入|写到|存为)$",
         flags=re.IGNORECASE,
     )

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -4,6 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal
 
+from ..constants import EXCEL_SUFFIXES
 from .upload_types import UploadInfo
 
 ExcelIntentRoute = Literal[
@@ -24,11 +25,12 @@ class ExcelRouteDecision:
 
 
 class ExcelIntentRouter:
+    _MATCH_CONTEXT_WINDOW = 24
     _WORKBOOK_TOOL_NAMES = frozenset(
         {"create_workbook", "write_rows", "export_workbook"}
     )
     _EXCEL_FILE_TOOL_NAMES = frozenset({"read_workbook", "execute_excel_script"})
-    _EXCEL_SUFFIXES = frozenset({".xlsx", ".xls"})
+    _EXCEL_SUFFIXES = EXCEL_SUFFIXES
     _EXCEL_SUBJECT_RE = re.compile(
         r"(\bexcel\b|\bxlsx\b|\bxls\b|工作簿|sheet|报表|汇总表)",
         flags=re.IGNORECASE,
@@ -67,6 +69,16 @@ class ExcelIntentRouter:
         flags=re.IGNORECASE,
     )
     _FILENAME_RE = re.compile(r"([^\s'\"`]+?\.(?:xlsx|xls))", flags=re.IGNORECASE)
+    _OUTPUT_FILENAME_PREFIX_RE = re.compile(
+        r"(文件名(?:叫|为)?|命名(?:为)?|保存(?:为|到)?|另存为|输出(?:成|为|到)?|"
+        r"导出(?:成|为)?|生成|创建|新建|写入|写到|存为)$",
+        flags=re.IGNORECASE,
+    )
+    _OUTPUT_FILENAME_SUFFIX_RE = re.compile(
+        r"^(?:\s*(?:作为|当作)\s*输出(?:文件)?|"
+        r"\s*(?:是|为)\s*输出(?:文件)?|\s*用于导出)",
+        flags=re.IGNORECASE,
+    )
 
     @classmethod
     def decide(
@@ -83,6 +95,8 @@ class ExcelIntentRouter:
             upload_infos=upload_infos,
         )
         has_excel_file = bool(matched_files)
+        has_read_intent = bool(cls._READ_RE.search(normalized_text))
+        has_modify_intent = bool(cls._MODIFY_RE.search(normalized_text))
         mentions_excel = bool(cls._EXCEL_SUBJECT_RE.search(normalized_text))
         mentions_excel_tool = bool(
             cls._WORKBOOK_TOOL_NAMES.union(cls._EXCEL_FILE_TOOL_NAMES).intersection(
@@ -94,23 +108,23 @@ class ExcelIntentRouter:
         if cls._CONVERSION_RE.search(normalized_text):
             return None
 
-        if has_excel_file and cls._READ_RE.search(normalized_text):
-            return ExcelRouteDecision(
-                route="read_existing",
-                matched_files=matched_files,
-                requires_script=False,
-                should_inject_guide=cls._can_read_existing(
-                    explicit_tool_name=explicit_tool_name,
-                    exposed_tool_names=exposed_tool_names,
-                ),
-            )
-
-        if has_excel_file and cls._MODIFY_RE.search(normalized_text):
+        if has_excel_file and has_modify_intent:
             return ExcelRouteDecision(
                 route="modify_existing",
                 matched_files=matched_files,
                 requires_script=True,
                 should_inject_guide=cls._can_run_script(
+                    explicit_tool_name=explicit_tool_name,
+                    exposed_tool_names=exposed_tool_names,
+                ),
+            )
+
+        if has_excel_file and has_read_intent:
+            return ExcelRouteDecision(
+                route="read_existing",
+                matched_files=matched_files,
+                requires_script=False,
+                should_inject_guide=cls._can_read_existing(
                     explicit_tool_name=explicit_tool_name,
                     exposed_tool_names=exposed_tool_names,
                 ),
@@ -163,12 +177,35 @@ class ExcelIntentRouter:
             if chosen_name and chosen_name not in matched_names:
                 matched_names.append(chosen_name)
 
-        for match in cls._FILENAME_RE.findall(request_text):
-            normalized_match = str(match).strip()
+        for match in cls._FILENAME_RE.finditer(request_text):
+            normalized_match = str(match.group(1)).strip()
+            if cls._looks_like_output_filename_reference(
+                request_text=request_text,
+                start=match.start(1),
+                end=match.end(1),
+            ):
+                continue
             if normalized_match and normalized_match not in matched_names:
                 matched_names.append(normalized_match)
 
         return tuple(matched_names)
+
+    @classmethod
+    def _looks_like_output_filename_reference(
+        cls,
+        *,
+        request_text: str,
+        start: int,
+        end: int,
+    ) -> bool:
+        context_start = max(0, start - cls._MATCH_CONTEXT_WINDOW)
+        context_end = min(len(request_text), end + cls._MATCH_CONTEXT_WINDOW)
+        prefix = request_text[context_start:start].rstrip()
+        suffix = request_text[end:context_end].lstrip()
+        return bool(
+            cls._OUTPUT_FILENAME_PREFIX_RE.search(prefix)
+            or cls._OUTPUT_FILENAME_SUFFIX_RE.search(suffix)
+        )
 
     @classmethod
     def _can_use_workbook_primitives(

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -52,6 +52,9 @@ class ExcelIntentRouter:
         r"(?:新增|增加|添加)\s*(?:一列|列|一行|行|sheet|工作表|公式|图表|条件格式|数据验证)|"
         r"更新\s*(?:这个|该|当前|现有|已有|原有|文件|工作簿|表格|sheet|xlsx|xls)|"
         r"更新.{0,32}(?:数据|内容|单元格|公式|样式)|"
+        r"\bupdate\s+(?:this|the|current|existing|workbook|file|sheet|xlsx|xls)\b|"
+        r"\bupdate\b.{0,32}\b(?:data|content|cell|cells|formula|formulas|style|styles|"
+        r"chart|charts|sheet|sheets|worksheet|worksheets)\b|"
         r"\bmodify\b|\bedit\b|\brewrite\b)",
         flags=re.IGNORECASE,
     )
@@ -80,7 +83,7 @@ class ExcelIntentRouter:
     _FILENAME_RE = re.compile(r"([^\s'\"`]+?\.(?:xlsx|xls))", flags=re.IGNORECASE)
     _OUTPUT_FILENAME_PREFIX_RE = re.compile(
         r"(文件名(?:叫|为)?|命名(?:为)?|保存(?:为|到)|另存为|输出(?:成|为|到)|"
-        r"导出(?:成|为)|生成|创建|新建|写入|写到|存为)$",
+        r"导出(?:成|为)|存为)$",
         flags=re.IGNORECASE,
     )
     _OUTPUT_FILENAME_SUFFIX_RE = re.compile(

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -88,7 +88,7 @@ class ExcelIntentRouter:
     )
     _OUTPUT_FILENAME_SUFFIX_RE = re.compile(
         r"^(?:\s*(?:作为|当作)\s*输出(?:文件)?|"
-        r"\s*(?:是|为)\s*输出(?:文件)?|\s*用于导出)",
+        r"\s*(?:是|为)\s*输出(?:文件)?)",
         flags=re.IGNORECASE,
     )
 

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -71,7 +71,7 @@ class ExcelIntentRouter:
     _FILENAME_RE = re.compile(r"([^\s'\"`]+?\.(?:xlsx|xls))", flags=re.IGNORECASE)
     _OUTPUT_FILENAME_PREFIX_RE = re.compile(
         r"(文件名(?:叫|为)?|命名(?:为)?|保存(?:为|到)?|另存为|输出(?:成|为|到)?|"
-        r"导出(?:成|为)?|生成|创建|新建|写入|写到|存为)$",
+        r"导出(?:成|为)|生成|创建|新建|写入|写到|存为)$",
         flags=re.IGNORECASE,
     )
     _OUTPUT_FILENAME_SUFFIX_RE = re.compile(

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -51,6 +51,7 @@ class ExcelIntentRouter:
         r"加公式|改样式|加样式|加图表|加条件格式|加数据验证|"
         r"(?:新增|增加|添加)\s*(?:一列|列|一行|行|sheet|工作表|公式|图表|条件格式|数据验证)|"
         r"更新\s*(?:这个|该|当前|现有|已有|原有|文件|工作簿|表格|sheet|xlsx|xls)|"
+        r"更新.{0,32}(?:数据|内容|单元格|公式|样式)|"
         r"\bmodify\b|\bedit\b|\brewrite\b)",
         flags=re.IGNORECASE,
     )

--- a/services/excel_intent_router.py
+++ b/services/excel_intent_router.py
@@ -46,6 +46,14 @@ class ExcelIntentRouter:
         r"\bmodify\b|\bedit\b|\bupdate\b|\brewrite\b)",
         flags=re.IGNORECASE,
     )
+    _EXPLICIT_MODIFY_RE = re.compile(
+        r"(修改|补写|重排|改写|调整|删除|追加|插入|替换|生成新版本|"
+        r"加公式|改样式|加样式|加图表|加条件格式|加数据验证|"
+        r"(?:新增|增加|添加)\s*(?:一列|列|一行|行|sheet|工作表|公式|图表|条件格式|数据验证)|"
+        r"更新\s*(?:这个|该|当前|现有|已有|原有|文件|工作簿|表格|sheet|xlsx|xls)|"
+        r"\bmodify\b|\bedit\b|\brewrite\b)",
+        flags=re.IGNORECASE,
+    )
     _NEW_RE = re.compile(
         r"(生成|创建|新建|制作|整理成|整理为|写入|填入|输出|导出(?:成|为)?|"
         r"做(?:个|一份|一个)?|帮我做|帮我生成|"
@@ -108,7 +116,9 @@ class ExcelIntentRouter:
         if cls._CONVERSION_RE.search(normalized_text):
             return None
 
-        if has_excel_file and has_modify_intent:
+        if has_excel_file and has_modify_intent and (
+            not has_read_intent or cls._has_explicit_modify_intent(normalized_text)
+        ):
             return ExcelRouteDecision(
                 route="modify_existing",
                 matched_files=matched_files,
@@ -206,6 +216,10 @@ class ExcelIntentRouter:
             cls._OUTPUT_FILENAME_PREFIX_RE.search(prefix)
             or cls._OUTPUT_FILENAME_SUFFIX_RE.search(suffix)
         )
+
+    @classmethod
+    def _has_explicit_modify_intent(cls, request_text: str) -> bool:
+        return bool(cls._EXPLICIT_MODIFY_RE.search(request_text))
 
     @classmethod
     def _can_use_workbook_primitives(

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
-import asyncio
 import json
-import shutil
-import subprocess
-import sys
 import tempfile
 import textwrap
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from uuid import uuid4
 
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from ..constants import EXCEL_SUFFIXES
+
+try:
+    from astrbot.core.computer.computer_client import (
+        get_booter as _get_computer_booter,
+    )
+except ImportError:  # pragma: no cover - depends on AstrBot runtime
+    _get_computer_booter = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,14 +31,29 @@ class ScriptProcessResult:
     script: str | None = None
 
 
+@dataclass(frozen=True, slots=True)
+class SandboxScriptPaths:
+    exec_dir: str
+    result_path: str
+    remote_result_path: str
+    input_files: list[str]
+    remote_input_files: list[str]
+    output_path: str | None = None
+    remote_output_path: str | None = None
+
+
 class ExcelScriptService:
     _EXCEL_SUFFIXES = EXCEL_SUFFIXES
     _MAX_SCRIPT_RETRIES = 2
     _RETRY_COUNT_EVENT_KEY = "office_assistant_excel_script_retry_failures"
+    _SCRIPT_TIMEOUT_SECONDS = 30
+    _SANDBOX_WORKSPACE_ROOT = "/workspace"
+    _SANDBOX_EXEC_ROOT = PurePosixPath(".office_assistant") / "excel_scripts"
 
     def __init__(
         self,
         *,
+        astrbot_context=None,
         workspace_service,
         file_delivery_service,
         allow_external_input_files: bool,
@@ -42,6 +61,7 @@ class ExcelScriptService:
         check_permission,
         group_feature_disabled_error,
     ) -> None:
+        self._astrbot_context = astrbot_context
         self._workspace_service = workspace_service
         self._file_delivery_service = file_delivery_service
         self._allow_external_input_files = allow_external_input_files
@@ -252,8 +272,16 @@ class ExcelScriptService:
             resolved_output_path = resolved_path
             resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        process_result = await asyncio.to_thread(
-            self._run_script_process,
+        booter, booter_error = await self._acquire_sandbox_booter(event)
+        if booter is None:
+            return self._build_non_retry_result(
+                event,
+                script=normalized_script,
+                error=booter_error or "错误：Excel sandbox 不可用",
+            )
+
+        process_result = await self._run_script_process(
+            booter=booter,
             script=normalized_script,
             input_files=resolved_input_files,
             output_path=resolved_output_path,
@@ -305,9 +333,174 @@ class ExcelScriptService:
             ensure_ascii=False,
         )
 
-    def _run_script_process(
+    def _resolve_runtime_mode(self, event: AstrMessageEvent) -> str:
+        if self._astrbot_context is None:
+            return "local"
+        get_config = getattr(self._astrbot_context, "get_config", None)
+        if not callable(get_config):
+            return "local"
+        session_id = str(getattr(event, "unified_msg_origin", "") or "")
+        try:
+            config = get_config(umo=session_id)
+        except TypeError:
+            config = get_config()
+        if not isinstance(config, dict):
+            return "local"
+        provider_settings = config.get("provider_settings", {})
+        if not isinstance(provider_settings, dict):
+            return "local"
+        runtime = provider_settings.get("computer_use_runtime", "local")
+        if isinstance(runtime, str) and runtime.strip():
+            return runtime.strip()
+        return "local"
+
+    async def _acquire_sandbox_booter(
+        self,
+        event: AstrMessageEvent,
+    ) -> tuple[object | None, str | None]:
+        if self._astrbot_context is None:
+            return None, "错误：当前服务未注入 AstrBot context，无法使用 sandbox"
+        if _get_computer_booter is None:
+            return None, "错误：当前 AstrBot 版本未提供 sandbox 执行接口"
+        if self._resolve_runtime_mode(event) != "sandbox":
+            return (
+                None,
+                "错误：execute_excel_script 仅支持 sandbox runtime，请在 AstrBot 中启用 sandbox",
+            )
+        session_id = str(getattr(event, "unified_msg_origin", "") or "").strip()
+        if not session_id:
+            return None, "错误：缺少会话标识，无法初始化 Excel sandbox"
+        try:
+            booter = await _get_computer_booter(self._astrbot_context, session_id)
+        except Exception as exc:
+            logger.warning(f"[文件管理] Excel sandbox 初始化失败: {exc}")
+            return None, f"错误：Excel sandbox 初始化失败：{exc}"
+
+        capabilities = getattr(booter, "capabilities", None)
+        if capabilities is not None:
+            required_capabilities = {"python", "filesystem"}
+            missing = sorted(required_capabilities.difference(capabilities))
+            if missing:
+                missing_text = ", ".join(missing)
+                return (
+                    None,
+                    f"错误：当前 sandbox profile 缺少必要能力：{missing_text}",
+                )
+        return booter, None
+
+    @classmethod
+    def _join_sandbox_path(cls, workspace_root: str, relative_path: PurePosixPath) -> str:
+        if len(workspace_root) >= 2 and workspace_root[1] == ":":
+            return str(Path(workspace_root) / Path(relative_path.as_posix()))
+        if "\\" in workspace_root:
+            return str(Path(workspace_root) / Path(relative_path.as_posix()))
+        return str(PurePosixPath(workspace_root or cls._SANDBOX_WORKSPACE_ROOT) / relative_path)
+
+    @classmethod
+    def _build_sandbox_paths(
+        cls,
+        booter,
+        *,
+        input_files: list[Path],
+        output_path: Path | None,
+    ) -> SandboxScriptPaths:
+        workspace_root = str(
+            getattr(booter, "workspace_root", cls._SANDBOX_WORKSPACE_ROOT)
+            or cls._SANDBOX_WORKSPACE_ROOT
+        )
+        exec_relative_dir = cls._SANDBOX_EXEC_ROOT / uuid4().hex
+        runtime_input_files: list[str] = []
+        remote_input_files: list[str] = []
+        for index, original_path in enumerate(input_files):
+            relative_input_path = (
+                exec_relative_dir / "_inputs" / str(index) / original_path.name
+            )
+            runtime_input_files.append(
+                cls._join_sandbox_path(workspace_root, relative_input_path)
+            )
+            remote_input_files.append(relative_input_path.as_posix())
+
+        relative_result_path = exec_relative_dir / "result.json"
+        runtime_result_path = cls._join_sandbox_path(workspace_root, relative_result_path)
+
+        runtime_output_path: str | None = None
+        remote_output_path: str | None = None
+        if output_path is not None:
+            relative_output_path = exec_relative_dir / "_output" / output_path.name
+            runtime_output_path = cls._join_sandbox_path(
+                workspace_root,
+                relative_output_path,
+            )
+            remote_output_path = relative_output_path.as_posix()
+
+        return SandboxScriptPaths(
+            exec_dir=cls._join_sandbox_path(workspace_root, exec_relative_dir),
+            result_path=runtime_result_path,
+            remote_result_path=relative_result_path.as_posix(),
+            input_files=runtime_input_files,
+            remote_input_files=remote_input_files,
+            output_path=runtime_output_path,
+            remote_output_path=remote_output_path,
+        )
+
+    @staticmethod
+    def _build_prepare_script(directory_paths: list[str]) -> str:
+        unique_paths = list(dict.fromkeys(directory_paths))
+        serialized_paths = json.dumps(unique_paths, ensure_ascii=False)
+        return textwrap.dedent(
+            f"""
+            import json
+            from pathlib import Path
+
+            for raw_path in json.loads({serialized_paths!r}):
+                Path(raw_path).mkdir(parents=True, exist_ok=True)
+            """
+        ).strip()
+
+    @staticmethod
+    def _build_cleanup_script(directory_path: str) -> str:
+        serialized_path = json.dumps(directory_path, ensure_ascii=False)
+        return textwrap.dedent(
+            f"""
+            import json
+            import shutil
+            from pathlib import Path
+
+            shutil.rmtree(Path(json.loads({serialized_path!r})), ignore_errors=True)
+            """
+        ).strip()
+
+    @staticmethod
+    def _format_exec_traceback(exec_result: dict) -> str:
+        parts: list[str] = []
+        error_text = str(exec_result.get("error", "") or "").strip()
+        if error_text:
+            parts.append(error_text)
+        output_text = str(exec_result.get("output", "") or "").strip()
+        if not output_text:
+            data = exec_result.get("data")
+            if isinstance(data, dict):
+                output_payload = data.get("output")
+                if isinstance(output_payload, dict):
+                    output_text = str(output_payload.get("text", "") or "").strip()
+        if output_text and output_text not in parts:
+            parts.append(output_text)
+        return "\n".join(parts).strip()
+
+    async def _cleanup_sandbox_exec_dir(self, booter, exec_dir: str) -> None:
+        try:
+            await booter.python.exec(
+                self._build_cleanup_script(exec_dir),
+                timeout=10,
+                silent=True,
+            )
+        except Exception as exc:  # pragma: no cover - cleanup failure should not mask result
+            logger.warning(f"[文件管理] 清理 Excel sandbox 临时目录失败: {exc}")
+
+    async def _run_script_process(
         self,
         *,
+        booter,
         script: str,
         input_files: list[Path],
         output_path: Path | None,
@@ -318,153 +511,208 @@ class ExcelScriptService:
             dir=str(workspace_root),
         ) as temp_dir:
             temp_root = Path(temp_dir)
-            copied_input_files: list[Path] = []
-            inputs_root = temp_root / "_inputs"
-            inputs_root.mkdir()
-            for index, original_path in enumerate(input_files):
-                copied_parent = inputs_root / str(index)
-                copied_parent.mkdir()
-                copied_path = copied_parent / original_path.name
-                shutil.copy2(original_path, copied_path)
-                copied_input_files.append(copied_path)
-            runner_path = temp_root / "runner.py"
+            sandbox_paths = self._build_sandbox_paths(
+                booter,
+                input_files=input_files,
+                output_path=output_path,
+            )
             result_path = temp_root / "result.json"
-            runner_path.write_text(
-                self._build_runner_script(
-                    script=script,
-                    input_files=copied_input_files,
-                    output_path=output_path,
-                    result_path=result_path,
-                ),
-                encoding="utf-8",
-            )
             try:
-                completed = subprocess.run(
-                    [sys.executable, str(runner_path)],
-                    cwd=str(workspace_root),
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                    shell=False,
+                prepare_result = await booter.python.exec(
+                    self._build_prepare_script(
+                        [
+                            str(Path(path).parent)
+                            for path in [
+                                *sandbox_paths.input_files,
+                                sandbox_paths.result_path,
+                                sandbox_paths.output_path,
+                            ]
+                            if path
+                        ]
+                    ),
+                    timeout=10,
+                    silent=True,
                 )
-            except subprocess.TimeoutExpired as exc:
-                return ScriptProcessResult(
-                    success=False,
-                    mode="error",
-                    error="Excel 脚本执行超时",
-                    traceback=str(exc),
-                    script=script,
-                )
+                if not prepare_result.get("success", False):
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel sandbox 初始化失败",
+                        traceback=self._format_exec_traceback(prepare_result),
+                        script=script,
+                    )
 
-            if not result_path.exists():
-                return ScriptProcessResult(
-                    success=False,
-                    mode="error",
-                    error="Excel 脚本未返回结果",
-                    traceback=(completed.stderr or completed.stdout or "").strip(),
-                    script=script,
-                )
+                for local_path, remote_path in zip(
+                    input_files,
+                    sandbox_paths.remote_input_files,
+                    strict=False,
+                ):
+                    upload_result = await booter.upload_file(str(local_path), remote_path)
+                    if not upload_result.get("success", False):
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="Excel 输入文件上传失败",
+                            traceback=str(upload_result.get("message", "") or ""),
+                            script=script,
+                        )
 
-            try:
-                payload = json.loads(result_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError) as exc:
-                return ScriptProcessResult(
-                    success=False,
-                    mode="error",
-                    error="Excel 脚本结果解析失败",
-                    traceback=str(exc),
-                    script=script,
+                exec_result = await booter.python.exec(
+                    self._build_runner_script(
+                        script=script,
+                        input_files=sandbox_paths.input_files,
+                        output_path=sandbox_paths.output_path,
+                        result_path=sandbox_paths.result_path,
+                    ),
+                    timeout=self._SCRIPT_TIMEOUT_SECONDS,
+                    silent=True,
                 )
-            if not isinstance(payload, dict):
-                return ScriptProcessResult(
-                    success=False,
-                    mode="error",
-                    error="Excel 脚本结果解析失败",
-                    traceback=f"Unexpected JSON payload type: {type(payload).__name__}",
-                    script=script,
-                )
-            if not payload.get("success"):
-                return ScriptProcessResult(
-                    success=False,
-                    mode="error",
-                    error=str(payload.get("error", "脚本执行失败")),
-                    traceback=str(payload.get("traceback", "")),
-                    script=script,
-                )
+                if not exec_result.get("success", False):
+                    traceback_text = self._format_exec_traceback(exec_result)
+                    error_text = "Excel 脚本执行失败"
+                    if "timeout" in traceback_text.lower():
+                        error_text = "Excel 脚本执行超时"
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error=error_text,
+                        traceback=traceback_text,
+                        script=script,
+                    )
 
-            mode = str(payload.get("mode", ""))
-            if mode == "text":
+                try:
+                    await booter.download_file(
+                        sandbox_paths.remote_result_path,
+                        str(result_path),
+                    )
+                except Exception as exc:
+                    traceback_text = str(exc)
+                    exec_traceback = self._format_exec_traceback(exec_result)
+                    if exec_traceback:
+                        traceback_text = f"{traceback_text}\n{exec_traceback}".strip()
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel 脚本未返回结果",
+                        traceback=traceback_text,
+                        script=script,
+                    )
+
+                try:
+                    payload = json.loads(result_path.read_text(encoding="utf-8"))
+                except (json.JSONDecodeError, OSError) as exc:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel 脚本结果解析失败",
+                        traceback=str(exc),
+                        script=script,
+                    )
+                if not isinstance(payload, dict):
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel 脚本结果解析失败",
+                        traceback=f"Unexpected JSON payload type: {type(payload).__name__}",
+                        script=script,
+                    )
+                if not payload.get("success"):
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error=str(payload.get("error", "脚本执行失败")),
+                        traceback=str(payload.get("traceback", "")),
+                        script=script,
+                    )
+
+                mode = str(payload.get("mode", ""))
+                if mode == "text":
+                    return ScriptProcessResult(
+                        success=True,
+                        mode="text",
+                        result_text=str(payload.get("result_text", "")),
+                    )
+                if mode == "file":
+                    output_path_value = payload.get("output_path")
+                    if not isinstance(output_path_value, str) or not output_path_value.strip():
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="脚本返回了 file 模式，但缺少 output_path",
+                            traceback="",
+                            script=script,
+                        )
+                    if output_path is None or sandbox_paths.output_path is None:
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="脚本返回了 file 模式，但当前请求未提供 output_path",
+                            traceback="",
+                            script=script,
+                        )
+                    if output_path_value != sandbox_paths.output_path:
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="脚本返回了无效的 output_path",
+                            traceback=f"Unexpected output_path: {output_path_value}",
+                            script=script,
+                        )
+                    try:
+                        await booter.download_file(
+                            sandbox_paths.remote_output_path or "",
+                            str(output_path),
+                        )
+                    except FileNotFoundError:
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="脚本返回了 file 模式，但 output_path 不存在",
+                            traceback="",
+                            script=script,
+                        )
+                    except Exception as exc:
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="Excel 脚本结果下载失败",
+                            traceback=str(exc),
+                            script=script,
+                        )
+                    if not output_path.exists():
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="脚本返回了 file 模式，但 output_path 不存在",
+                            traceback="",
+                            script=script,
+                        )
+                    return ScriptProcessResult(
+                        success=True,
+                        mode="file",
+                        output_path=output_path,
+                    )
                 return ScriptProcessResult(
-                    success=True,
-                    mode="text",
-                    result_text=str(payload.get("result_text", "")),
+                    success=False,
+                    mode="error",
+                    error=f"未知脚本返回模式: {mode}",
+                    traceback="",
+                    script=script,
                 )
-            if mode == "file":
-                output_path_value = payload.get("output_path")
-                if not isinstance(output_path_value, str) or not output_path_value.strip():
-                    return ScriptProcessResult(
-                        success=False,
-                        mode="error",
-                        error="脚本返回了 file 模式，但缺少 output_path",
-                        traceback="",
-                        script=script,
-                    )
-                if output_path is None:
-                    return ScriptProcessResult(
-                        success=False,
-                        mode="error",
-                        error="脚本返回了 file 模式，但当前请求未提供 output_path",
-                        traceback="",
-                        script=script,
-                    )
-                resolved_output_path = Path(output_path_value).resolve(strict=False)
-                expected_output_path = output_path.resolve(strict=False)
-                if resolved_output_path != expected_output_path:
-                    return ScriptProcessResult(
-                        success=False,
-                        mode="error",
-                        error="脚本返回了无效的 output_path",
-                        traceback=f"Unexpected output_path: {output_path_value}",
-                        script=script,
-                    )
-                if not resolved_output_path.exists():
-                    return ScriptProcessResult(
-                        success=False,
-                        mode="error",
-                        error="脚本返回了 file 模式，但 output_path 不存在",
-                        traceback="",
-                        script=script,
-                    )
-                return ScriptProcessResult(
-                    success=True,
-                    mode="file",
-                    output_path=resolved_output_path,
-                )
-            return ScriptProcessResult(
-                success=False,
-                mode="error",
-                error=f"未知脚本返回模式: {mode}",
-                traceback="",
-                script=script,
-            )
+            finally:
+                await self._cleanup_sandbox_exec_dir(booter, sandbox_paths.exec_dir)
 
     @staticmethod
     def _build_runner_script(
         *,
         script: str,
-        input_files: list[Path],
-        output_path: Path | None,
-        result_path: Path,
+        input_files: list[str],
+        output_path: str | None,
+        result_path: str,
     ) -> str:
-        serialized_input_files = json.dumps(
-            [str(path.resolve()) for path in input_files],
-            ensure_ascii=False,
-        )
-        serialized_output_path = json.dumps(
-            str(output_path.resolve()) if output_path is not None else None,
-            ensure_ascii=False,
-        )
-        serialized_result_path = json.dumps(str(result_path.resolve()), ensure_ascii=False)
+        serialized_input_files = json.dumps(input_files, ensure_ascii=False)
+        serialized_output_path = json.dumps(output_path, ensure_ascii=False)
+        serialized_result_path = json.dumps(result_path, ensure_ascii=False)
         serialized_script = json.dumps(script, ensure_ascii=False)
         return textwrap.dedent(
             f"""
@@ -477,9 +725,6 @@ class ExcelScriptService:
             output_path = Path(output_path_value) if output_path_value else None
             result_path = Path(json.loads({serialized_result_path!r}))
             script = json.loads({serialized_script!r})
-            initial_exists = output_path.exists() if output_path is not None else False
-            initial_size = output_path.stat().st_size if initial_exists else None
-            initial_mtime_ns = output_path.stat().st_mtime_ns if initial_exists else None
 
             try:
                 import openpyxl
@@ -499,15 +744,7 @@ class ExcelScriptService:
                 exec(script, namespace, namespace)
                 result_text = namespace.get("result_text")
                 has_text = result_text is not None
-                has_file = False
-                if output_path is not None and output_path.exists():
-                    if not initial_exists:
-                        has_file = True
-                    else:
-                        has_file = (
-                            output_path.stat().st_size != initial_size
-                            or output_path.stat().st_mtime_ns != initial_mtime_ns
-                        )
+                has_file = output_path is not None and output_path.exists()
                 if has_text and has_file:
                     payload = {{
                         "success": False,

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -15,7 +15,10 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from ..constants import EXCEL_SUFFIXES
-from .runtime_config import resolve_computer_runtime_mode
+from .runtime_config import (
+    SUPPORTED_COMPUTER_RUNTIME_MODES,
+    resolve_computer_runtime_mode,
+)
 
 try:
     from astrbot.core.computer.computer_client import (
@@ -178,6 +181,7 @@ class ExcelScriptService:
         script: str,
         error: str,
         traceback_text: str = "",
+        retry_exhausted: bool = False,
     ) -> str:
         failure_count = self._get_failure_count(event)
         return self._build_error_result(
@@ -185,7 +189,7 @@ class ExcelScriptService:
             error=error,
             traceback_text=traceback_text,
             retry_count=self._retry_used_count(failure_count),
-            retry_exhausted=False,
+            retry_exhausted=retry_exhausted,
         )
 
     async def execute_excel_script(
@@ -216,6 +220,7 @@ class ExcelScriptService:
                 event,
                 script=normalized_script,
                 error=self._group_feature_disabled_error(),
+                retry_exhausted=True,
             )
 
         if not self._check_permission(event):
@@ -223,6 +228,7 @@ class ExcelScriptService:
                 event,
                 script=normalized_script,
                 error="错误：权限不足",
+                retry_exhausted=True,
             )
 
         resolved_input_files: list[Path] = []
@@ -287,6 +293,17 @@ class ExcelScriptService:
                 script=normalized_script,
                 error="错误：读取当前会话 computer runtime 失败",
                 traceback_text=str(exc),
+                retry_exhausted=True,
+            )
+        if runtime_mode not in SUPPORTED_COMPUTER_RUNTIME_MODES:
+            return self._build_non_retry_result(
+                event,
+                script=normalized_script,
+                error=(
+                    f"错误：不支持的 computer runtime 配置：{runtime_mode}，"
+                    "请使用 local、sandbox 或 none"
+                ),
+                retry_exhausted=True,
             )
         if runtime_mode == "none":
             return self._build_non_retry_result(
@@ -296,6 +313,7 @@ class ExcelScriptService:
                     "错误：当前 computer runtime 为 none，无法执行 Excel 脚本，"
                     "请启用 local 或 sandbox，或改走原语路径"
                 ),
+                retry_exhausted=True,
             )
 
         booter = None
@@ -309,6 +327,7 @@ class ExcelScriptService:
                     event,
                     script=normalized_script,
                     error=booter_error or "错误：Excel sandbox 不可用",
+                    retry_exhausted=True,
                 )
 
         process_result = await self._run_script_process(
@@ -320,16 +339,19 @@ class ExcelScriptService:
         )
 
         if not process_result.success:
-            build_error_result = (
-                self._build_failure_result
-                if getattr(process_result, "retryable", True)
-                else self._build_non_retry_result
-            )
-            return build_error_result(
+            if getattr(process_result, "retryable", True):
+                return self._build_failure_result(
+                    event,
+                    script=process_result.script or normalized_script,
+                    error=process_result.error or "脚本执行失败",
+                    traceback_text=process_result.traceback or "",
+                )
+            return self._build_non_retry_result(
                 event,
                 script=process_result.script or normalized_script,
                 error=process_result.error or "脚本执行失败",
                 traceback_text=process_result.traceback or "",
+                retry_exhausted=True,
             )
 
         if process_result.mode == "text":
@@ -546,6 +568,18 @@ class ExcelScriptService:
                 script=script,
                 input_files=input_files,
                 output_path=output_path,
+            )
+        if runtime_mode != "local":
+            return ScriptProcessResult(
+                success=False,
+                mode="error",
+                error=(
+                    f"错误：不支持的 computer runtime 配置：{runtime_mode}，"
+                    "请使用 local、sandbox 或 none"
+                ),
+                traceback="",
+                script=script,
+                retryable=False,
             )
         return await asyncio.to_thread(
             self._run_local_script_process,

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -861,6 +861,7 @@ class ExcelScriptService:
                     cwd=str(workspace_root),
                     capture_output=True,
                     text=True,
+                    shell=False,
                     timeout=self._SCRIPT_TIMEOUT_SECONDS,
                 )
             except subprocess.TimeoutExpired as exc:

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
+from ..constants import EXCEL_SUFFIXES
+
 
 @dataclass(frozen=True, slots=True)
 class ScriptProcessResult:
@@ -26,7 +28,7 @@ class ScriptProcessResult:
 
 
 class ExcelScriptService:
-    _EXCEL_SUFFIXES = frozenset({".xlsx", ".xls"})
+    _EXCEL_SUFFIXES = EXCEL_SUFFIXES
     _MAX_SCRIPT_RETRIES = 2
     _RETRY_COUNT_EVENT_KEY = "office_assistant_excel_script_retry_failures"
 
@@ -143,6 +145,23 @@ class ExcelScriptService:
             retry_exhausted=False,
         )
 
+    def _build_non_retry_result(
+        self,
+        event: AstrMessageEvent,
+        *,
+        script: str,
+        error: str,
+        traceback_text: str = "",
+    ) -> str:
+        failure_count = self._get_failure_count(event)
+        return self._build_error_result(
+            script=script,
+            error=error,
+            traceback_text=traceback_text,
+            retry_count=self._retry_used_count(failure_count),
+            retry_exhausted=False,
+        )
+
     async def execute_excel_script(
         self,
         event: AstrMessageEvent,
@@ -160,21 +179,21 @@ class ExcelScriptService:
                 failure_count=current_failure_count,
             )
         if not normalized_script:
-            return self._build_failure_result(
+            return self._build_non_retry_result(
                 event,
                 script=script or "",
                 error="缺少 script 参数",
             )
 
         if not self._is_group_feature_enabled(event):
-            return self._build_failure_result(
+            return self._build_non_retry_result(
                 event,
                 script=normalized_script,
                 error=self._group_feature_disabled_error(),
             )
 
         if not self._check_permission(event):
-            return self._build_failure_result(
+            return self._build_non_retry_result(
                 event,
                 script=normalized_script,
                 error="错误：权限不足",
@@ -193,13 +212,13 @@ class ExcelScriptService:
                 group_feature_disabled_error=self._group_feature_disabled_error,
             )
             if not ok:
-                return self._build_failure_result(
+                return self._build_non_retry_result(
                     event,
                     script=normalized_script,
                     error=err or "错误：未知错误",
                 )
             if resolved_path is None:
-                return self._build_failure_result(
+                return self._build_non_retry_result(
                     event,
                     script=normalized_script,
                     error="错误：输入文件路径解析失败",
@@ -219,13 +238,13 @@ class ExcelScriptService:
                 group_feature_disabled_error=self._group_feature_disabled_error,
             )
             if not ok:
-                return self._build_failure_result(
+                return self._build_non_retry_result(
                     event,
                     script=normalized_script,
                     error=err or "错误：未知错误",
                 )
             if resolved_path is None:
-                return self._build_failure_result(
+                return self._build_non_retry_result(
                     event,
                     script=normalized_script,
                     error="错误：输出文件路径解析失败",
@@ -326,6 +345,7 @@ class ExcelScriptService:
                     capture_output=True,
                     text=True,
                     timeout=30,
+                    shell=False,
                 )
             except subprocess.TimeoutExpired as exc:
                 return ScriptProcessResult(
@@ -380,11 +400,41 @@ class ExcelScriptService:
                     result_text=str(payload.get("result_text", "")),
                 )
             if mode == "file":
-                resolved_output_path = (
-                    Path(str(payload.get("output_path")))
-                    if payload.get("output_path")
-                    else output_path
-                )
+                output_path_value = payload.get("output_path")
+                if not isinstance(output_path_value, str) or not output_path_value.strip():
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但缺少 output_path",
+                        traceback="",
+                        script=script,
+                    )
+                if output_path is None:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但当前请求未提供 output_path",
+                        traceback="",
+                        script=script,
+                    )
+                resolved_output_path = Path(output_path_value).resolve(strict=False)
+                expected_output_path = output_path.resolve(strict=False)
+                if resolved_output_path != expected_output_path:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了无效的 output_path",
+                        traceback=f"Unexpected output_path: {output_path_value}",
+                        script=script,
+                    )
+                if not resolved_output_path.exists():
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但 output_path 不存在",
+                        traceback="",
+                        script=script,
+                    )
                 return ScriptProcessResult(
                     success=True,
                     mode="file",

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
+import shutil
+import subprocess
+import sys
 import tempfile
 import textwrap
 from dataclasses import dataclass
@@ -274,19 +278,33 @@ class ExcelScriptService:
             resolved_output_path = resolved_path
             resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        booter, booter_error = await self._acquire_sandbox_booter(event)
-        if booter is None:
+        runtime_mode = self._resolve_runtime_mode(event)
+        if runtime_mode == "none":
             return self._build_non_retry_result(
                 event,
                 script=normalized_script,
-                error=booter_error or "错误：Excel sandbox 不可用",
+                error=(
+                    "错误：当前 computer runtime 为 none，无法执行 Excel 脚本，"
+                    "请启用 local 或 sandbox，或改走原语路径"
+                ),
             )
 
+        booter = None
+        if runtime_mode == "sandbox":
+            booter, booter_error = await self._acquire_sandbox_booter(event)
+            if booter is None:
+                return self._build_non_retry_result(
+                    event,
+                    script=normalized_script,
+                    error=booter_error or "错误：Excel sandbox 不可用",
+                )
+
         process_result = await self._run_script_process(
-            booter=booter,
             script=normalized_script,
             input_files=resolved_input_files,
             output_path=resolved_output_path,
+            runtime_mode=runtime_mode,
+            booter=booter,
         )
 
         if not process_result.success:
@@ -355,7 +373,7 @@ class ExcelScriptService:
             return "local"
         runtime = provider_settings.get("computer_use_runtime", "local")
         if isinstance(runtime, str) and runtime.strip():
-            return runtime.strip()
+            return runtime.strip().lower()
         return "local"
 
     @staticmethod
@@ -534,6 +552,38 @@ class ExcelScriptService:
             logger.warning(f"[文件管理] 清理 Excel sandbox 临时目录失败: {exc}")
 
     async def _run_script_process(
+        self,
+        *,
+        script: str,
+        input_files: list[Path],
+        output_path: Path | None,
+        runtime_mode: str,
+        booter=None,
+    ) -> ScriptProcessResult:
+        if runtime_mode == "sandbox":
+            if booter is None:
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel sandbox 不可用",
+                    traceback="Missing sandbox booter",
+                    script=script,
+                    retryable=False,
+                )
+            return await self._run_sandbox_script_process(
+                booter=booter,
+                script=script,
+                input_files=input_files,
+                output_path=output_path,
+            )
+        return await asyncio.to_thread(
+            self._run_local_script_process,
+            script=script,
+            input_files=input_files,
+            output_path=output_path,
+        )
+
+    async def _run_sandbox_script_process(
         self,
         *,
         booter,
@@ -769,6 +819,158 @@ class ExcelScriptService:
             finally:
                 await self._cleanup_sandbox_exec_dir(booter, sandbox_paths.exec_dir)
 
+    def _run_local_script_process(
+        self,
+        *,
+        script: str,
+        input_files: list[Path],
+        output_path: Path | None,
+    ) -> ScriptProcessResult:
+        workspace_root = self._workspace_service.plugin_data_path.resolve()
+        with tempfile.TemporaryDirectory(
+            prefix="excel_script_",
+            dir=str(workspace_root),
+        ) as temp_dir:
+            temp_root = Path(temp_dir)
+            copied_input_files: list[Path] = []
+            inputs_root = temp_root / "_inputs"
+            inputs_root.mkdir()
+            for index, original_path in enumerate(input_files):
+                copied_parent = inputs_root / str(index)
+                copied_parent.mkdir()
+                copied_path = copied_parent / original_path.name
+                shutil.copy2(original_path, copied_path)
+                copied_input_files.append(copied_path)
+
+            runner_path = temp_root / "runner.py"
+            result_path = temp_root / "result.json"
+            runner_path.write_text(
+                self._build_runner_script(
+                    script=script,
+                    input_files=[str(path.resolve()) for path in copied_input_files],
+                    output_path=(
+                        str(output_path.resolve()) if output_path is not None else None
+                    ),
+                    result_path=str(result_path.resolve()),
+                ),
+                encoding="utf-8",
+            )
+            try:
+                completed = subprocess.run(
+                    [sys.executable, str(runner_path)],
+                    cwd=str(workspace_root),
+                    capture_output=True,
+                    text=True,
+                    timeout=self._SCRIPT_TIMEOUT_SECONDS,
+                )
+            except subprocess.TimeoutExpired as exc:
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel 脚本执行超时",
+                    traceback=str(exc),
+                    script=script,
+                )
+            except OSError as exc:
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel 脚本执行失败",
+                    traceback=str(exc),
+                    script=script,
+                )
+
+            if not result_path.exists():
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel 脚本未返回结果",
+                    traceback=(completed.stderr or completed.stdout or "").strip(),
+                    script=script,
+                )
+
+            try:
+                payload = json.loads(result_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel 脚本结果解析失败",
+                    traceback=str(exc),
+                    script=script,
+                )
+            if not isinstance(payload, dict):
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error="Excel 脚本结果解析失败",
+                    traceback=f"Unexpected JSON payload type: {type(payload).__name__}",
+                    script=script,
+                )
+            if not payload.get("success"):
+                return ScriptProcessResult(
+                    success=False,
+                    mode="error",
+                    error=str(payload.get("error", "脚本执行失败")),
+                    traceback=str(payload.get("traceback", "")),
+                    script=script,
+                )
+
+            mode = str(payload.get("mode", ""))
+            if mode == "text":
+                return ScriptProcessResult(
+                    success=True,
+                    mode="text",
+                    result_text=str(payload.get("result_text", "")),
+                )
+            if mode == "file":
+                output_path_value = payload.get("output_path")
+                if not isinstance(output_path_value, str) or not output_path_value.strip():
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但缺少 output_path",
+                        traceback="",
+                        script=script,
+                    )
+                if output_path is None:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但当前请求未提供 output_path",
+                        traceback="",
+                        script=script,
+                    )
+                expected_output_path = str(output_path.resolve())
+                if output_path_value != expected_output_path:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了无效的 output_path",
+                        traceback=f"Unexpected output_path: {output_path_value}",
+                        script=script,
+                    )
+                if not output_path.exists():
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="脚本返回了 file 模式，但 output_path 不存在",
+                        traceback="",
+                        script=script,
+                    )
+                return ScriptProcessResult(
+                    success=True,
+                    mode="file",
+                    output_path=output_path,
+                )
+            return ScriptProcessResult(
+                success=False,
+                mode="error",
+                error=f"未知脚本返回模式: {mode}",
+                traceback="",
+                script=script,
+            )
+
     @staticmethod
     def _build_runner_script(
         *,
@@ -792,6 +994,9 @@ class ExcelScriptService:
             output_path = Path(output_path_value) if output_path_value else None
             result_path = Path(json.loads({serialized_result_path!r}))
             script = json.loads({serialized_script!r})
+            initial_exists = output_path.exists() if output_path is not None else False
+            initial_size = output_path.stat().st_size if initial_exists else None
+            initial_mtime_ns = output_path.stat().st_mtime_ns if initial_exists else None
 
             try:
                 import openpyxl
@@ -811,7 +1016,15 @@ class ExcelScriptService:
                 exec(script, namespace, namespace)
                 result_text = namespace.get("result_text")
                 has_text = result_text is not None
-                has_file = output_path is not None and output_path.exists()
+                has_file = False
+                if output_path is not None and output_path.exists():
+                    if not initial_exists:
+                        has_file = True
+                    else:
+                        has_file = (
+                            output_path.stat().st_size != initial_size
+                            or output_path.stat().st_mtime_ns != initial_mtime_ns
+                        )
                 if has_text and has_file:
                     payload = {{
                         "success": False,

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import json
 import tempfile
 import textwrap
@@ -29,6 +30,7 @@ class ScriptProcessResult:
     error: str | None = None
     traceback: str | None = None
     script: str | None = None
+    retryable: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -288,7 +290,12 @@ class ExcelScriptService:
         )
 
         if not process_result.success:
-            return self._build_failure_result(
+            build_error_result = (
+                self._build_failure_result
+                if getattr(process_result, "retryable", True)
+                else self._build_non_retry_result
+            )
+            return build_error_result(
                 event,
                 script=process_result.script or normalized_script,
                 error=process_result.error or "脚本执行失败",
@@ -340,10 +347,7 @@ class ExcelScriptService:
         if not callable(get_config):
             return "local"
         session_id = str(getattr(event, "unified_msg_origin", "") or "")
-        try:
-            config = get_config(umo=session_id)
-        except TypeError:
-            config = get_config()
+        config = self._get_session_config(get_config, session_id)
         if not isinstance(config, dict):
             return "local"
         provider_settings = config.get("provider_settings", {})
@@ -353,6 +357,32 @@ class ExcelScriptService:
         if isinstance(runtime, str) and runtime.strip():
             return runtime.strip()
         return "local"
+
+    @staticmethod
+    def _get_session_config(get_config, session_id: str):
+        try:
+            signature = inspect.signature(get_config)
+        except (TypeError, ValueError):
+            return get_config(umo=session_id)
+
+        parameters = tuple(signature.parameters.values())
+        if any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+        ) or "umo" in signature.parameters:
+            return get_config(umo=session_id)
+
+        if any(
+            parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            )
+            for parameter in parameters
+        ):
+            return get_config(session_id)
+
+        return get_config()
 
     async def _acquire_sandbox_booter(
         self,
@@ -545,7 +575,7 @@ class ExcelScriptService:
                 for local_path, remote_path in zip(
                     input_files,
                     sandbox_paths.remote_input_files,
-                    strict=False,
+                    strict=True,
                 ):
                     upload_result = await booter.upload_file(str(local_path), remote_path)
                     if not upload_result.get("success", False):
@@ -555,6 +585,7 @@ class ExcelScriptService:
                             error="Excel 输入文件上传失败",
                             traceback=str(upload_result.get("message", "") or ""),
                             script=script,
+                            retryable=False,
                         )
 
                 exec_result = await booter.python.exec(

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -8,7 +8,7 @@ import sys
 import tempfile
 import textwrap
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from uuid import uuid4
 
 from astrbot.api import logger
@@ -418,9 +418,9 @@ class ExcelScriptService:
     @classmethod
     def _join_sandbox_path(cls, workspace_root: str, relative_path: PurePosixPath) -> str:
         if len(workspace_root) >= 2 and workspace_root[1] == ":":
-            return str(Path(workspace_root) / Path(relative_path.as_posix()))
+            return str(PureWindowsPath(workspace_root) / relative_path.as_posix())
         if "\\" in workspace_root:
-            return str(Path(workspace_root) / Path(relative_path.as_posix()))
+            return str(PureWindowsPath(workspace_root) / relative_path.as_posix())
         return str(PurePosixPath(workspace_root or cls._SANDBOX_WORKSPACE_ROOT) / relative_path)
 
     @classmethod
@@ -471,8 +471,8 @@ class ExcelScriptService:
         )
 
     @staticmethod
-    def _build_prepare_script(directory_paths: list[str]) -> str:
-        unique_paths = list(dict.fromkeys(directory_paths))
+    def _build_prepare_script(file_paths: list[str]) -> str:
+        unique_paths = list(dict.fromkeys(file_paths))
         serialized_paths = json.dumps(unique_paths, ensure_ascii=False)
         return textwrap.dedent(
             f"""
@@ -480,7 +480,7 @@ class ExcelScriptService:
             from pathlib import Path
 
             for raw_path in json.loads({serialized_paths!r}):
-                Path(raw_path).mkdir(parents=True, exist_ok=True)
+                Path(raw_path).parent.mkdir(parents=True, exist_ok=True)
             """
         ).strip()
 
@@ -581,7 +581,7 @@ class ExcelScriptService:
                     prepare_result = await booter.python.exec(
                         self._build_prepare_script(
                             [
-                                str(Path(path).parent)
+                                path
                                 for path in [
                                     *sandbox_paths.input_files,
                                     sandbox_paths.result_path,

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -363,7 +363,13 @@ class ExcelScriptService:
         try:
             signature = inspect.signature(get_config)
         except (TypeError, ValueError):
-            return get_config(umo=session_id)
+            try:
+                return get_config(session_id)
+            except TypeError:
+                try:
+                    return get_config(umo=session_id)
+                except TypeError:
+                    return get_config()
 
         parameters = tuple(signature.parameters.values())
         if any(
@@ -548,21 +554,30 @@ class ExcelScriptService:
             )
             result_path = temp_root / "result.json"
             try:
-                prepare_result = await booter.python.exec(
-                    self._build_prepare_script(
-                        [
-                            str(Path(path).parent)
-                            for path in [
-                                *sandbox_paths.input_files,
-                                sandbox_paths.result_path,
-                                sandbox_paths.output_path,
+                try:
+                    prepare_result = await booter.python.exec(
+                        self._build_prepare_script(
+                            [
+                                str(Path(path).parent)
+                                for path in [
+                                    *sandbox_paths.input_files,
+                                    sandbox_paths.result_path,
+                                    sandbox_paths.output_path,
+                                ]
+                                if path
                             ]
-                            if path
-                        ]
-                    ),
-                    timeout=10,
-                    silent=True,
-                )
+                        ),
+                        timeout=10,
+                        silent=True,
+                    )
+                except Exception as exc:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel sandbox 初始化失败",
+                        traceback=str(exc),
+                        script=script,
+                    )
                 if not prepare_result.get("success", False):
                     return ScriptProcessResult(
                         success=False,
@@ -577,7 +592,19 @@ class ExcelScriptService:
                     sandbox_paths.remote_input_files,
                     strict=True,
                 ):
-                    upload_result = await booter.upload_file(str(local_path), remote_path)
+                    try:
+                        upload_result = await booter.upload_file(
+                            str(local_path),
+                            remote_path,
+                        )
+                    except Exception as exc:
+                        return ScriptProcessResult(
+                            success=False,
+                            mode="error",
+                            error="Excel 输入文件上传失败",
+                            traceback=str(exc),
+                            script=script,
+                        )
                     if not upload_result.get("success", False):
                         return ScriptProcessResult(
                             success=False,
@@ -588,16 +615,25 @@ class ExcelScriptService:
                             retryable=False,
                         )
 
-                exec_result = await booter.python.exec(
-                    self._build_runner_script(
+                try:
+                    exec_result = await booter.python.exec(
+                        self._build_runner_script(
+                            script=script,
+                            input_files=sandbox_paths.input_files,
+                            output_path=sandbox_paths.output_path,
+                            result_path=sandbox_paths.result_path,
+                        ),
+                        timeout=self._SCRIPT_TIMEOUT_SECONDS,
+                        silent=True,
+                    )
+                except Exception as exc:
+                    return ScriptProcessResult(
+                        success=False,
+                        mode="error",
+                        error="Excel 脚本执行失败",
+                        traceback=str(exc),
                         script=script,
-                        input_files=sandbox_paths.input_files,
-                        output_path=sandbox_paths.output_path,
-                        result_path=sandbox_paths.result_path,
-                    ),
-                    timeout=self._SCRIPT_TIMEOUT_SECONDS,
-                    silent=True,
-                )
+                    )
                 if not exec_result.get("success", False):
                     traceback_text = self._format_exec_traceback(exec_result)
                     error_text = "Excel 脚本执行失败"

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -417,9 +417,7 @@ class ExcelScriptService:
 
     @classmethod
     def _join_sandbox_path(cls, workspace_root: str, relative_path: PurePosixPath) -> str:
-        if len(workspace_root) >= 2 and workspace_root[1] == ":":
-            return str(PureWindowsPath(workspace_root) / relative_path.as_posix())
-        if "\\" in workspace_root:
+        if (len(workspace_root) >= 2 and workspace_root[1] == ":") or "\\" in workspace_root:
             return str(PureWindowsPath(workspace_root) / relative_path.as_posix())
         return str(PurePosixPath(workspace_root or cls._SANDBOX_WORKSPACE_ROOT) / relative_path)
 

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -278,7 +278,16 @@ class ExcelScriptService:
             resolved_output_path = resolved_path
             resolved_output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        runtime_mode = self._resolve_runtime_mode(event)
+        try:
+            runtime_mode = self._resolve_runtime_mode(event)
+        except Exception as exc:
+            logger.warning(f"[文件管理] 读取 Excel runtime 配置失败: {exc}")
+            return self._build_non_retry_result(
+                event,
+                script=normalized_script,
+                error="错误：读取当前会话 computer runtime 失败",
+                traceback_text=str(exc),
+            )
         if runtime_mode == "none":
             return self._build_non_retry_result(
                 event,
@@ -291,7 +300,10 @@ class ExcelScriptService:
 
         booter = None
         if runtime_mode == "sandbox":
-            booter, booter_error = await self._acquire_sandbox_booter(event)
+            booter, booter_error = await self._acquire_sandbox_booter(
+                event,
+                runtime_mode=runtime_mode,
+            )
             if booter is None:
                 return self._build_non_retry_result(
                     event,
@@ -411,12 +423,20 @@ class ExcelScriptService:
     async def _acquire_sandbox_booter(
         self,
         event: AstrMessageEvent,
+        *,
+        runtime_mode: str | None = None,
     ) -> tuple[object | None, str | None]:
         if self._astrbot_context is None:
             return None, "错误：当前服务未注入 AstrBot context，无法使用 sandbox"
         if _get_computer_booter is None:
             return None, "错误：当前 AstrBot 版本未提供 sandbox 执行接口"
-        if self._resolve_runtime_mode(event) != "sandbox":
+        if runtime_mode is None:
+            try:
+                runtime_mode = self._resolve_runtime_mode(event)
+            except Exception as exc:
+                logger.warning(f"[文件管理] 读取 Excel runtime 配置失败: {exc}")
+                return None, "错误：读取当前会话 computer runtime 失败"
+        if runtime_mode != "sandbox":
             return (
                 None,
                 "错误：execute_excel_script 仅支持 sandbox runtime，请在 AstrBot 中启用 sandbox",

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import inspect
 import json
 import shutil
 import subprocess
@@ -16,6 +15,7 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
 from ..constants import EXCEL_SUFFIXES
+from .runtime_config import resolve_computer_runtime_mode
 
 try:
     from astrbot.core.computer.computer_client import (
@@ -371,54 +371,7 @@ class ExcelScriptService:
         )
 
     def _resolve_runtime_mode(self, event: AstrMessageEvent) -> str:
-        if self._astrbot_context is None:
-            return "local"
-        get_config = getattr(self._astrbot_context, "get_config", None)
-        if not callable(get_config):
-            return "local"
-        session_id = str(getattr(event, "unified_msg_origin", "") or "")
-        config = self._get_session_config(get_config, session_id)
-        if not isinstance(config, dict):
-            return "local"
-        provider_settings = config.get("provider_settings", {})
-        if not isinstance(provider_settings, dict):
-            return "local"
-        runtime = provider_settings.get("computer_use_runtime", "local")
-        if isinstance(runtime, str) and runtime.strip():
-            return runtime.strip().lower()
-        return "local"
-
-    @staticmethod
-    def _get_session_config(get_config, session_id: str):
-        try:
-            signature = inspect.signature(get_config)
-        except (TypeError, ValueError):
-            try:
-                return get_config(session_id)
-            except TypeError:
-                try:
-                    return get_config(umo=session_id)
-                except TypeError:
-                    return get_config()
-
-        parameters = tuple(signature.parameters.values())
-        if any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
-        ) or "umo" in signature.parameters:
-            return get_config(umo=session_id)
-
-        if any(
-            parameter.kind
-            in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.VAR_POSITIONAL,
-            )
-            for parameter in parameters
-        ):
-            return get_config(session_id)
-
-        return get_config()
+        return resolve_computer_runtime_mode(self._astrbot_context, event)
 
     async def _acquire_sandbox_booter(
         self,

--- a/services/excel_script_service.py
+++ b/services/excel_script_service.py
@@ -428,7 +428,14 @@ class ExcelScriptService:
         capabilities = getattr(booter, "capabilities", None)
         if capabilities is not None:
             required_capabilities = {"python", "filesystem"}
-            missing = sorted(required_capabilities.difference(capabilities))
+            if isinstance(capabilities, dict):
+                missing = sorted(
+                    capability
+                    for capability in required_capabilities
+                    if not capabilities.get(capability)
+                )
+            else:
+                missing = sorted(required_capabilities.difference(capabilities))
             if missing:
                 missing_text = ", ".join(missing)
                 return (

--- a/services/file_read_service.py
+++ b/services/file_read_service.py
@@ -11,7 +11,13 @@ import mcp
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 
-from ..constants import PDF_SUFFIX, SUFFIX_TO_OFFICE_TYPE, TEXT_SUFFIXES, OfficeType
+from ..constants import (
+    EXCEL_SUFFIXES,
+    PDF_SUFFIX,
+    SUFFIX_TO_OFFICE_TYPE,
+    TEXT_SUFFIXES,
+    OfficeType,
+)
 from ..utils import extract_excel_sheets, format_file_size, safe_error_message
 
 if TYPE_CHECKING:
@@ -20,7 +26,7 @@ if TYPE_CHECKING:
 
 
 class FileReadService:
-    _EXCEL_SUFFIXES = frozenset({".xlsx", ".xls"})
+    _EXCEL_SUFFIXES = EXCEL_SUFFIXES
 
     @dataclass(frozen=True, slots=True)
     class ReadTarget:
@@ -108,10 +114,6 @@ class FileReadService:
             return
 
         try:
-            if target is None:
-                yield "错误：文件路径解析失败"
-                return
-
             resolved_path = target.resolved_path
             suffix = target.suffix
             if suffix in TEXT_SUFFIXES:
@@ -194,9 +196,6 @@ class FileReadService:
         )
         if err:
             yield err
-            return
-        if target is None:
-            yield "错误：文件路径解析失败"
             return
 
         try:

--- a/services/file_tool_service.py
+++ b/services/file_tool_service.py
@@ -42,6 +42,7 @@ class FileToolService:
     def __init__(
         self,
         *,
+        astrbot_context=None,
         workspace_service=None,
         office_generator=None,
         pdf_converter=None,
@@ -121,6 +122,7 @@ class FileToolService:
         self._excel_script_service = excel_script_service
         if self._excel_script_service is None and workspace_service is not None:
             self._excel_script_service = ExcelScriptService(
+                astrbot_context=astrbot_context,
                 workspace_service=workspace_service,
                 file_delivery_service=generated_output_delivery_service,
                 allow_external_input_files=allow_external_input_files,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -35,7 +35,10 @@ from .request_hook_notice_helpers import (
     FollowUpNoticeRule,
 )
 from .upload_types import UploadInfo
-from .runtime_config import resolve_computer_runtime_mode
+from .runtime_config import (
+    SUPPORTED_COMPUTER_RUNTIME_MODES,
+    resolve_computer_runtime_mode,
+)
 
 
 def _normalize_string_list(value: object) -> list[str]:
@@ -683,10 +686,16 @@ class RequestHookService:
                 f"[文件管理] 读取 Excel runtime 配置失败，跳过 execute_excel_script 显隐控制: {exc}"
             )
             return context
-        if runtime_mode != "none":
+        if runtime_mode in {"local", "sandbox"}:
             return context
         context.request.func_tool.remove_tool("execute_excel_script")
-        logger.info("[文件管理] 当前 computer runtime 为 none，已隐藏 execute_excel_script")
+        if runtime_mode == "none":
+            logger.info("[文件管理] 当前 computer runtime 为 none，已隐藏 execute_excel_script")
+            return context
+        if runtime_mode not in SUPPORTED_COMPUTER_RUNTIME_MODES:
+            logger.warning(
+                f"[文件管理] 当前 computer runtime 配置不受支持：{runtime_mode}，已隐藏 execute_excel_script"
+            )
         return context
 
     async def apply_explicit_file_tool_restriction(

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -1,4 +1,3 @@
-import inspect
 import re
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -36,6 +35,7 @@ from .request_hook_notice_helpers import (
     FollowUpNoticeRule,
 )
 from .upload_types import UploadInfo
+from .runtime_config import resolve_computer_runtime_mode
 
 
 def _normalize_string_list(value: object) -> list[str]:
@@ -220,54 +220,7 @@ class RequestHookService:
         return {str(name) for name in names() if name}
 
     def _resolve_excel_runtime_mode(self, event: AstrMessageEvent) -> str:
-        if self._astrbot_context is None:
-            return "local"
-        get_config = getattr(self._astrbot_context, "get_config", None)
-        if not callable(get_config):
-            return "local"
-        session_id = str(getattr(event, "unified_msg_origin", "") or "")
-        config = self._get_session_config(get_config, session_id)
-        if not isinstance(config, dict):
-            return "local"
-        provider_settings = config.get("provider_settings", {})
-        if not isinstance(provider_settings, dict):
-            return "local"
-        runtime = provider_settings.get("computer_use_runtime", "local")
-        if isinstance(runtime, str) and runtime.strip():
-            return runtime.strip().lower()
-        return "local"
-
-    @staticmethod
-    def _get_session_config(get_config, session_id: str):
-        try:
-            signature = inspect.signature(get_config)
-        except (TypeError, ValueError):
-            try:
-                return get_config(session_id)
-            except TypeError:
-                try:
-                    return get_config(umo=session_id)
-                except TypeError:
-                    return get_config()
-
-        parameters = tuple(signature.parameters.values())
-        if any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
-        ) or "umo" in signature.parameters:
-            return get_config(umo=session_id)
-
-        if any(
-            parameter.kind
-            in (
-                inspect.Parameter.POSITIONAL_ONLY,
-                inspect.Parameter.POSITIONAL_OR_KEYWORD,
-                inspect.Parameter.VAR_POSITIONAL,
-            )
-            for parameter in parameters
-        ):
-            return get_config(session_id)
-
-        return get_config()
+        return resolve_computer_runtime_mode(self._astrbot_context, event)
 
     @classmethod
     def _has_workbook_tools_available(cls, *, exposed_tool_names: set[str]) -> bool:

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -723,7 +723,14 @@ class RequestHookService:
     ) -> ToolExposureContext:
         if not (context.should_expose and context.request.func_tool):
             return context
-        if self._resolve_excel_runtime_mode(context.event) != "none":
+        try:
+            runtime_mode = self._resolve_excel_runtime_mode(context.event)
+        except Exception as exc:
+            logger.warning(
+                f"[文件管理] 读取 Excel runtime 配置失败，跳过 execute_excel_script 显隐控制: {exc}"
+            )
+            return context
+        if runtime_mode != "none":
             return context
         context.request.func_tool.remove_tool("execute_excel_script")
         logger.info("[文件管理] 当前 computer runtime 为 none，已隐藏 execute_excel_script")

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -1,3 +1,4 @@
+import inspect
 import re
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -111,6 +112,7 @@ class RequestHookService:
     def __init__(
         self,
         *,
+        astrbot_context=None,
         auto_block_execution_tools: bool,
         get_cached_upload_infos: Callable[[AstrMessageEvent], list[UploadInfo]],
         extract_upload_source: Callable[
@@ -123,6 +125,7 @@ class RequestHookService:
         lookup_document_summary: Callable[[str], dict[str, object] | None] | None = None,
         lookup_workbook_summary: Callable[[str], dict[str, object] | None] | None = None,
     ) -> None:
+        self._astrbot_context = astrbot_context
         self._auto_block_execution_tools = auto_block_execution_tools
         self._get_cached_upload_infos = get_cached_upload_infos
         self._extract_upload_source = extract_upload_source
@@ -144,6 +147,7 @@ class RequestHookService:
         ]
         self._tool_exposure_hooks = [
             self.apply_execution_tool_block,
+            self.apply_excel_script_runtime_restriction,
             self.apply_explicit_file_tool_restriction,
         ]
 
@@ -214,6 +218,56 @@ class RequestHookService:
         if not callable(names):
             return set()
         return {str(name) for name in names() if name}
+
+    def _resolve_excel_runtime_mode(self, event: AstrMessageEvent) -> str:
+        if self._astrbot_context is None:
+            return "local"
+        get_config = getattr(self._astrbot_context, "get_config", None)
+        if not callable(get_config):
+            return "local"
+        session_id = str(getattr(event, "unified_msg_origin", "") or "")
+        config = self._get_session_config(get_config, session_id)
+        if not isinstance(config, dict):
+            return "local"
+        provider_settings = config.get("provider_settings", {})
+        if not isinstance(provider_settings, dict):
+            return "local"
+        runtime = provider_settings.get("computer_use_runtime", "local")
+        if isinstance(runtime, str) and runtime.strip():
+            return runtime.strip().lower()
+        return "local"
+
+    @staticmethod
+    def _get_session_config(get_config, session_id: str):
+        try:
+            signature = inspect.signature(get_config)
+        except (TypeError, ValueError):
+            try:
+                return get_config(session_id)
+            except TypeError:
+                try:
+                    return get_config(umo=session_id)
+                except TypeError:
+                    return get_config()
+
+        parameters = tuple(signature.parameters.values())
+        if any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+        ) or "umo" in signature.parameters:
+            return get_config(umo=session_id)
+
+        if any(
+            parameter.kind
+            in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.VAR_POSITIONAL,
+            )
+            for parameter in parameters
+        ):
+            return get_config(session_id)
+
+        return get_config()
 
     @classmethod
     def _has_workbook_tools_available(cls, *, exposed_tool_names: set[str]) -> bool:
@@ -661,6 +715,18 @@ class RequestHookService:
             for tool_name in EXECUTION_TOOLS:
                 context.request.func_tool.remove_tool(tool_name)
             logger.debug("[文件管理] 已自动屏蔽 shell/python 执行类工具")
+        return context
+
+    async def apply_excel_script_runtime_restriction(
+        self,
+        context: ToolExposureContext,
+    ) -> ToolExposureContext:
+        if not (context.should_expose and context.request.func_tool):
+            return context
+        if self._resolve_excel_runtime_mode(context.event) != "none":
+            return context
+        context.request.func_tool.remove_tool("execute_excel_script")
+        logger.info("[文件管理] 当前 computer runtime 为 none，已隐藏 execute_excel_script")
         return context
 
     async def apply_explicit_file_tool_restriction(

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -141,6 +141,7 @@ def build_plugin_runtime(
         store_uploaded_file=store_uploaded_file,
     )
     file_processing_services = _build_file_processing_services(
+        astrbot_context=context,
         settings=settings,
         workspace_service=workspace_service,
         delivery_service=delivery_service,
@@ -315,6 +316,7 @@ def _build_workbook_summary_lookup(workbook_toolset):
 
 def _build_file_processing_services(
     *,
+    astrbot_context,
     settings: PluginSettings,
     workspace_service: WorkspaceService,
     delivery_service: DeliveryService,
@@ -363,6 +365,7 @@ def _build_file_processing_services(
         group_feature_disabled_error=access_policy_service.group_feature_disabled_error,
     )
     file_tool_service = FileToolService(
+        astrbot_context=astrbot_context,
         workspace_service=workspace_service,
         office_generator=office_gen,
         pdf_converter=pdf_converter,

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -132,6 +132,7 @@ def build_plugin_runtime(
         after_export=handle_exported_document_tool,
     )
     request_pipeline_services = _build_request_pipeline_services(
+        astrbot_context=context,
         settings=settings,
         upload_session_service=upload_session_service,
         access_policy_service=access_policy_service,
@@ -236,6 +237,7 @@ def _build_default_document_style(settings: PluginSettings) -> dict[str, object]
 
 def _build_request_pipeline_services(
     *,
+    astrbot_context,
     settings: PluginSettings,
     upload_session_service: UploadSessionService,
     access_policy_service: AccessPolicyService,
@@ -249,6 +251,7 @@ def _build_request_pipeline_services(
     )
 
     request_hook_service = RequestHookService(
+        astrbot_context=astrbot_context,
         auto_block_execution_tools=settings.auto_block_execution_tools,
         get_cached_upload_infos=upload_session_service.get_cached_upload_infos,
         extract_upload_source=extract_upload_source,

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -17,11 +17,6 @@ def get_session_config(get_config, session_id: str):
 
     parameters = tuple(signature.parameters.values())
     if any(
-        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
-    ) or "umo" in signature.parameters:
-        return get_config(umo=session_id)
-
-    if any(
         parameter.kind
         in (
             inspect.Parameter.POSITIONAL_ONLY,
@@ -31,6 +26,11 @@ def get_session_config(get_config, session_id: str):
         for parameter in parameters
     ):
         return get_config(session_id)
+
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    ) or "umo" in signature.parameters:
+        return get_config(umo=session_id)
 
     return get_config()
 

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -2,6 +2,8 @@ import inspect
 
 from astrbot.api.event import AstrMessageEvent
 
+SUPPORTED_COMPUTER_RUNTIME_MODES = frozenset({"local", "sandbox", "none"})
+
 
 def get_session_config(get_config, session_id: str):
     try:

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -67,7 +67,15 @@ def resolve_computer_runtime_mode(
     provider_settings = config.get("provider_settings", {})
     if not isinstance(provider_settings, dict):
         return default
-    runtime = provider_settings.get("computer_use_runtime", default)
+    if "computer_use_runtime" not in provider_settings:
+        return default
+    runtime = provider_settings.get("computer_use_runtime")
     if isinstance(runtime, str) and runtime.strip():
         return runtime.strip().lower()
-    return default
+    if runtime is None:
+        return "null"
+    if isinstance(runtime, bool):
+        return str(runtime).lower()
+    if isinstance(runtime, str):
+        return "<empty>"
+    return str(runtime)

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -1,0 +1,62 @@
+import inspect
+
+from astrbot.api.event import AstrMessageEvent
+
+
+def get_session_config(get_config, session_id: str):
+    try:
+        signature = inspect.signature(get_config)
+    except (TypeError, ValueError):
+        try:
+            return get_config(session_id)
+        except TypeError:
+            try:
+                return get_config(umo=session_id)
+            except TypeError:
+                return get_config()
+
+    parameters = tuple(signature.parameters.values())
+    if any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters
+    ) or "umo" in signature.parameters:
+        return get_config(umo=session_id)
+
+    if any(
+        parameter.kind
+        in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        )
+        for parameter in parameters
+    ):
+        return get_config(session_id)
+
+    return get_config()
+
+
+def resolve_computer_runtime_mode(
+    astrbot_context,
+    event: AstrMessageEvent,
+    *,
+    default: str = "local",
+) -> str:
+    if astrbot_context is None:
+        return default
+    config = None
+    get_config = getattr(astrbot_context, "get_config", None)
+    if callable(get_config):
+        session_id = str(getattr(event, "unified_msg_origin", "") or "")
+        config = get_session_config(get_config, session_id)
+    if not isinstance(config, dict):
+        legacy_config = getattr(astrbot_context, "astrbot_config", None)
+        config = legacy_config if isinstance(legacy_config, dict) else None
+    if not isinstance(config, dict):
+        return default
+    provider_settings = config.get("provider_settings", {})
+    if not isinstance(provider_settings, dict):
+        return default
+    runtime = provider_settings.get("computer_use_runtime", default)
+    if isinstance(runtime, str) and runtime.strip():
+        return runtime.strip().lower()
+    return default

--- a/services/runtime_config.py
+++ b/services/runtime_config.py
@@ -5,16 +5,25 @@ from astrbot.api.event import AstrMessageEvent
 SUPPORTED_COMPUTER_RUNTIME_MODES = frozenset({"local", "sandbox", "none"})
 
 
+def _is_call_shape_type_error(exc: TypeError) -> bool:
+    traceback_obj = exc.__traceback__
+    return traceback_obj is not None and traceback_obj.tb_next is None
+
+
 def get_session_config(get_config, session_id: str):
     try:
         signature = inspect.signature(get_config)
     except (TypeError, ValueError):
         try:
             return get_config(session_id)
-        except TypeError:
+        except TypeError as exc:
+            if not _is_call_shape_type_error(exc):
+                raise
             try:
                 return get_config(umo=session_id)
-            except TypeError:
+            except TypeError as exc:
+                if not _is_call_shape_type_error(exc):
+                    raise
                 return get_config()
 
     parameters = tuple(signature.parameters.values())

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -243,6 +243,40 @@ async def test_before_llm_chat_keeps_workbook_id_follow_up_prompt_lightweight():
 
 
 @pytest.mark.asyncio
+async def test_before_llm_chat_hides_execute_excel_script_when_runtime_is_none():
+    context = MagicMock()
+    context.get_config.side_effect = lambda *args, **kwargs: {
+        "provider_settings": {"computer_use_runtime": "none"}
+    }
+    plugin = FileOperationPlugin(context=context, config=_build_config())
+    try:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        req = ProviderRequest(
+            prompt="请生成一个带公式和条件格式的 Excel 报表",
+            system_prompt="base",
+            func_tool=ToolSet(
+                [
+                    _tool("existing_tool"),
+                    _tool("execute_excel_script"),
+                    _tool("astrbot_execute_shell"),
+                ]
+            ),
+        )
+
+        await plugin.before_llm_chat(event, req)
+
+        tool_names = set(req.func_tool.names())
+        assert "existing_tool" in tool_names
+        assert "astrbot_execute_shell" not in tool_names
+        assert "execute_excel_script" not in tool_names
+        assert "execute_excel_script" not in req.prompt
+    finally:
+        await plugin.terminate()
+
+
+@pytest.mark.asyncio
 async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
     context = MagicMock()
     plugin = FileOperationPlugin(context=context, config=_build_config())

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -1,3 +1,4 @@
+import contextlib
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -34,6 +35,8 @@ from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entities import ProviderRequest
 from conftest import build_notice_once_callback as _build_notice_once_callback
+
+_REQUEST_FUNC_TOOL_UNSET = object()
 
 
 def _build_config() -> dict:
@@ -93,26 +96,81 @@ def _tool(name: str) -> FunctionTool:
     )
 
 
+def _build_provider_request(
+    prompt: str,
+    *,
+    tool_names: list[str] | tuple[str, ...] | None = None,
+    system_prompt: str = "base",
+    func_tool=_REQUEST_FUNC_TOOL_UNSET,
+):
+    if func_tool is _REQUEST_FUNC_TOOL_UNSET:
+        func_tool = ToolSet([_tool(name) for name in tool_names or []])
+    return ProviderRequest(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        func_tool=func_tool,
+    )
+
+
+@contextlib.asynccontextmanager
+async def _managed_plugin(*, context=None, config=None):
+    effective_context = context or MagicMock()
+    plugin = FileOperationPlugin(
+        context=effective_context,
+        config=config or _build_config(),
+    )
+    try:
+        yield SimpleNamespace(context=effective_context, plugin=plugin)
+    finally:
+        await plugin.terminate()
+
+
+def _build_request_hook_service(
+    *,
+    auto_block_execution_tools: bool = True,
+    get_cached_upload_infos=None,
+    extract_upload_source=None,
+    store_uploaded_file=None,
+    consume_session_notice_once=None,
+    allow_external_input_files: bool = False,
+):
+    return RequestHookService(
+        auto_block_execution_tools=auto_block_execution_tools,
+        get_cached_upload_infos=get_cached_upload_infos or (lambda _event: []),
+        extract_upload_source=extract_upload_source or AsyncMock(),
+        store_uploaded_file=store_uploaded_file or MagicMock(),
+        consume_session_notice_once=consume_session_notice_once
+        or _build_notice_once_callback(),
+        allow_external_input_files=allow_external_input_files,
+    )
+
+
+def _configure_uploaded_file(
+    plugin: FileOperationPlugin,
+    *,
+    source_path: Path,
+    original_name: str,
+    stored_name: str,
+):
+    async def _fake_extract_upload_source(_component):
+        return source_path, original_name
+
+    plugin._extract_upload_source = _fake_extract_upload_source
+    plugin._store_uploaded_file = lambda *_args, **_kwargs: Path(stored_name)
+
+
 @pytest.mark.asyncio
 async def test_before_llm_chat_injects_document_tools_per_request():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt="请生成一份 Word 报告，并导出给我。",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("astrbot_execute_shell"),
-                ]
-            ),
+        req = _build_provider_request(
+            "请生成一份 Word 报告，并导出给我。",
+            tool_names=["existing_tool", "astrbot_execute_shell"],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -130,66 +188,46 @@ async def test_before_llm_chat_injects_document_tools_per_request():
         assert "NEVER 调用网络搜索" in req.prompt
         assert "文件工具使用指南" not in req.system_prompt
         assert req.prompt.startswith("请生成一份 Word 报告，并导出给我。")
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt='继续完善 document_id="doc-1" 的内容',
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("create_document"),
-                ]
-            ),
+        req = _build_provider_request(
+            '继续完善 document_id="doc-1" 的内容',
+            tool_names=["existing_tool", "create_document"],
         )
-        document_store = plugin._runtime.document_toolset.document_store
+        document_store = managed.plugin._runtime.document_toolset.document_store
         document = document_store.create_document(
             CreateDocumentRequest(title="季度经营复盘")
         )
 
         req.prompt = f'继续完善 document_id="{document.document_id}" 的内容'
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         assert "文件工具使用指南" not in req.system_prompt
         assert "当前文档状态摘要" not in req.system_prompt
         assert "文件工具使用指南" not in req.prompt
         assert "当前文档状态摘要" not in req.prompt
         assert "文件工具细节指南" not in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_injects_workbook_tools_per_request():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt="请生成一个 Excel 汇总表，分多 sheet 输出给我。",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("astrbot_execute_shell"),
-                ]
-            ),
+        req = _build_provider_request(
+            "请生成一个 Excel 汇总表，分多 sheet 输出给我。",
+            tool_names=["existing_tool", "astrbot_execute_shell"],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -203,43 +241,31 @@ async def test_before_llm_chat_injects_workbook_tools_per_request():
         assert "create_workbook" in req.prompt
         assert "write_rows" in req.prompt
         assert "export_workbook" in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_keeps_workbook_id_follow_up_prompt_lightweight():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt='继续补充 workbook_id="wb-1" 的数据',
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("create_workbook"),
-                ]
-            ),
+        req = _build_provider_request(
+            '继续补充 workbook_id="wb-1" 的数据',
+            tool_names=["existing_tool", "create_workbook"],
         )
-        workbook_store = plugin._runtime.workbook_toolset.workbook_store
+        workbook_store = managed.plugin._runtime.workbook_toolset.workbook_store
         workbook = workbook_store.create_workbook(
             CreateWorkbookRequest(filename="sales-summary.xlsx")
         )
 
         req.prompt = f'继续补充 workbook_id="{workbook.workbook_id}" 的数据'
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         assert "Excel 原语工具使用指南" not in req.system_prompt
         assert "Excel 原语工具使用指南" not in req.prompt
         assert "当前工作簿阶段" in req.prompt
         assert "`create_workbook` → `write_rows`" not in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -248,54 +274,40 @@ async def test_before_llm_chat_hides_execute_excel_script_when_runtime_is_none()
     context.get_config.side_effect = lambda *args, **kwargs: {
         "provider_settings": {"computer_use_runtime": "none"}
     }
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin(context=context) as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt="请生成一个带公式和条件格式的 Excel 报表",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("execute_excel_script"),
-                    _tool("astrbot_execute_shell"),
-                ]
-            ),
+        req = _build_provider_request(
+            "请生成一个带公式和条件格式的 Excel 报表",
+            tool_names=[
+                "existing_tool",
+                "execute_excel_script",
+                "astrbot_execute_shell",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "astrbot_execute_shell" not in tool_names
         assert "execute_excel_script" not in tool_names
         assert "execute_excel_script" not in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
         )
-        req = ProviderRequest(
-            prompt="hello",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("astrbot_execute_shell"),
-                ]
-            ),
+        req = _build_provider_request(
+            "hello",
+            tool_names=["existing_tool", "astrbot_execute_shell"],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -308,22 +320,18 @@ async def test_before_llm_chat_skips_document_guide_for_generic_prompt():
         }.issubset(tool_names)
         assert "文件工具使用指南" not in req.system_prompt
         assert "文件工具使用指南" not in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruction():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
         event._buffered = True
-        req = ProviderRequest(
-            prompt=(
+        req = _build_provider_request(
+            (
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
                 "- 原始文件名: source.docx\n"
@@ -333,16 +341,10 @@ async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruct
                 "[处理要求]\n"
                 "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("astrbot_execute_shell"),
-                ]
-            ),
+            tool_names=["existing_tool", "astrbot_execute_shell"],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -356,32 +358,25 @@ async def test_before_llm_chat_injects_document_guide_for_buffered_word_instruct
         assert "文件工具使用指南" in req.prompt
         assert "文件工具细节指南" not in req.prompt
         assert "文件工具使用指南" not in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_removes_file_tools_without_permission():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2"
         )
-        req = ProviderRequest(
-            prompt="hello",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("export_document"),
-                    _tool("existing_tool"),
-                ]
-            ),
+        req = _build_provider_request(
+            "hello",
+            tool_names=[
+                "read_file",
+                "create_document",
+                "export_document",
+                "existing_tool",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -392,30 +387,23 @@ async def test_before_llm_chat_removes_file_tools_without_permission():
         assert "generate_complex_word_document" not in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
         assert "`astrbot_execute_python`" in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_warns_when_group_feature_disabled():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(message_type=MessageType.GROUP_MESSAGE, sender_id="user-1")
-        req = ProviderRequest(
-            prompt="请生成一份 Word 报告",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("astrbot_execute_python"),
-                    _tool("existing_tool"),
-                ]
-            ),
+        req = _build_provider_request(
+            "请生成一份 Word 报告",
+            tool_names=[
+                "read_file",
+                "create_document",
+                "astrbot_execute_python",
+                "existing_tool",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -426,15 +414,11 @@ async def test_before_llm_chat_warns_when_group_feature_disabled():
         assert "generate_complex_word_document" not in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
         assert "`astrbot_execute_python`" in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_requires_read_before_document_tools_for_uploaded_files():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
@@ -443,28 +427,21 @@ async def test_before_llm_chat_requires_read_before_document_tools_for_uploaded_
         event.message_obj.message = [
             Comp.File(name="source.docx", file=str(source_path)),
         ]
-
-        async def _fake_extract_upload_source(_component):
-            return source_path, "source.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.docx")
-
-        req = ProviderRequest(
-            prompt="根据上传文档整理成正式汇报",
-            system_prompt="base",
-            func_tool=ToolSet([_tool("existing_tool")]),
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="source.docx",
+            stored_name="source_1.docx",
         )
+        req = _build_provider_request("根据上传文档整理成正式汇报", tool_names=["existing_tool"])
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         assert "read_file" in req.prompt
         assert "source.docx" in req.prompt
         assert "source_1.docx" in req.prompt
         assert "读取前不要创建新文档" in req.prompt
         assert "source_1.docx" not in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -489,30 +466,25 @@ async def test_before_llm_chat_restricts_file_tools_for_explicit_tool_call(
     prompt: str,
     expected_tool: str,
 ):
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
-        req = ProviderRequest(
-            prompt=prompt,
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("create_office_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                    _tool("finalize_document"),
-                    _tool("export_document"),
-                    _tool("read_file"),
-                ]
-            ),
+        req = _build_provider_request(
+            prompt,
+            tool_names=[
+                "existing_tool",
+                "create_office_file",
+                "create_document",
+                "add_blocks",
+                "finalize_document",
+                "export_document",
+                "read_file",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -522,34 +494,27 @@ async def test_before_llm_chat_restricts_file_tools_for_explicit_tool_call(
         assert "finalize_document" not in tool_names
         assert "export_document" not in tool_names
         assert "read_file" not in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_does_not_restrict_when_prompt_mentions_multiple_tools():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
-        req = ProviderRequest(
-            prompt="先调用 read_file 再调用 create_document 处理文件",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                    _tool("export_document"),
-                ]
-            ),
+        req = _build_provider_request(
+            "先调用 read_file 再调用 create_document 处理文件",
+            tool_names=[
+                "existing_tool",
+                "read_file",
+                "create_document",
+                "add_blocks",
+                "export_document",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -557,41 +522,32 @@ async def test_before_llm_chat_does_not_restrict_when_prompt_mentions_multiple_t
         assert "create_document" in tool_names
         assert "add_blocks" in tool_names
         assert "export_document" in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_does_not_restrict_for_question_style_tool_mention():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
-        req = ProviderRequest(
-            prompt="请问 create_office_file 怎么用？先告诉我可用工具。",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("create_office_file"),
-                    _tool("create_document"),
-                    _tool("read_file"),
-                ]
-            ),
+        req = _build_provider_request(
+            "请问 create_office_file 怎么用？先告诉我可用工具。",
+            tool_names=[
+                "existing_tool",
+                "create_office_file",
+                "create_document",
+                "read_file",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "create_office_file" in tool_names
         assert "create_document" in tool_names
         assert "read_file" in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -605,62 +561,50 @@ async def test_before_llm_chat_does_not_restrict_for_question_style_tool_mention
 async def test_before_llm_chat_does_not_restrict_for_non_explicit_tool_mentions(
     prompt: str,
 ):
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
-        req = ProviderRequest(
-            prompt=prompt,
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("create_office_file"),
-                    _tool("create_document"),
-                    _tool("read_file"),
-                ]
-            ),
+        req = _build_provider_request(
+            prompt,
+            tool_names=[
+                "existing_tool",
+                "create_office_file",
+                "create_document",
+                "read_file",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "create_office_file" in tool_names
         assert "create_document" in tool_names
         assert "read_file" in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_does_not_treat_system_notice_as_explicit_tool_call():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
         event.message_str = "[System Notice] 用户上传了文件，请先调用 `read_file` 读取内容，再继续处理。"
-        req = ProviderRequest(
-            prompt="",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                    _tool("export_document"),
-                ]
-            ),
+        req = _build_provider_request(
+            "",
+            tool_names=[
+                "existing_tool",
+                "read_file",
+                "create_document",
+                "add_blocks",
+                "export_document",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -668,55 +612,44 @@ async def test_before_llm_chat_does_not_treat_system_notice_as_explicit_tool_cal
         assert "create_document" in tool_names
         assert "add_blocks" in tool_names
         assert "export_document" in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_falls_back_to_raw_prompt_when_system_notice_block_is_missing():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
-        req = ProviderRequest(
-            prompt="[System Notice] 这是用户自己输入的字面量。调用 read_file，filename=report.txt",
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                ]
-            ),
+        req = _build_provider_request(
+            "[System Notice] 这是用户自己输入的字面量。调用 read_file，filename=report.txt",
+            tool_names=[
+                "existing_tool",
+                "read_file",
+                "create_document",
+                "add_blocks",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "read_file" in tool_names
         assert "create_document" not in tool_names
         assert "add_blocks" not in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_uses_buffered_user_instruction_for_explicit_tool_detection():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
         event._buffered = True
-        req = ProviderRequest(
-            prompt=(
+        req = _build_provider_request(
+            (
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
                 "- 原始文件名: source.docx\n"
@@ -726,20 +659,17 @@ async def test_before_llm_chat_uses_buffered_user_instruction_for_explicit_tool_
                 "[处理要求]\n"
                 "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                    _tool("finalize_document"),
-                    _tool("export_document"),
-                ]
-            ),
+            tool_names=[
+                "existing_tool",
+                "read_file",
+                "create_document",
+                "add_blocks",
+                "finalize_document",
+                "export_document",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
@@ -748,22 +678,18 @@ async def test_before_llm_chat_uses_buffered_user_instruction_for_explicit_tool_
         assert "add_blocks" in tool_names
         assert "finalize_document" in tool_names
         assert "export_document" in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_can_still_restrict_tool_from_buffered_user_instruction():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
             sender_id="user-1",
         )
         event._buffered = True
-        req = ProviderRequest(
-            prompt=(
+        req = _build_provider_request(
+            (
                 "[System Notice] 用户上传了 1 个文件\n\n"
                 "[文件信息]\n"
                 "- 原始文件名: table.csv\n"
@@ -773,26 +699,21 @@ async def test_before_llm_chat_can_still_restrict_tool_from_buffered_user_instru
                 "[处理要求]\n"
                 "1. 优先围绕这些上传文件完成用户请求。\n"
             ),
-            system_prompt="base",
-            func_tool=ToolSet(
-                [
-                    _tool("existing_tool"),
-                    _tool("read_file"),
-                    _tool("create_document"),
-                    _tool("add_blocks"),
-                ]
-            ),
+            tool_names=[
+                "existing_tool",
+                "read_file",
+                "create_document",
+                "add_blocks",
+            ],
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "existing_tool" in tool_names
         assert "read_file" in tool_names
         assert "create_document" not in tool_names
         assert "add_blocks" not in tool_names
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -816,10 +737,9 @@ async def test_llm_request_policy_runs_internal_notice_and_tool_hooks():
         tool_exposure_hooks=[_custom_tool_hook],
     )
     event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1")
-    req = ProviderRequest(
-        prompt="hello",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("create_document"), _tool("existing_tool")]),
+    req = _build_provider_request(
+        "hello",
+        tool_names=["create_document", "existing_tool"],
     )
 
     await policy.apply(event, req)
@@ -850,14 +770,7 @@ async def test_llm_request_policy_does_not_build_request_hook_service_when_hooks
 
 @pytest.mark.asyncio
 async def test_llm_request_policy_uses_injected_request_hook_service_for_default_hooks():
-    request_hook_service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
-    )
+    request_hook_service = _build_request_hook_service()
     policy = LLMRequestPolicy(
         document_toolset=SimpleNamespace(tools=[_tool("create_document")]),
         require_at_in_group=True,
@@ -867,16 +780,13 @@ async def test_llm_request_policy_uses_injected_request_hook_service_for_default
         request_hook_service=request_hook_service,
     )
     event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1")
-    req = ProviderRequest(
-        prompt="请生成一份 Word 报告，并导出给我。",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("create_document"),
-                _tool("existing_tool"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    req = _build_provider_request(
+        "请生成一份 Word 报告，并导出给我。",
+        tool_names=[
+            "create_document",
+            "existing_tool",
+            "astrbot_execute_shell",
+        ],
     )
 
     with patch(
@@ -917,11 +827,7 @@ async def test_llm_request_policy_appends_notice_to_prompt_suffix_without_extra_
         tool_exposure_hooks=[],
     )
     event = _build_event()
-    req = ProviderRequest(
-        prompt="hello",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("existing_tool")]),
-    )
+    req = _build_provider_request("hello", tool_names=["existing_tool"])
 
     await policy.apply(event, req)
 
@@ -945,11 +851,7 @@ async def test_llm_request_policy_uses_notice_directly_when_prompt_is_empty():
         tool_exposure_hooks=[],
     )
     event = _build_event()
-    req = ProviderRequest(
-        prompt="",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("existing_tool")]),
-    )
+    req = _build_provider_request("", tool_names=["existing_tool"])
 
     await policy.apply(event, req)
 
@@ -975,10 +877,9 @@ async def test_llm_request_policy_checks_permission_once_per_request():
         tool_exposure_hooks=[],
     )
     event = _build_event(message_type=MessageType.FRIEND_MESSAGE, sender_id="user-2")
-    req = ProviderRequest(
-        prompt="hello",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("create_document"), _tool("existing_tool")]),
+    req = _build_provider_request(
+        "hello",
+        tool_names=["create_document", "existing_tool"],
     )
 
     await policy.apply(event, req)
@@ -1003,8 +904,7 @@ def test_llm_request_policy_requires_hook_pairs():
 
 @pytest.mark.asyncio
 async def test_llm_request_policy_returns_after_tools_denied_notice():
-    request_hook_service = RequestHookService(
-        auto_block_execution_tools=True,
+    request_hook_service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: [
             {
                 "original_name": "report.docx",
@@ -1014,10 +914,6 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
                 "is_supported": True,
             }
         ],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
     policy = LLMRequestPolicy(
         document_toolset=SimpleNamespace(tools=[_tool("create_document")]),
@@ -1031,16 +927,13 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
     event.message_obj.message = [
         Comp.File(name="report.docx", file="/tmp/report.docx"),
     ]
-    req = ProviderRequest(
-        prompt="根据上传文件整理一下",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_file"),
-                _tool("existing_tool"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    req = _build_provider_request(
+        "根据上传文件整理一下",
+        tool_names=[
+            "read_file",
+            "existing_tool",
+            "astrbot_execute_shell",
+        ],
     )
 
     await policy.apply(event, req)
@@ -1054,14 +947,7 @@ async def test_llm_request_policy_returns_after_tools_denied_notice():
 
 @pytest.mark.asyncio
 async def test_llm_request_policy_group_switch_off_hides_execution_tools():
-    request_hook_service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
-    )
+    request_hook_service = _build_request_hook_service()
     policy = LLMRequestPolicy(
         document_toolset=SimpleNamespace(tools=[_tool("create_document")]),
         require_at_in_group=True,
@@ -1071,16 +957,13 @@ async def test_llm_request_policy_group_switch_off_hides_execution_tools():
         request_hook_service=request_hook_service,
     )
     event = _build_event(message_type=MessageType.GROUP_MESSAGE, sender_id="user-2")
-    req = ProviderRequest(
-        prompt="根据上传文件整理一下",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_file"),
-                _tool("existing_tool"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    req = _build_provider_request(
+        "根据上传文件整理一下",
+        tool_names=[
+            "read_file",
+            "existing_tool",
+            "astrbot_execute_shell",
+        ],
     )
 
     await policy.apply(event, req)
@@ -1093,13 +976,9 @@ async def test_llm_request_policy_group_switch_off_hides_execution_tools():
 
 @pytest.mark.asyncio
 async def test_runtime_bundle_does_not_expose_recent_text_cache():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
-        assert hasattr(plugin._runtime, "upload_session_service") is True
-        assert hasattr(plugin._runtime, "recent_text_by_session") is False
-    finally:
-        await plugin.terminate()
+    async with _managed_plugin() as managed:
+        assert hasattr(managed.plugin._runtime, "upload_session_service") is True
+        assert hasattr(managed.plugin._runtime, "recent_text_by_session") is False
 
 
 @pytest.mark.asyncio
@@ -1187,62 +1066,50 @@ async def test_handle_exported_document_tool_uses_bound_service_after_runtime_re
 
 @pytest.mark.asyncio
 async def test_doc_list_command_stops_event_after_sending():
-    context = MagicMock()
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(config=config) as managed:
         event = _build_event(message_type=MessageType.GROUP_MESSAGE)
         event.set_result = MagicMock()
 
-        await plugin.doc_list(event)
+        await managed.plugin.doc_list(event)
 
         event.set_result.assert_called_once()
         result = event.set_result.call_args.args[0]
         assert result.get_plain_text() == "当前没有可处理的上传文件。"
         assert result.is_stopped() is True
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_doc_use_command_stops_event_after_requeue():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         event = _build_event(message_type=MessageType.GROUP_MESSAGE)
         event.stop_event = MagicMock()
-        plugin._runtime.command_service.doc_use = AsyncMock(return_value=None)
+        managed.plugin._runtime.command_service.doc_use = AsyncMock(return_value=None)
 
-        await plugin.doc_use(event, "f1 根据这份文件整理")
+        await managed.plugin.doc_use(event, "f1 根据这份文件整理")
 
-        plugin._runtime.command_service.doc_use.assert_awaited_once_with(
+        managed.plugin._runtime.command_service.doc_use.assert_awaited_once_with(
             event,
             "f1 根据这份文件整理",
         )
         event.stop_event.assert_called_once_with()
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_doc_clear_command_sets_stopped_result():
-    context = MagicMock()
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(config=config) as managed:
         event = _build_event(message_type=MessageType.GROUP_MESSAGE)
         event.set_result = MagicMock()
 
-        await plugin.doc_clear(event, "")
+        await managed.plugin.doc_clear(event, "")
 
         event.set_result.assert_called_once()
         result = event.set_result.call_args.args[0]
         assert result.get_plain_text() == "❌ 当前没有可处理的上传文件。"
         assert result.is_stopped() is True
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -1250,24 +1117,23 @@ async def test_buffered_upload_without_prompt_requeues_in_friend_chat():
     context = MagicMock()
     event_queue = AsyncMock()
     context.get_event_queue.return_value = event_queue
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin(context=context) as managed:
         source_path = Path(__file__).resolve()
         event = _build_event()
         upload = Comp.File(name="report.docx", file="report.docx")
         buf = BufferedMessage(event=event, files=[upload], texts=[])
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="report.docx",
+            stored_name="report_1.docx",
+        )
 
-        async def _fake_extract_upload_source(_component):
-            return source_path, "report.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("report_1.docx")
-
-        await plugin._on_buffer_complete(buf)
+        await managed.plugin._on_buffer_complete(buf)
 
         queued_event = event_queue.put.await_args.args[0]
         prompt_text = queued_event.message_obj.message[0].text
-        upload_infos = plugin._runtime.upload_session_service.list_session_upload_infos(
+        upload_infos = managed.plugin._runtime.upload_session_service.list_session_upload_infos(
             event
         )
         assert len(upload_infos) == 1
@@ -1276,8 +1142,6 @@ async def test_buffered_upload_without_prompt_requeues_in_friend_chat():
         assert upload_infos[0]["file_id"] == "f1"
         assert "[用户指令]" not in prompt_text
         assert "用户意图尚不明确时，再用中文询问用户想要如何处理" in prompt_text
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -1285,31 +1149,28 @@ async def test_buffered_upload_without_prompt_only_caches_upload_infos_in_group_
     context = MagicMock()
     event_queue = AsyncMock()
     context.get_event_queue.return_value = event_queue
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin(context=context) as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(message_type=MessageType.GROUP_MESSAGE)
         upload = Comp.File(name="report.docx", file="report.docx")
         buf = BufferedMessage(event=event, files=[upload], texts=[])
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="report.docx",
+            stored_name="report_1.docx",
+        )
 
-        async def _fake_extract_upload_source(_component):
-            return source_path, "report.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("report_1.docx")
-
-        await plugin._on_buffer_complete(buf)
+        await managed.plugin._on_buffer_complete(buf)
 
         event_queue.put.assert_not_awaited()
-        upload_infos = plugin._runtime.upload_session_service.list_session_upload_infos(
+        upload_infos = managed.plugin._runtime.upload_session_service.list_session_upload_infos(
             event
         )
         assert len(upload_infos) == 1
         assert upload_infos[0]["original_name"] == "report.docx"
         assert upload_infos[0]["stored_name"] == "report_1.docx"
         assert upload_infos[0]["file_id"] == "f1"
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -1367,8 +1228,7 @@ async def test_before_llm_chat_exposes_file_tools_for_buffered_group_upload_when
     context.get_event_queue.return_value = event_queue
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(context=context, config=config) as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(
             message_type=MessageType.GROUP_MESSAGE,
@@ -1388,23 +1248,22 @@ async def test_before_llm_chat_exposes_file_tools_for_buffered_group_upload_when
             files=[upload],
             texts=["请根据上传文档整理成正式汇报"],
         )
-
-        async def _fake_extract_upload_source(_component):
-            return source_path, "source.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.docx")
-
-        await plugin._on_buffer_complete(buf)
-        queued_event = event_queue.put.await_args.args[0]
-
-        req = ProviderRequest(
-            prompt=queued_event.message_str,
-            system_prompt="base",
-            func_tool=ToolSet([_tool("existing_tool")]),
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="source.docx",
+            stored_name="source_1.docx",
         )
 
-        await plugin.before_llm_chat(queued_event, req)
+        await managed.plugin._on_buffer_complete(buf)
+        queued_event = event_queue.put.await_args.args[0]
+
+        req = _build_provider_request(
+            queued_event.message_str,
+            tool_names=["existing_tool"],
+        )
+
+        await managed.plugin.before_llm_chat(queued_event, req)
 
         tool_names = set(req.func_tool.names())
         assert queued_event.message_obj.raw_message is raw_message
@@ -1414,8 +1273,6 @@ async def test_before_llm_chat_exposes_file_tools_for_buffered_group_upload_when
         assert "export_document" in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
         assert "source_1.docx" in req.prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
@@ -1425,8 +1282,7 @@ async def test_before_llm_chat_hides_file_tools_for_buffered_group_upload_when_n
     context.get_event_queue.return_value = event_queue
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(context=context, config=config) as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(
             message_type=MessageType.GROUP_MESSAGE,
@@ -1446,22 +1302,21 @@ async def test_before_llm_chat_hides_file_tools_for_buffered_group_upload_when_n
             files=[upload],
             texts=["请根据上传文档整理成正式汇报"],
         )
-
-        async def _fake_extract_upload_source(_component):
-            return source_path, "source.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.docx")
-
-        await plugin._on_buffer_complete(buf)
-
-        req = ProviderRequest(
-            prompt=event.message_str,
-            system_prompt="base",
-            func_tool=ToolSet([_tool("existing_tool")]),
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="source.docx",
+            stored_name="source_1.docx",
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin._on_buffer_complete(buf)
+
+        req = _build_provider_request(
+            event.message_str,
+            tool_names=["existing_tool"],
+        )
+
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert event.message_obj.raw_message is raw_message
@@ -1471,17 +1326,13 @@ async def test_before_llm_chat_hides_file_tools_for_buffered_group_upload_when_n
         assert "export_document" not in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
         assert "工作区文件名：source_1.docx" not in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_exposes_file_tools_for_group_doc_command_without_mention():
-    context = MagicMock()
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(config=config) as managed:
         event = _build_event(
             message_type=MessageType.GROUP_MESSAGE,
             sender_id="user-1",
@@ -1494,35 +1345,27 @@ async def test_before_llm_chat_exposes_file_tools_for_group_doc_command_without_
             "[文件信息]\n"
             "- 原始文件名: B.xlsx\n"
             "  工作区文件名: B_1.xlsx\n\n"
-            "[用户指令]\n"
-            "根据这份文件整理成正式汇报\n\n"
-            "[处理要求]\n"
-            "1. 优先围绕这些上传文件完成用户请求。\n"
+                "[用户指令]\n"
+                "根据这份文件整理成正式汇报\n\n"
+                "[处理要求]\n"
+                "1. 优先围绕这些上传文件完成用户请求。\n"
         )
-        req = ProviderRequest(
-            prompt=event.message_str,
-            system_prompt="base",
-            func_tool=ToolSet([_tool("existing_tool")]),
-        )
+        req = _build_provider_request(event.message_str, tool_names=["existing_tool"])
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         tool_names = set(req.func_tool.names())
         assert "create_document" in tool_names
         assert "add_blocks" in tool_names
         assert "export_document" in tool_names
         assert "当前聊天不可使用文件/Office/PDF 相关功能" not in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_does_not_inject_upload_notice_when_file_tools_hidden():
-    context = MagicMock()
     config = _build_config()
     config["trigger_settings"]["enable_features_in_group"] = True
-    plugin = FileOperationPlugin(context=context, config=config)
-    try:
+    async with _managed_plugin(config=config) as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(
             message_type=MessageType.GROUP_MESSAGE,
@@ -1532,33 +1375,28 @@ async def test_before_llm_chat_does_not_inject_upload_notice_when_file_tools_hid
         event.message_obj.message = [
             Comp.File(name="source.docx", file=str(source_path)),
         ]
-
-        async def _fake_extract_upload_source(_component):
-            return source_path, "source.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.docx")
-
-        req = ProviderRequest(
-            prompt="根据上传文档整理成正式汇报",
-            system_prompt="base",
-            func_tool=ToolSet([_tool("existing_tool")]),
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="source.docx",
+            stored_name="source_1.docx",
         )
 
-        await plugin.before_llm_chat(event, req)
+        req = _build_provider_request(
+            "根据上传文档整理成正式汇报",
+            tool_names=["existing_tool"],
+        )
+
+        await managed.plugin.before_llm_chat(event, req)
 
         assert "当前聊天不可使用文件/Office/PDF 相关功能" in req.system_prompt
         assert "工作区文件名：source_1.docx" not in req.system_prompt
         assert "MUST 先调用 `read_file` 读取此文件" not in req.system_prompt
-    finally:
-        await plugin.terminate()
 
 
 @pytest.mark.asyncio
 async def test_before_llm_chat_skips_upload_notices_when_func_tool_missing():
-    context = MagicMock()
-    plugin = FileOperationPlugin(context=context, config=_build_config())
-    try:
+    async with _managed_plugin() as managed:
         source_path = Path(__file__).resolve()
         event = _build_event(
             message_type=MessageType.FRIEND_MESSAGE,
@@ -1567,23 +1405,20 @@ async def test_before_llm_chat_skips_upload_notices_when_func_tool_missing():
         event.message_obj.message = [
             Comp.File(name="source.docx", file=str(source_path)),
         ]
+        _configure_uploaded_file(
+            managed.plugin,
+            source_path=source_path,
+            original_name="source.docx",
+            stored_name="source_1.docx",
+        )
 
-        async def _fake_extract_upload_source(_component):
-            return source_path, "source.docx"
-
-        plugin._extract_upload_source = _fake_extract_upload_source
-        plugin._store_uploaded_file = lambda *_args, **_kwargs: Path("source_1.docx")
-
-        req = ProviderRequest(
-            prompt="根据上传文档整理成正式汇报",
-            system_prompt="base",
+        req = _build_provider_request(
+            "根据上传文档整理成正式汇报",
             func_tool=None,
         )
 
-        await plugin.before_llm_chat(event, req)
+        await managed.plugin.before_llm_chat(event, req)
 
         assert "文件工具使用指南" not in req.system_prompt
         assert "工作区文件名：source_1.docx" not in req.system_prompt
         assert "MUST 先调用 `read_file` 读取此文件" not in req.system_prompt
-    finally:
-        await plugin.terminate()

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -54,6 +54,9 @@ from astrbot_plugin_office_assistant.services.runtime_builder import (
     _build_workbook_toolset,
     _build_workbook_summary_lookup,
 )
+from astrbot_plugin_office_assistant.services.excel_intent_router import (
+    ExcelIntentRouter,
+)
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
     SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
@@ -2783,6 +2786,40 @@ async def test_request_hook_service_injects_excel_script_notice_for_mixed_read_m
     assert "execute_excel_script" in context.notices[1]
 
 
+def test_excel_intent_router_keeps_export_worded_existing_filename():
+    decision = ExcelIntentRouter.decide(
+        request_text="请导出 report.xlsx 的内容并总结",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.matched_files == ("report.xlsx",)
+
+
+def test_excel_intent_router_ignores_output_filename_when_upload_present():
+    decision = ExcelIntentRouter.decide(
+        request_text="请读取 input.xlsx 并生成 result.xlsx 作为输出文件",
+        upload_infos=[
+            {
+                "original_name": "input.xlsx",
+                "file_suffix": ".xlsx",
+                "stored_name": "input.xlsx",
+                "source_path": "",
+                "is_supported": True,
+            }
+        ],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.matched_files == ("input.xlsx",)
+
+
 @pytest.mark.asyncio
 async def test_request_hook_service_treats_output_xlsx_name_as_new_workbook_request():
     service = RequestHookService(
@@ -5482,6 +5519,172 @@ async def test_file_tool_service_execute_excel_script_rejects_non_sandbox_runtim
     assert payload["retry_count"] == 0
     assert payload["retry_exhausted"] is False
     mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_accepts_positional_session_config():
+    class _PositionalSessionContext:
+        @staticmethod
+        def get_config(session_id):
+            assert session_id == "session-1"
+            return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    workspace_dir = _make_workspace("execute-excel-script-positional-config")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_PositionalSessionContext(),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        service._excel_script_service._run_script_process = AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                mode="text",
+                result_text="ok",
+                output_path=None,
+            )
+        )
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(return_value=MagicMock(capabilities=("python", "filesystem"))),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["mode"] == "text"
+    assert payload["result_text"] == "ok"
+    mocked_get_booter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_sandbox_missing_capabilities():
+    workspace_dir = _make_workspace("execute-excel-script-missing-capabilities")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_build_astrbot_context(runtime="sandbox"),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(return_value=MagicMock(capabilities=("python",))),
+        ):
+            first = json.loads(
+                await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                )
+            )
+            second = json.loads(
+                await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                )
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    assert first["success"] is False
+    assert "当前 sandbox profile 缺少必要能力：filesystem" in first["error"]
+    assert first["retry_count"] == 0
+    assert first["retry_exhausted"] is False
+    assert second["success"] is False
+    assert second["retry_count"] == 0
+    assert second["retry_exhausted"] is False
+    runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_upload_failure_does_not_consume_retry_budget():
+    class _UploadFailureSandboxBooter(_FakeSandboxBooter):
+        async def upload_file(self, path: str, file_name: str) -> dict[str, object]:
+            _ = path
+            _ = file_name
+            return {"success": False, "message": "upload failed"}
+
+    workspace_dir = _make_workspace("execute-excel-script-upload-failure")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        openpyxl = pytest.importorskip("openpyxl")
+        source_path = workspace_dir / "source.xlsx"
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "原始"
+        workbook.save(source_path)
+
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        with _patch_excel_sandbox(_UploadFailureSandboxBooter(sandbox_dir)):
+            first = json.loads(
+                await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                    input_files=[source_path.name],
+                )
+            )
+            second = json.loads(
+                await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                    input_files=[source_path.name],
+                )
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    assert first["success"] is False
+    assert first["error"] == "Excel 输入文件上传失败"
+    assert first["retry_count"] == 0
+    assert first["retry_exhausted"] is False
+    assert second["success"] is False
+    assert second["error"] == "Excel 输入文件上传失败"
+    assert second["retry_count"] == 0
+    assert second["retry_exhausted"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -394,6 +394,22 @@ def test_get_session_config_accepts_positional_with_var_keyword():
     assert calls == [("session-1", {})]
 
 
+def test_get_session_config_reraises_internal_typeerror_when_signature_unavailable():
+    calls: list[str] = []
+
+    def _get_config(session_id):
+        calls.append(session_id)
+        raise TypeError("backend exploded")
+
+    with patch(
+        "astrbot_plugin_office_assistant.services.runtime_config.inspect.signature",
+        side_effect=ValueError("signature unavailable"),
+    ), pytest.raises(TypeError, match="backend exploded"):
+        get_session_config(_get_config, "session-1")
+
+    assert calls == ["session-1"]
+
+
 def test_excel_script_service_join_sandbox_path_uses_windows_path_semantics():
     joined = ExcelScriptService._join_sandbox_path(
         "C:\\sandbox",
@@ -5822,6 +5838,53 @@ async def test_file_tool_service_execute_excel_script_rejects_sandbox_missing_ca
     assert second["success"] is False
     assert second["retry_count"] == 0
     assert second["retry_exhausted"] is True
+    runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_sandbox_disabled_capability_flags():
+    workspace_dir = _make_workspace("execute-excel-script-disabled-capability-flags")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_build_astrbot_context(runtime="sandbox"),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(
+                return_value=MagicMock(
+                    capabilities={"python": True, "filesystem": False}
+                )
+            ),
+        ):
+            result = json.loads(
+                await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                )
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    assert result["success"] is False
+    assert "当前 sandbox profile 缺少必要能力：filesystem" in result["error"]
+    assert result["retry_count"] == 0
+    assert result["retry_exhausted"] is True
     runner.assert_not_awaited()
 
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1332,6 +1332,45 @@ async def test_request_hook_service_builds_default_tool_hooks():
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_hides_execute_excel_script_for_none_runtime():
+    request = ProviderRequest(
+        prompt="请生成一个带公式的 Excel 报表",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_workbook"),
+                _tool("execute_excel_script"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+    service = RequestHookService(
+        astrbot_context=_build_astrbot_context(runtime="none"),
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=_build_event(),
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+    )
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_workbook" in tool_names
+    assert "execute_excel_script" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_skips_explicit_restriction_for_unavailable_workbook_tool():
     request = ProviderRequest(
         prompt="请调用 create_workbook",
@@ -2632,6 +2671,48 @@ async def test_request_hook_service_injects_excel_read_notice_for_reading_xlsx_r
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_prefers_excel_read_notice_for_update_record_query():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [
+            {
+                "original_name": "report.xlsx",
+                "file_suffix": ".xlsx",
+                "stored_name": "report.xlsx",
+                "source_path": "",
+                "is_supported": True,
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请读取 report.xlsx 更新记录并总结",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("read_workbook"), _tool("execute_excel_script")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_EXCEL_ROUTING,
+        SECTION_STATIC_EXCEL_READ,
+    ]
+    assert SECTION_STATIC_EXCEL_SCRIPT not in context.section_names
+    assert "read_workbook" in context.notices[1]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_skips_workbook_guide_for_xlsx_to_pdf_conversion_requests():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -2818,6 +2899,20 @@ def test_excel_intent_router_ignores_output_filename_when_upload_present():
     assert decision is not None
     assert decision.route == "read_existing"
     assert decision.matched_files == ("input.xlsx",)
+
+
+def test_excel_intent_router_prefers_read_for_update_record_query():
+    decision = ExcelIntentRouter.decide(
+        request_text="请读取 report.xlsx 更新记录并总结",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook", "execute_excel_script"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.requires_script is False
+    assert decision.should_inject_guide is True
 
 
 @pytest.mark.asyncio
@@ -5482,8 +5577,8 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
 
 
 @pytest.mark.asyncio
-async def test_file_tool_service_execute_excel_script_rejects_non_sandbox_runtime():
-    workspace_dir = _make_workspace("execute-excel-script-non-sandbox")
+async def test_file_tool_service_execute_excel_script_runs_in_local_runtime():
+    workspace_dir = _make_workspace("execute-excel-script-local-runtime")
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5514,10 +5609,52 @@ async def test_file_tool_service_execute_excel_script_rejects_non_sandbox_runtim
         shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["mode"] == "text"
+    assert payload["result_text"] == "ok"
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
+    workspace_dir = _make_workspace("execute-excel-script-none-runtime")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_build_astrbot_context(runtime="none"),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
     assert payload["success"] is False
-    assert "仅支持 sandbox runtime" in payload["error"]
+    assert "computer runtime 为 none" in payload["error"]
     assert payload["retry_count"] == 0
     assert payload["retry_exhausted"] is False
+    runner.assert_not_awaited()
     mocked_get_booter.assert_not_awaited()
 
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1,6 +1,9 @@
 import base64
+import contextlib
 import json
+import io
 import shutil
+import traceback
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -142,6 +145,105 @@ def _make_workspace(name: str) -> Path:
     return workspace_dir
 
 
+def _build_astrbot_context(*, runtime: str = "sandbox"):
+    context = MagicMock()
+    context.get_config.side_effect = lambda *args, **kwargs: {
+        "provider_settings": {"computer_use_runtime": runtime}
+    }
+    return context
+
+
+class _FakeSandboxPython:
+    def __init__(self, workspace_root: Path):
+        self._workspace_root = workspace_root
+
+    async def exec(
+        self,
+        code: str,
+        kernel_id: str | None = None,
+        timeout: int = 30,
+        silent: bool = False,
+    ) -> dict[str, object]:
+        _ = kernel_id
+        _ = timeout
+        globals_dict = {"__name__": "__main__"}
+        stdout_buffer = io.StringIO()
+        stderr_buffer = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout_buffer), contextlib.redirect_stderr(
+                stderr_buffer
+            ):
+                exec(compile(code, "<fake-sandbox>", "exec"), globals_dict, globals_dict)
+        except Exception:
+            if not stderr_buffer.getvalue():
+                stderr_buffer.write(traceback.format_exc())
+            error_text = stderr_buffer.getvalue()
+            return {
+                "success": False,
+                "output": "" if silent else stdout_buffer.getvalue(),
+                "error": error_text,
+                "data": {
+                    "output": {"text": "" if silent else stdout_buffer.getvalue()},
+                    "error": error_text,
+                },
+            }
+
+        output_text = "" if silent else stdout_buffer.getvalue()
+        return {
+            "success": True,
+            "output": output_text,
+            "error": stderr_buffer.getvalue(),
+            "data": {
+                "output": {"text": output_text},
+                "error": stderr_buffer.getvalue(),
+            },
+        }
+
+
+class _FakeSandboxBooter:
+    def __init__(
+        self,
+        workspace_root: Path,
+        *,
+        capabilities: tuple[str, ...] = ("python", "filesystem"),
+    ):
+        self.workspace_root = str(workspace_root)
+        self.capabilities = capabilities
+        self.python = _FakeSandboxPython(workspace_root)
+
+    def _resolve_remote_path(self, path: str) -> Path:
+        path_obj = Path(path)
+        if path_obj.is_absolute():
+            return path_obj
+        return Path(self.workspace_root) / path_obj
+
+    async def upload_file(self, path: str, file_name: str) -> dict[str, object]:
+        source = Path(path)
+        destination = Path(self.workspace_root) / Path(file_name)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        return {
+            "success": True,
+            "message": "uploaded",
+            "file_path": str(destination),
+        }
+
+    async def download_file(self, remote_path: str, local_path: str) -> None:
+        source = self._resolve_remote_path(remote_path)
+        if not source.exists():
+            raise FileNotFoundError(remote_path)
+        destination = Path(local_path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def _patch_excel_sandbox(booter):
+    return patch(
+        "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+        new=AsyncMock(return_value=booter),
+    )
+
+
 def _write_png(path: Path) -> None:
     png_bytes = base64.b64decode(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9kAAAAASUVORK5CYII="
@@ -172,6 +274,7 @@ def _node_render_backend_config_for_tests() -> DocumentRenderBackendConfig:
 
 def _build_file_tool_service(
     *,
+    astrbot_context=None,
     workspace_service,
     office_generator=None,
     pdf_converter=None,
@@ -186,7 +289,9 @@ def _build_file_tool_service(
     group_feature_disabled_error=None,
 ):
     delivery_service = delivery_service or MagicMock()
+    astrbot_context = astrbot_context or _build_astrbot_context()
     return FileToolService(
+        astrbot_context=astrbot_context,
         workspace_service=workspace_service,
         office_generator=office_generator or MagicMock(),
         pdf_converter=pdf_converter or MagicMock(),
@@ -5191,6 +5296,8 @@ async def test_file_tool_service_read_workbook_rejects_non_excel_suffix():
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_text_result():
     workspace_dir = _make_workspace("execute-excel-script-text")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5209,17 +5316,17 @@ async def test_file_tool_service_execute_excel_script_returns_text_result():
             delivery_service=delivery_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script=(
-                "workbook = Workbook()\n"
-                "worksheet = workbook.active\n"
-                "worksheet.title = '总表'\n"
-                "worksheet['A1'] = '值'\n"
-                "result_text = worksheet['A1'].value\n"
-            ),
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script=(
+                    "workbook = Workbook()\n"
+                    "worksheet = workbook.active\n"
+                    "worksheet.title = '总表'\n"
+                    "worksheet['A1'] = '值'\n"
+                    "result_text = worksheet['A1'].value\n"
+                ),
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5234,6 +5341,8 @@ async def test_file_tool_service_execute_excel_script_returns_text_result():
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_generated_file():
     workspace_dir = _make_workspace("execute-excel-script-file")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5252,17 +5361,17 @@ async def test_file_tool_service_execute_excel_script_returns_generated_file():
             delivery_service=delivery_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script=(
-                "workbook = Workbook()\n"
-                "worksheet = workbook.active\n"
-                "worksheet['A1'] = '导出'\n"
-                "workbook.save(output_path)\n"
-            ),
-            output_name="script-output.xlsx",
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script=(
+                    "workbook = Workbook()\n"
+                    "worksheet = workbook.active\n"
+                    "worksheet['A1'] = '导出'\n"
+                    "workbook.save(output_path)\n"
+                ),
+                output_name="script-output.xlsx",
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5336,8 +5445,50 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
 
 
 @pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_non_sandbox_runtime():
+    workspace_dir = _make_workspace("execute-excel-script-non-sandbox")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_build_astrbot_context(runtime="local"),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "仅支持 sandbox runtime" in payload["error"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is False
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_uses_input_file_copies():
     workspace_dir = _make_workspace("execute-excel-script-input-copy")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5359,18 +5510,18 @@ async def test_file_tool_service_execute_excel_script_uses_input_file_copies():
             workspace_service=workspace_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script=(
-                "workbook = load_workbook(input_files[0])\n"
-                "worksheet = workbook.active\n"
-                "worksheet['A1'] = '已修改'\n"
-                "workbook.save(input_files[0])\n"
-                "result_text = worksheet['A1'].value\n"
-            ),
-            input_files=[source_path.name],
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script=(
+                    "workbook = load_workbook(input_files[0])\n"
+                    "worksheet = workbook.active\n"
+                    "worksheet['A1'] = '已修改'\n"
+                    "workbook.save(input_files[0])\n"
+                    "result_text = worksheet['A1'].value\n"
+                ),
+                input_files=[source_path.name],
+            )
         reloaded = openpyxl.load_workbook(source_path)
     finally:
         executor.shutdown(wait=False)
@@ -5386,6 +5537,8 @@ async def test_file_tool_service_execute_excel_script_uses_input_file_copies():
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_keeps_same_named_inputs_separate():
     workspace_dir = _make_workspace("execute-excel-script-same-name-inputs")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5417,18 +5570,18 @@ async def test_file_tool_service_execute_excel_script_keeps_same_named_inputs_se
             workspace_service=workspace_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script=(
-                "values = []\n"
-                "for path in input_files:\n"
-                "    workbook = load_workbook(path)\n"
-                "    values.append(workbook.active['A1'].value)\n"
-                "result_text = '|'.join(values)\n"
-            ),
-            input_files=["north/sales.xlsx", "south/sales.xlsx"],
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script=(
+                    "values = []\n"
+                    "for path in input_files:\n"
+                    "    workbook = load_workbook(path)\n"
+                    "    values.append(workbook.active['A1'].value)\n"
+                    "result_text = '|'.join(values)\n"
+                ),
+                input_files=["north/sales.xlsx", "south/sales.xlsx"],
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5442,6 +5595,8 @@ async def test_file_tool_service_execute_excel_script_keeps_same_named_inputs_se
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_rejects_text_and_file_together():
     workspace_dir = _make_workspace("execute-excel-script-conflict")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5457,16 +5612,16 @@ async def test_file_tool_service_execute_excel_script_rejects_text_and_file_toge
             workspace_service=workspace_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script=(
-                "workbook = Workbook()\n"
-                "workbook.save(output_path)\n"
-                "result_text = 'done'\n"
-            ),
-            output_name="conflict.xlsx",
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script=(
+                    "workbook = Workbook()\n"
+                    "workbook.save(output_path)\n"
+                    "result_text = 'done'\n"
+                ),
+                output_name="conflict.xlsx",
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5480,6 +5635,8 @@ async def test_file_tool_service_execute_excel_script_rejects_text_and_file_toge
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_traceback_on_failure():
     workspace_dir = _make_workspace("execute-excel-script-error")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5495,11 +5652,11 @@ async def test_file_tool_service_execute_excel_script_returns_traceback_on_failu
             workspace_service=workspace_service,
             office_libs={"openpyxl": object()},
         )
-
-        result = await service.execute_excel_script(
-            event,
-            script="raise ValueError('boom')",
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script="raise ValueError('boom')",
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5514,6 +5671,8 @@ async def test_file_tool_service_execute_excel_script_returns_traceback_on_failu
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_handles_invalid_result_json():
     workspace_dir = _make_workspace("execute-excel-script-invalid-result-json")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5530,10 +5689,11 @@ async def test_file_tool_service_execute_excel_script_handles_invalid_result_jso
             office_libs={"openpyxl": object()},
         )
 
-        def _invalid_result_runner(*, result_path: Path, **_kwargs) -> str:
+        def _invalid_result_runner(*, result_path: str, **_kwargs) -> str:
+            result_file = Path(result_path)
             return (
                 "from pathlib import Path\n"
-                f"Path({str(result_path.resolve())!r}).write_text('not json', encoding='utf-8')\n"
+                f"Path({str(result_file)!r}).write_text('not json', encoding='utf-8')\n"
             )
 
         with patch.object(
@@ -5541,10 +5701,11 @@ async def test_file_tool_service_execute_excel_script_handles_invalid_result_jso
             "_build_runner_script",
             side_effect=_invalid_result_runner,
         ):
-            result = await service.execute_excel_script(
-                event,
-                script="result_text = 'ok'",
-            )
+            with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+                result = await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5569,6 +5730,8 @@ async def test_file_tool_service_execute_excel_script_handles_non_object_result_
     traceback_fragment,
 ):
     workspace_dir = _make_workspace("execute-excel-script-non-object-result-json")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5585,10 +5748,11 @@ async def test_file_tool_service_execute_excel_script_handles_non_object_result_
             office_libs={"openpyxl": object()},
         )
 
-        def _non_object_result_runner(*, result_path: Path, **_kwargs) -> str:
+        def _non_object_result_runner(*, result_path: str, **_kwargs) -> str:
+            result_file = Path(result_path)
             return (
                 "from pathlib import Path\n"
-                f"Path({str(result_path.resolve())!r}).write_text({result_content!r}, encoding='utf-8')\n"
+                f"Path({str(result_file)!r}).write_text({result_content!r}, encoding='utf-8')\n"
             )
 
         with patch.object(
@@ -5596,10 +5760,11 @@ async def test_file_tool_service_execute_excel_script_handles_non_object_result_
             "_build_runner_script",
             side_effect=_non_object_result_runner,
         ):
-            result = await service.execute_excel_script(
-                event,
-                script="result_text = 'ok'",
-            )
+            with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+                result = await service.execute_excel_script(
+                    event,
+                    script="result_text = 'ok'",
+                )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5633,6 +5798,8 @@ async def test_file_tool_service_execute_excel_script_validates_file_mode_output
     traceback_fragment,
 ):
     workspace_dir = _make_workspace("execute-excel-script-invalid-file-output-path")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5649,10 +5816,11 @@ async def test_file_tool_service_execute_excel_script_validates_file_mode_output
             office_libs={"openpyxl": object()},
         )
 
-        def _file_payload_runner(*, result_path: Path, **_kwargs) -> str:
+        def _file_payload_runner(*, result_path: str, **_kwargs) -> str:
+            result_file = Path(result_path)
             return (
                 "from pathlib import Path\n"
-                f"Path({str(result_path.resolve())!r}).write_text({payload_text!r}, encoding='utf-8')\n"
+                f"Path({str(result_file)!r}).write_text({payload_text!r}, encoding='utf-8')\n"
             )
 
         with patch.object(
@@ -5660,11 +5828,12 @@ async def test_file_tool_service_execute_excel_script_validates_file_mode_output
             "_build_runner_script",
             side_effect=_file_payload_runner,
         ):
-            result = await service.execute_excel_script(
-                event,
-                script="workbook = Workbook()",
-                output_name="script-output.xlsx",
-            )
+            with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+                result = await service.execute_excel_script(
+                    event,
+                    script="workbook = Workbook()",
+                    output_name="script-output.xlsx",
+                )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5683,6 +5852,8 @@ async def test_file_tool_service_execute_excel_script_handles_result_read_error(
     monkeypatch,
 ):
     workspace_dir = _make_workspace("execute-excel-script-result-read-error")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
     executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
@@ -5706,10 +5877,11 @@ async def test_file_tool_service_execute_excel_script_handles_result_read_error(
             return original_read_text(self, *args, **kwargs)
 
         monkeypatch.setattr(Path, "read_text", _broken_read_text)
-        result = await service.execute_excel_script(
-            event,
-            script="result_text = 'ok'",
-        )
+        with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
     finally:
         executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
@@ -5748,7 +5920,10 @@ async def test_file_tool_service_execute_excel_script_marks_retry_exhausted_afte
                 script="raise ValueError('boom')",
             )
         )
-        service._excel_script_service._run_script_process = runner
+        service._excel_script_service._run_script_process = AsyncMock(side_effect=runner)
+        service._excel_script_service._acquire_sandbox_booter = AsyncMock(
+            return_value=(MagicMock(capabilities=("python", "filesystem")), None)
+        )
 
         first = json.loads(
             await service.execute_excel_script(
@@ -5812,7 +5987,10 @@ async def test_file_tool_service_execute_excel_script_stops_running_after_retry_
                 script="raise ValueError('boom')",
             )
         )
-        service._excel_script_service._run_script_process = runner
+        service._excel_script_service._run_script_process = AsyncMock(side_effect=runner)
+        service._excel_script_service._acquire_sandbox_booter = AsyncMock(
+            return_value=(MagicMock(capabilities=("python", "filesystem")), None)
+        )
 
         for _ in range(3):
             await service.execute_excel_script(
@@ -5878,7 +6056,10 @@ async def test_file_tool_service_execute_excel_script_resets_retry_count_after_s
                 ),
             ]
         )
-        service._excel_script_service._run_script_process = runner
+        service._excel_script_service._run_script_process = AsyncMock(side_effect=runner)
+        service._excel_script_service._acquire_sandbox_booter = AsyncMock(
+            return_value=(MagicMock(capabilities=("python", "filesystem")), None)
+        )
 
         first = json.loads(
             await service.execute_excel_script(

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -3153,6 +3153,19 @@ def test_excel_intent_router_keeps_output_worded_existing_filename():
     assert decision.matched_files == ("report.xlsx",)
 
 
+def test_excel_intent_router_keeps_export_purpose_existing_filename():
+    decision = ExcelIntentRouter.decide(
+        request_text="请读取 report.xlsx 用于导出并总结",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.matched_files == ("report.xlsx",)
+
+
 def test_excel_intent_router_prefers_read_for_update_record_query():
     decision = ExcelIntentRouter.decide(
         request_text="请读取 report.xlsx 更新记录并总结",
@@ -3206,6 +3219,40 @@ def test_excel_intent_router_keeps_write_into_existing_filename():
     assert decision is not None
     assert decision.route == "read_existing"
     assert decision.matched_files == ("report.xlsx",)
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_keeps_excel_read_notice_for_export_purpose_phrase():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请读取 report.xlsx 用于导出并总结",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("read_workbook")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_EXCEL_ROUTING,
+        SECTION_STATIC_EXCEL_READ,
+    ]
+    assert "read_workbook" in context.notices[1]
+    assert SECTION_STATIC_WORKBOOK_TOOLS not in context.section_names
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -3181,8 +3181,35 @@ def test_excel_intent_router_treats_update_data_prompt_as_modify_existing():
     assert decision.should_inject_guide is True
 
 
+def test_excel_intent_router_treats_english_read_update_formula_prompt_as_modify_existing():
+    decision = ExcelIntentRouter.decide(
+        request_text="read report.xlsx and update formulas",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook", "execute_excel_script"},
+    )
+
+    assert decision is not None
+    assert decision.route == "modify_existing"
+    assert decision.requires_script is True
+    assert decision.should_inject_guide is True
+
+
+def test_excel_intent_router_keeps_write_into_existing_filename():
+    decision = ExcelIntentRouter.decide(
+        request_text="请把数据写入 report.xlsx 并统计",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook", "create_workbook", "write_rows", "export_workbook"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.matched_files == ("report.xlsx",)
+
+
 @pytest.mark.asyncio
-async def test_request_hook_service_treats_output_xlsx_name_as_new_workbook_request():
+async def test_request_hook_service_treats_explicit_output_xlsx_name_as_new_workbook_request():
     service = RequestHookService(
         auto_block_execution_tools=True,
         get_cached_upload_infos=lambda _event: [],
@@ -3196,7 +3223,7 @@ async def test_request_hook_service_treats_output_xlsx_name_as_new_workbook_requ
         NoticeBuildContext(
             event=_build_event(),
             request=ProviderRequest(
-                prompt="请生成 sales.xlsx 并汇总 Q1 销售数据",
+                prompt="请生成一个 Excel，保存为 sales.xlsx，并汇总 Q1 销售数据",
                 system_prompt="base",
                 func_tool=ToolSet(
                     [

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -5575,6 +5575,61 @@ async def test_file_tool_service_execute_excel_script_accepts_positional_session
 
 
 @pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_accepts_noarg_session_config_when_signature_unavailable():
+    class _NoArgSessionContext:
+        @staticmethod
+        def get_config():
+            return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    workspace_dir = _make_workspace("execute-excel-script-noarg-config")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_NoArgSessionContext(),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        service._excel_script_service._run_script_process = AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                mode="text",
+                result_text="ok",
+                output_path=None,
+            )
+        )
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service.inspect.signature",
+            side_effect=ValueError("signature unavailable"),
+        ), patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(return_value=MagicMock(capabilities=("python", "filesystem"))),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["mode"] == "text"
+    assert payload["result_text"] == "ok"
+    mocked_get_booter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_rejects_sandbox_missing_capabilities():
     workspace_dir = _make_workspace("execute-excel-script-missing-capabilities")
     executor = ThreadPoolExecutor(max_workers=1)
@@ -5624,6 +5679,62 @@ async def test_file_tool_service_execute_excel_script_rejects_sandbox_missing_ca
     assert second["retry_count"] == 0
     assert second["retry_exhausted"] is False
     runner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_handles_sandbox_exec_exception():
+    class _ExecFailureSandboxPython(_FakeSandboxPython):
+        async def exec(
+            self,
+            code: str,
+            kernel_id: str | None = None,
+            timeout: int = 30,
+            silent: bool = False,
+        ) -> dict[str, object]:
+            _ = code
+            _ = kernel_id
+            _ = timeout
+            _ = silent
+            raise RuntimeError("sandbox rpc failed")
+
+    class _ExecFailureSandboxBooter(_FakeSandboxBooter):
+        def __init__(self, workspace_root: Path):
+            super().__init__(workspace_root)
+            self.python = _ExecFailureSandboxPython(workspace_root)
+
+    workspace_dir = _make_workspace("execute-excel-script-exec-exception")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        with _patch_excel_sandbox(_ExecFailureSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["error"] == "Excel sandbox 初始化失败"
+    assert "sandbox rpc failed" in payload["traceback"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is False
 
 
 @pytest.mark.asyncio
@@ -5685,6 +5796,56 @@ async def test_file_tool_service_execute_excel_script_upload_failure_does_not_co
     assert second["error"] == "Excel 输入文件上传失败"
     assert second["retry_count"] == 0
     assert second["retry_exhausted"] is False
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_handles_upload_exception():
+    class _UploadExceptionSandboxBooter(_FakeSandboxBooter):
+        async def upload_file(self, path: str, file_name: str) -> dict[str, object]:
+            _ = path
+            _ = file_name
+            raise RuntimeError("upload rpc failed")
+
+    workspace_dir = _make_workspace("execute-excel-script-upload-exception")
+    sandbox_dir = workspace_dir / "fake-sandbox"
+    sandbox_dir.mkdir()
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        openpyxl = pytest.importorskip("openpyxl")
+        source_path = workspace_dir / "source.xlsx"
+        workbook = openpyxl.Workbook()
+        workbook.active["A1"] = "原始"
+        workbook.save(source_path)
+
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        with _patch_excel_sandbox(_UploadExceptionSandboxBooter(sandbox_dir)):
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+                input_files=[source_path.name],
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["error"] == "Excel 输入文件上传失败"
+    assert "upload rpc failed" in payload["traceback"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2637,6 +2637,89 @@ async def test_request_hook_service_injects_excel_script_notice_for_existing_xls
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_injects_excel_script_notice_for_mixed_read_modify_xlsx_requests():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [
+            {
+                "original_name": "sales.xlsx",
+                "file_suffix": ".xlsx",
+                "stored_name": "sales_1.xlsx",
+                "source_path": "",
+                "is_supported": True,
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请读取这个 xlsx 后新增一列公式并导出新版本",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("execute_excel_script")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_EXCEL_ROUTING,
+        SECTION_STATIC_EXCEL_SCRIPT,
+    ]
+    assert SECTION_STATIC_EXCEL_READ not in context.section_names
+    assert "execute_excel_script" in context.notices[1]
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_treats_output_xlsx_name_as_new_workbook_request():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请生成 sales.xlsx 并汇总 Q1 销售数据",
+                system_prompt="base",
+                func_tool=ToolSet(
+                    [
+                        _tool("read_workbook"),
+                        _tool("create_workbook"),
+                        _tool("write_rows"),
+                        _tool("export_workbook"),
+                    ]
+                ),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_EXCEL_ROUTING,
+        SECTION_STATIC_WORKBOOK_TOOLS,
+    ]
+    assert SECTION_STATIC_EXCEL_READ not in context.section_names
+    assert "create_workbook" in context.notices[1]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_falls_back_to_workbook_guide_when_workbook_lookup_disabled():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -5192,6 +5275,67 @@ async def test_file_tool_service_execute_excel_script_returns_generated_file():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("is_group_feature_enabled", "check_permission", "expected_error"),
+    [
+        (lambda _event: False, lambda _event: True, "group disabled"),
+        (lambda _event: True, lambda _event: False, "错误：权限不足"),
+    ],
+)
+async def test_file_tool_service_execute_excel_script_validation_errors_do_not_consume_retry_budget(
+    is_group_feature_enabled,
+    check_permission,
+    expected_error,
+):
+    workspace_dir = _make_workspace("execute-excel-script-validation-error")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+            is_group_feature_enabled=is_group_feature_enabled,
+            check_permission=check_permission,
+        )
+        runner = MagicMock()
+        service._excel_script_service._run_script_process = runner
+
+        first = json.loads(
+            await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+        )
+        second = json.loads(
+            await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+        )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    assert first["success"] is False
+    assert first["error"] == expected_error
+    assert first["retry_count"] == 0
+    assert first["retry_exhausted"] is False
+    assert second["success"] is False
+    assert second["error"] == expected_error
+    assert second["retry_count"] == 0
+    assert second["retry_exhausted"] is False
+    assert runner.call_count == 0
+
+
+@pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_uses_input_file_copies():
     workspace_dir = _make_workspace("execute-excel-script-input-copy")
     executor = ThreadPoolExecutor(max_workers=1)
@@ -5465,6 +5609,73 @@ async def test_file_tool_service_execute_excel_script_handles_non_object_result_
     assert payload["error"] == "Excel 脚本结果解析失败"
     assert traceback_fragment in payload["traceback"]
     assert payload["script"] == "result_text = 'ok'"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload_text", "expected_error", "traceback_fragment"),
+    [
+        (
+            '{"success": true, "mode": "file"}',
+            "脚本返回了 file 模式，但缺少 output_path",
+            "",
+        ),
+        (
+            '{"success": true, "mode": "file", "output_path": "unexpected.xlsx"}',
+            "脚本返回了无效的 output_path",
+            "unexpected.xlsx",
+        ),
+    ],
+)
+async def test_file_tool_service_execute_excel_script_validates_file_mode_output_path(
+    payload_text,
+    expected_error,
+    traceback_fragment,
+):
+    workspace_dir = _make_workspace("execute-excel-script-invalid-file-output-path")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+
+        def _file_payload_runner(*, result_path: Path, **_kwargs) -> str:
+            return (
+                "from pathlib import Path\n"
+                f"Path({str(result_path.resolve())!r}).write_text({payload_text!r}, encoding='utf-8')\n"
+            )
+
+        with patch.object(
+            service._excel_script_service,
+            "_build_runner_script",
+            side_effect=_file_payload_runner,
+        ):
+            result = await service.execute_excel_script(
+                event,
+                script="workbook = Workbook()",
+                output_name="script-output.xlsx",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["error"] == expected_error
+    if traceback_fragment:
+        assert traceback_fragment in payload["traceback"]
+    else:
+        assert payload["traceback"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -162,6 +162,212 @@ def _build_astrbot_context(*, runtime: str = "sandbox"):
     return context
 
 
+def _build_provider_request(
+    prompt: str,
+    *,
+    tool_names: list[str] | tuple[str, ...],
+    system_prompt: str = "base",
+):
+    return ProviderRequest(
+        prompt=prompt,
+        system_prompt=system_prompt,
+        func_tool=ToolSet([_tool(name) for name in tool_names]),
+    )
+
+
+def _build_request_hook_service(
+    *,
+    astrbot_context=None,
+    auto_block_execution_tools: bool = True,
+    get_cached_upload_infos=None,
+    extract_upload_source=None,
+    store_uploaded_file=None,
+    consume_session_notice_once=None,
+    allow_external_input_files: bool = False,
+    **kwargs,
+):
+    return RequestHookService(
+        astrbot_context=astrbot_context,
+        auto_block_execution_tools=auto_block_execution_tools,
+        get_cached_upload_infos=get_cached_upload_infos or (lambda _event: []),
+        extract_upload_source=extract_upload_source or AsyncMock(),
+        store_uploaded_file=store_uploaded_file or MagicMock(),
+        consume_session_notice_once=consume_session_notice_once
+        or _build_notice_once_callback(),
+        allow_external_input_files=allow_external_input_files,
+        **kwargs,
+    )
+
+
+def _build_tool_exposure_context(
+    request,
+    *,
+    event=None,
+    should_expose: bool = True,
+    can_process_upload: bool = True,
+    explicit_tool_name: str | None = None,
+):
+    return SimpleNamespace(
+        event=event or _build_event(),
+        request=request,
+        should_expose=should_expose,
+        can_process_upload=can_process_upload,
+        explicit_tool_name=explicit_tool_name,
+    )
+
+
+def _build_notice_context(
+    request,
+    *,
+    event=None,
+    should_expose: bool = True,
+    can_process_upload: bool = True,
+    explicit_tool_name: str | None = None,
+    notices=None,
+    section_names=None,
+    system_notices=None,
+    system_section_names=None,
+):
+    return NoticeBuildContext(
+        event=event or _build_event(),
+        request=request,
+        should_expose=should_expose,
+        can_process_upload=can_process_upload,
+        explicit_tool_name=explicit_tool_name,
+        notices=notices or [],
+        section_names=section_names or [],
+        system_notices=system_notices or [],
+        system_section_names=system_section_names or [],
+    )
+
+
+@contextlib.contextmanager
+def _managed_workspace_service(
+    *,
+    name: str | None = None,
+    plugin_data_path: Path | None = None,
+    office_libs=None,
+    max_file_size: int = 1024 * 1024,
+    feature_settings=None,
+):
+    workspace_dir = plugin_data_path or _make_workspace(name or "workspace-service")
+    executor = ThreadPoolExecutor(max_workers=1)
+    should_cleanup = plugin_data_path is None
+    try:
+        yield SimpleNamespace(
+            workspace_dir=workspace_dir,
+            executor=executor,
+            workspace_service=WorkspaceService(
+                plugin_data_path=workspace_dir,
+                executor=executor,
+                office_libs=office_libs or {},
+                max_file_size=max_file_size,
+                feature_settings=feature_settings or {},
+            ),
+        )
+    finally:
+        executor.shutdown(wait=False)
+        if should_cleanup:
+            shutil.rmtree(workspace_dir, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def _managed_file_tool_service(
+    *,
+    workspace_name: str | None = None,
+    plugin_data_path: Path | None = None,
+    office_libs=None,
+    workspace_office_libs=None,
+    max_file_size: int = 1024 * 1024,
+    feature_settings=None,
+    **service_kwargs,
+):
+    effective_office_libs = office_libs or {}
+    with _managed_workspace_service(
+        name=workspace_name,
+        plugin_data_path=plugin_data_path,
+        office_libs=workspace_office_libs or effective_office_libs,
+        max_file_size=max_file_size,
+        feature_settings=feature_settings,
+    ) as managed:
+        service = _build_file_tool_service(
+            workspace_service=managed.workspace_service,
+            office_libs=effective_office_libs,
+            **service_kwargs,
+        )
+        yield SimpleNamespace(
+            workspace_dir=managed.workspace_dir,
+            workspace_service=managed.workspace_service,
+            service=service,
+        )
+
+
+def _build_upload_session_service(
+    *,
+    context=None,
+    recent_text_ttl_seconds: int = 30,
+    upload_session_ttl_seconds: int = 300,
+    recent_text_max_entries: int = 32,
+    recent_text_cleanup_interval_seconds: int = 10,
+    upload_session_cleanup_interval_seconds: int = 30,
+    extract_upload_source=None,
+    store_uploaded_file=None,
+    allow_external_input_files: bool = False,
+):
+    return UploadSessionService(
+        context=context or MagicMock(),
+        recent_text_ttl_seconds=recent_text_ttl_seconds,
+        upload_session_ttl_seconds=upload_session_ttl_seconds,
+        recent_text_max_entries=recent_text_max_entries,
+        recent_text_cleanup_interval_seconds=recent_text_cleanup_interval_seconds,
+        upload_session_cleanup_interval_seconds=upload_session_cleanup_interval_seconds,
+        extract_upload_source=extract_upload_source or AsyncMock(),
+        store_uploaded_file=store_uploaded_file or MagicMock(),
+        allow_external_input_files=allow_external_input_files,
+    )
+
+
+def _build_command_service(
+    *,
+    workspace_service,
+    plugin_data_path: Path,
+    pdf_converter=None,
+    upload_session_service=None,
+    auto_delete: bool = False,
+    allow_external_input_files: bool = False,
+    enable_features_in_group: bool = True,
+    auto_block_execution_tools: bool = True,
+    reply_to_user: bool = True,
+    is_group_feature_enabled=None,
+    check_permission=None,
+    group_feature_disabled_error=None,
+    **kwargs,
+):
+    pdf_converter = pdf_converter or MagicMock()
+    if not hasattr(pdf_converter, "capabilities"):
+        pdf_converter.capabilities = {
+            "office_to_pdf": False,
+            "pdf_to_word": False,
+            "pdf_to_excel": False,
+        }
+    return CommandService(
+        workspace_service=workspace_service,
+        pdf_converter=pdf_converter,
+        plugin_data_path=plugin_data_path,
+        auto_delete=auto_delete,
+        allow_external_input_files=allow_external_input_files,
+        enable_features_in_group=enable_features_in_group,
+        auto_block_execution_tools=auto_block_execution_tools,
+        reply_to_user=reply_to_user,
+        upload_session_service=upload_session_service or MagicMock(),
+        is_group_feature_enabled=is_group_feature_enabled or (lambda _event: True),
+        check_permission=check_permission or (lambda _event: True),
+        group_feature_disabled_error=group_feature_disabled_error
+        or (lambda: "group disabled"),
+        **kwargs,
+    )
+
+
 def test_get_session_config_prefers_positional_before_umo_keyword():
     calls: list[tuple[str, str | None]] = []
 
@@ -1347,31 +1553,18 @@ async def test_export_hook_service_aliases_post_export_hook_service():
 
 @pytest.mark.asyncio
 async def test_request_hook_service_builds_default_tool_hooks():
-    request = ProviderRequest(
-        prompt="请用 read_file 看一下 report.docx",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_file"),
-                _tool("create_document"),
-                _tool("astrbot_execute_shell"),
-                _tool("astrbot_execute_python"),
-            ]
-        ),
+    request = _build_provider_request(
+        "请用 read_file 看一下 report.docx",
+        tool_names=[
+            "read_file",
+            "create_document",
+            "astrbot_execute_shell",
+            "astrbot_execute_python",
+        ],
     )
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
-    )
-    context = SimpleNamespace(
-        event=_build_event(),
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
+    service = _build_request_hook_service()
+    context = _build_tool_exposure_context(
+        request,
         explicit_tool_name="read_file",
     )
 
@@ -1387,33 +1580,18 @@ async def test_request_hook_service_builds_default_tool_hooks():
 
 @pytest.mark.asyncio
 async def test_request_hook_service_hides_execute_excel_script_for_none_runtime():
-    request = ProviderRequest(
-        prompt="请生成一个带公式的 Excel 报表",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_workbook"),
-                _tool("execute_excel_script"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    request = _build_provider_request(
+        "请生成一个带公式的 Excel 报表",
+        tool_names=[
+            "read_workbook",
+            "execute_excel_script",
+            "astrbot_execute_shell",
+        ],
     )
-    service = RequestHookService(
+    service = _build_request_hook_service(
         astrbot_context=_build_astrbot_context(runtime="none"),
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
-        event=_build_event(),
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-    )
+    context = _build_tool_exposure_context(request)
 
     for hook in service.build_tool_exposure_hooks():
         context = await hook(context)
@@ -1426,35 +1604,20 @@ async def test_request_hook_service_hides_execute_excel_script_for_none_runtime(
 
 @pytest.mark.asyncio
 async def test_request_hook_service_hides_execute_excel_script_for_legacy_none_runtime():
-    request = ProviderRequest(
-        prompt="请生成一个带公式的 Excel 报表",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_workbook"),
-                _tool("execute_excel_script"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    request = _build_provider_request(
+        "请生成一个带公式的 Excel 报表",
+        tool_names=[
+            "read_workbook",
+            "execute_excel_script",
+            "astrbot_execute_shell",
+        ],
     )
-    service = RequestHookService(
+    service = _build_request_hook_service(
         astrbot_context=SimpleNamespace(
             astrbot_config={"provider_settings": {"computer_use_runtime": "none"}}
         ),
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
-        event=_build_event(),
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-    )
+    context = _build_tool_exposure_context(request)
 
     for hook in service.build_tool_exposure_hooks():
         context = await hook(context)
@@ -1472,33 +1635,18 @@ async def test_request_hook_service_keeps_execute_excel_script_when_runtime_look
         def get_config(*_args, **_kwargs):
             raise RuntimeError("config backend unavailable")
 
-    request = ProviderRequest(
-        prompt="请生成一个带公式的 Excel 报表",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_workbook"),
-                _tool("execute_excel_script"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    request = _build_provider_request(
+        "请生成一个带公式的 Excel 报表",
+        tool_names=[
+            "read_workbook",
+            "execute_excel_script",
+            "astrbot_execute_shell",
+        ],
     )
-    service = RequestHookService(
+    service = _build_request_hook_service(
         astrbot_context=_BrokenConfigContext(),
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
-        event=_build_event(),
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-    )
+    context = _build_tool_exposure_context(request)
 
     for hook in service.build_tool_exposure_hooks():
         context = await hook(context)
@@ -1511,30 +1659,17 @@ async def test_request_hook_service_keeps_execute_excel_script_when_runtime_look
 
 @pytest.mark.asyncio
 async def test_request_hook_service_skips_explicit_restriction_for_unavailable_workbook_tool():
-    request = ProviderRequest(
-        prompt="请调用 create_workbook",
-        system_prompt="base",
-        func_tool=ToolSet(
-            [
-                _tool("read_file"),
-                _tool("create_document"),
-                _tool("astrbot_execute_shell"),
-            ]
-        ),
+    request = _build_provider_request(
+        "请调用 create_workbook",
+        tool_names=[
+            "read_file",
+            "create_document",
+            "astrbot_execute_shell",
+        ],
     )
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
-    )
-    context = SimpleNamespace(
-        event=_build_event(),
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
+    service = _build_request_hook_service()
+    context = _build_tool_exposure_context(
+        request,
         explicit_tool_name="create_workbook",
     )
 
@@ -1550,17 +1685,13 @@ async def test_request_hook_service_skips_explicit_restriction_for_unavailable_w
 
 @pytest.mark.asyncio
 async def test_request_hook_service_merges_multiple_uploaded_files_into_one_notice():
-    request = ProviderRequest(
-        prompt="根据上传文件整理内容",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
-    )
+    request = _build_provider_request("根据上传文件整理内容", tool_names=["read_file"])
     event = _build_event()
     event.message_obj.message = [
         Comp.File(name="report.docx", file="report.docx"),
         Comp.File(name="notes.txt", file="notes.txt"),
     ]
-    service = RequestHookService(
+    service = _build_request_hook_service(
         auto_block_execution_tools=True,
         get_cached_upload_infos=lambda _event: [
             {
@@ -1580,22 +1711,9 @@ async def test_request_hook_service_merges_multiple_uploaded_files_into_one_noti
                 "source_path": "/AstrBot/data/temp/notes.txt",
             },
         ],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
-    context = NoticeBuildContext(
-        event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-        notices=[],
-        section_names=[],
-        system_notices=[],
-        system_section_names=[],
-    )
+    context = _build_notice_context(request, event=event)
 
     context = await service.append_uploaded_file_notices(context)
 
@@ -1618,29 +1736,17 @@ async def test_request_hook_service_merges_multiple_uploaded_files_into_one_noti
 
 @pytest.mark.asyncio
 async def test_request_hook_service_limits_multi_file_notice_details():
-    request = ProviderRequest(
-        prompt="根据上传文件整理内容",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
-    )
+    request = _build_provider_request("根据上传文件整理内容", tool_names=["read_file"])
     event = _build_event()
     event.message_obj.message = [
         Comp.File(name=f"file-{idx}.txt", file=f"file-{idx}.txt") for idx in range(5)
     ]
-    service = RequestHookService(
-        auto_block_execution_tools=True,
+    service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: _build_upload_infos(5),
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
+    context = _build_notice_context(
+        request,
         event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
         notices=[],
         section_names=[],
     )
@@ -1659,35 +1765,26 @@ async def test_request_hook_service_limits_multi_file_notice_details():
 
 @pytest.mark.asyncio
 async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_prompt():
-    request = ProviderRequest(
-        prompt=(
+    request = _build_provider_request(
+        (
             "\n[System Notice] 用户上传了 2 个文件\n\n"
             "[文件信息]\n"
             "- 原始文件名: file-0.txt\n"
             "  工作区文件名: file_0.txt\n"
         ),
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
+        tool_names=["read_file"],
     )
     event = _build_event()
     event._buffered = True
     event.message_obj.message = [
         Comp.File(name=f"file-{idx}.txt", file=f"file-{idx}.txt") for idx in range(2)
     ]
-    service = RequestHookService(
-        auto_block_execution_tools=True,
+    service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: _build_upload_infos(2),
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
+    context = _build_notice_context(
+        request,
         event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
         notices=[],
         section_names=[],
     )
@@ -1700,8 +1797,8 @@ async def test_request_hook_service_skips_scene_notice_for_file_only_buffered_pr
 
 @pytest.mark.asyncio
 async def test_request_hook_service_skips_additional_notice_for_buffered_prompt_with_instruction():
-    request = ProviderRequest(
-        prompt=(
+    request = _build_provider_request(
+        (
             "\n[System Notice] 用户上传了 1 个文件\n\n"
             "[文件信息]\n"
             "- 原始文件名: report.docx\n"
@@ -1709,14 +1806,12 @@ async def test_request_hook_service_skips_additional_notice_for_buffered_prompt_
             "[用户指令]\n"
             "根据文件整理成正式汇报\n"
         ),
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
+        tool_names=["read_file"],
     )
     event = _build_event()
     event._buffered = True
     event.message_obj.message = [Comp.File(name="report.docx", file="report.docx")]
-    service = RequestHookService(
-        auto_block_execution_tools=True,
+    service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: [
             {
                 "original_name": "report.docx",
@@ -1727,17 +1822,10 @@ async def test_request_hook_service_skips_additional_notice_for_buffered_prompt_
                 "source_path": "",
             }
         ],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
     )
-    context = SimpleNamespace(
+    context = _build_notice_context(
+        request,
         event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
         notices=[],
         section_names=[],
     )
@@ -1750,32 +1838,21 @@ async def test_request_hook_service_skips_additional_notice_for_buffered_prompt_
 
 @pytest.mark.asyncio
 async def test_request_hook_service_omitted_files_use_names_without_external_paths():
-    request = ProviderRequest(
-        prompt="根据上传文件整理内容",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
-    )
+    request = _build_provider_request("根据上传文件整理内容", tool_names=["read_file"])
     event = _build_event()
     event.message_obj.message = [
         Comp.File(name=f"file-{idx}.txt", file=f"file-{idx}.txt") for idx in range(5)
     ]
-    service = RequestHookService(
-        auto_block_execution_tools=True,
+    service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: _build_upload_infos(
             5,
             source_path_template="/tmp/file_{idx}.txt",
         ),
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
-    context = SimpleNamespace(
+    context = _build_notice_context(
+        request,
         event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
         notices=[],
         section_names=[],
     )
@@ -1793,11 +1870,7 @@ async def test_request_hook_service_omitted_files_use_names_without_external_pat
 
 @pytest.mark.asyncio
 async def test_request_hook_service_keeps_omitted_count_aligned_with_mixed_path_items():
-    request = ProviderRequest(
-        prompt="根据上传文件整理内容",
-        system_prompt="base",
-        func_tool=ToolSet([_tool("read_file")]),
-    )
+    request = _build_provider_request("根据上传文件整理内容", tool_names=["read_file"])
     event = _build_event()
     event.message_obj.message = [
         Comp.File(name=f"file-{idx}.txt", file=f"file-{idx}.txt") for idx in range(5)
@@ -1805,20 +1878,13 @@ async def test_request_hook_service_keeps_omitted_count_aligned_with_mixed_path_
     upload_infos = _build_upload_infos(5)
     upload_infos[3]["source_path"] = "/tmp/file_3.txt"
     upload_infos[4]["source_path"] = ""
-    service = RequestHookService(
-        auto_block_execution_tools=True,
+    service = _build_request_hook_service(
         get_cached_upload_infos=lambda _event: upload_infos,
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
         allow_external_input_files=True,
     )
-    context = SimpleNamespace(
+    context = _build_notice_context(
+        request,
         event=event,
-        request=request,
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
         notices=[],
         section_names=[],
     )
@@ -1834,30 +1900,18 @@ async def test_request_hook_service_keeps_omitted_count_aligned_with_mixed_path_
 
 @pytest.mark.asyncio
 async def test_request_hook_service_injects_document_follow_up_notice_for_draft():
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
+    service = _build_request_hook_service(
         lookup_document_summary=lambda document_id: {
             "document_id": document_id,
             "status": "draft",
             "block_count": 3,
         },
     )
-    context = NoticeBuildContext(
-        event=_build_event(),
-        request=ProviderRequest(
-            prompt='继续完善 document_id="doc-1" 的内容',
-            system_prompt="base",
-            func_tool=ToolSet([_tool("create_document")]),
+    context = _build_notice_context(
+        _build_provider_request(
+            '继续完善 document_id="doc-1" 的内容',
+            tool_names=["create_document"],
         ),
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-        notices=[],
     )
 
     context = await service.append_document_tool_guide_notice(context)
@@ -1871,13 +1925,7 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_draft(
 
 @pytest.mark.asyncio
 async def test_request_hook_service_injects_workbook_follow_up_notice_for_draft():
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
+    service = _build_request_hook_service(
         lookup_workbook_summary=lambda workbook_id: {
             "workbook_id": workbook_id,
             "status": "draft",
@@ -1887,17 +1935,11 @@ async def test_request_hook_service_injects_workbook_follow_up_notice_for_draft(
             "next_allowed_actions": ["write_rows", "export_workbook"],
         },
     )
-    context = NoticeBuildContext(
-        event=_build_event(),
-        request=ProviderRequest(
-            prompt='继续补充 workbook_id="wb-1" 的数据',
-            system_prompt="base",
-            func_tool=ToolSet([_tool("create_workbook")]),
+    context = _build_notice_context(
+        _build_provider_request(
+            '继续补充 workbook_id="wb-1" 的数据',
+            tool_names=["create_workbook"],
         ),
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-        notices=[],
     )
 
     context = await service.append_document_tool_guide_notice(context)
@@ -1911,13 +1953,7 @@ async def test_request_hook_service_injects_workbook_follow_up_notice_for_draft(
 
 @pytest.mark.asyncio
 async def test_request_hook_service_filters_none_values_from_workbook_follow_up_notice():
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
+    service = _build_request_hook_service(
         lookup_workbook_summary=lambda workbook_id: {
             "workbook_id": workbook_id,
             "status": "draft",
@@ -1927,17 +1963,11 @@ async def test_request_hook_service_filters_none_values_from_workbook_follow_up_
             "next_allowed_actions": [None, "write_rows", " "],
         },
     )
-    context = NoticeBuildContext(
-        event=_build_event(),
-        request=ProviderRequest(
-            prompt='继续补充 workbook_id="wb-2" 的数据',
-            system_prompt="base",
-            func_tool=ToolSet([_tool("write_rows")]),
+    context = _build_notice_context(
+        _build_provider_request(
+            '继续补充 workbook_id="wb-2" 的数据',
+            tool_names=["write_rows"],
         ),
-        should_expose=True,
-        can_process_upload=True,
-        explicit_tool_name=None,
-        notices=[],
     )
 
     context = await service.append_document_tool_guide_notice(context)
@@ -1950,28 +1980,16 @@ async def test_request_hook_service_filters_none_values_from_workbook_follow_up_
 
 @pytest.mark.asyncio
 async def test_request_hook_service_injects_workbook_follow_up_notice_for_missing_summary():
-    service = RequestHookService(
-        auto_block_execution_tools=True,
-        get_cached_upload_infos=lambda _event: [],
-        extract_upload_source=AsyncMock(),
-        store_uploaded_file=MagicMock(),
-        consume_session_notice_once=_build_notice_once_callback(),
-        allow_external_input_files=False,
+    service = _build_request_hook_service(
         lookup_workbook_summary=lambda _workbook_id: None,
     )
 
     context = await service.append_document_tool_guide_notice(
-        NoticeBuildContext(
-            event=_build_event(),
-            request=ProviderRequest(
+        _build_notice_context(
+            _build_provider_request(
                 prompt='继续处理 workbook_id="wb-missing"',
-                system_prompt="base",
-                func_tool=ToolSet([_tool("write_rows")]),
+                tool_names=["write_rows"],
             ),
-            should_expose=True,
-            can_process_upload=True,
-            explicit_tool_name=None,
-            notices=[],
         )
     )
 
@@ -3837,16 +3855,10 @@ async def test_upload_session_service_omits_external_path_when_disabled():
 async def test_upload_session_service_uses_extracted_filename_for_type_detection():
     context = MagicMock()
     source_path = Path(__file__).resolve()
-    service = UploadSessionService(
+    service = _build_upload_session_service(
         context=context,
-        recent_text_ttl_seconds=30,
-        upload_session_ttl_seconds=300,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(return_value=(source_path, "report.docx")),
         store_uploaded_file=MagicMock(return_value=Path("report_1.docx")),
-        allow_external_input_files=False,
     )
     event = _build_event()
     upload = Comp.File(name="upload-token", file="upload-token")
@@ -3867,13 +3879,8 @@ async def test_upload_session_service_uses_extracted_filename_for_type_detection
 async def test_upload_session_service_assigns_file_ids_per_session_user():
     context = MagicMock()
     source_path = Path(__file__).resolve()
-    service = UploadSessionService(
+    service = _build_upload_session_service(
         context=context,
-        recent_text_ttl_seconds=30,
-        upload_session_ttl_seconds=300,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(
             side_effect=[
                 (source_path, "A.docx"),
@@ -3884,7 +3891,6 @@ async def test_upload_session_service_assigns_file_ids_per_session_user():
         store_uploaded_file=MagicMock(
             side_effect=[Path("A_1.docx"), Path("B_1.xlsx"), Path("C_1.docx")]
         ),
-        allow_external_input_files=False,
     )
     user_a = _build_event(sender_id="user-a")
     user_b = _build_event(sender_id="user-b")
@@ -3916,16 +3922,12 @@ async def test_upload_session_service_assigns_file_ids_per_session_user():
 async def test_upload_session_service_uses_independent_upload_ttl():
     context = MagicMock()
     source_path = Path(__file__).resolve()
-    service = UploadSessionService(
+    service = _build_upload_session_service(
         context=context,
         recent_text_ttl_seconds=20,
         upload_session_ttl_seconds=120,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(return_value=(source_path, "A.docx")),
         store_uploaded_file=MagicMock(return_value=Path("A_1.docx")),
-        allow_external_input_files=False,
     )
     event = _build_event(sender_id="user-a")
 
@@ -3954,13 +3956,8 @@ async def test_command_service_doc_lists_selects_and_clears_uploaded_files():
     context.get_event_queue.return_value = event_queue
     context.get_config.return_value = {"wake_prefix": ["/"]}
     source_path = Path(__file__).resolve()
-    upload_session_service = UploadSessionService(
+    upload_session_service = _build_upload_session_service(
         context=context,
-        recent_text_ttl_seconds=30,
-        upload_session_ttl_seconds=300,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(
             side_effect=[
                 (source_path, "A.docx"),
@@ -3968,37 +3965,12 @@ async def test_command_service_doc_lists_selects_and_clears_uploaded_files():
             ]
         ),
         store_uploaded_file=MagicMock(side_effect=[Path("A_1.docx"), Path("B_1.xlsx")]),
-        allow_external_input_files=False,
     )
-    workspace_dir = _make_workspace("command-doc")
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        pdf_converter = MagicMock()
-        pdf_converter.capabilities = {
-            "office_to_pdf": False,
-            "pdf_to_word": False,
-            "pdf_to_excel": False,
-        }
-        service = CommandService(
-            workspace_service=workspace_service,
-            pdf_converter=pdf_converter,
-            plugin_data_path=workspace_dir,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
+    with _managed_workspace_service(name="command-doc") as managed:
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
             upload_session_service=upload_session_service,
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
         )
         upload_event_a = _build_event(sender_id="user-a")
         upload_event_b = _build_event(sender_id="user-a")
@@ -4039,9 +4011,6 @@ async def test_command_service_doc_lists_selects_and_clears_uploaded_files():
         remaining = service.doc_list(_build_event(sender_id="user-a"))
         assert "[f1] A.docx" not in remaining
         assert "[f2] B.xlsx" in remaining
-    finally:
-        shutil.rmtree(workspace_dir, ignore_errors=True)
-        executor.shutdown(wait=False)
 
 
 @pytest.mark.asyncio
@@ -4051,13 +4020,8 @@ async def test_command_service_doc_use_supports_multiple_file_ids():
     context.get_event_queue.return_value = event_queue
     context.get_config.return_value = {"wake_prefix": ["/"]}
     source_path = Path(__file__).resolve()
-    upload_session_service = UploadSessionService(
+    upload_session_service = _build_upload_session_service(
         context=context,
-        recent_text_ttl_seconds=30,
-        upload_session_ttl_seconds=300,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(
             side_effect=[
                 (source_path, "A.docx"),
@@ -4065,37 +4029,12 @@ async def test_command_service_doc_use_supports_multiple_file_ids():
             ]
         ),
         store_uploaded_file=MagicMock(side_effect=[Path("A_1.docx"), Path("B_1.xlsx")]),
-        allow_external_input_files=False,
     )
-    workspace_dir = _make_workspace("command-doc-multi")
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        pdf_converter = MagicMock()
-        pdf_converter.capabilities = {
-            "office_to_pdf": False,
-            "pdf_to_word": False,
-            "pdf_to_excel": False,
-        }
-        service = CommandService(
-            workspace_service=workspace_service,
-            pdf_converter=pdf_converter,
-            plugin_data_path=workspace_dir,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
+    with _managed_workspace_service(name="command-doc-multi") as managed:
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
             upload_session_service=upload_session_service,
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
         )
         await upload_session_service._ensure_upload_infos(
             _build_event(sender_id="user-a"),
@@ -4117,9 +4056,6 @@ async def test_command_service_doc_use_supports_multiple_file_ids():
         cached_infos = upload_session_service.get_cached_upload_infos(queued_event)
         assert [info["file_id"] for info in cached_infos] == ["f1", "f2"]
         assert "根据这些文件整理成正式汇报" in queued_event.message_str
-    finally:
-        shutil.rmtree(workspace_dir, ignore_errors=True)
-        executor.shutdown(wait=False)
 
 
 @pytest.mark.asyncio
@@ -4128,16 +4064,10 @@ async def test_upload_session_service_requeue_uses_configured_wake_prefix():
     event_queue = AsyncMock()
     context.get_event_queue.return_value = event_queue
     context.get_config.return_value = {"wake_prefix": ["!"]}
-    service = UploadSessionService(
+    service = _build_upload_session_service(
         context=context,
-        recent_text_ttl_seconds=30,
-        upload_session_ttl_seconds=300,
-        recent_text_max_entries=32,
-        recent_text_cleanup_interval_seconds=10,
-        upload_session_cleanup_interval_seconds=30,
         extract_upload_source=AsyncMock(),
         store_uploaded_file=MagicMock(),
-        allow_external_input_files=False,
     )
     event = _build_event(sender_id="user-a")
     upload_info = {
@@ -4655,26 +4585,12 @@ async def test_error_hook_service_uses_event_session_when_target_not_configured(
 
 @pytest.mark.asyncio
 async def test_file_tool_service_reads_text_from_workspace_file():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={},
-        )
-
-        result = await service.read_file(event, Path(__file__).resolve().name)
-    finally:
-        executor.shutdown(wait=False)
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent
+    ) as managed:
+        result = await managed.service.read_file(event, Path(__file__).resolve().name)
 
     assert result is not None
     assert "[文件:" in result
@@ -4683,13 +4599,14 @@ async def test_file_tool_service_reads_text_from_workspace_file():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_reads_docx_and_extracts_embedded_images():
-    workspace_dir = _make_workspace("read-docx-images")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-report.docx"
-    image_path = workspace_dir / "embedded.png"
 
-    try:
+    with _managed_file_tool_service(
+        workspace_name="read-docx-images",
+        office_libs={"docx": object()},
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         docx = _import_docx()
 
         _write_png(image_path)
@@ -4699,22 +4616,7 @@ async def test_file_tool_service_reads_docx_and_extracts_embedded_images():
         document.add_paragraph("图片后的说明")
         document.save(docx_path)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.read_file(event, docx_path.name)
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
+        result = await managed.service.read_file(event, docx_path.name)
 
     assert result is not None
     assert "文档正文" in result
@@ -4815,11 +4717,6 @@ def test_extract_word_content_returns_structured_result_for_legacy_doc(
 def test_workspace_service_extract_office_text_reads_legacy_doc(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    workspace_dir = _make_workspace("workspace-legacy-doc")
-    executor = ThreadPoolExecutor(max_workers=1)
-    doc_path = workspace_dir / "legacy.doc"
-    doc_path.write_bytes(b"legacy")
-
     monkeypatch.setattr(office_utils, "_ANTIWORD_AVAILABLE", True)
     monkeypatch.setattr(office_utils, "_WIN32COM_AVAILABLE", False)
     monkeypatch.setattr(
@@ -4828,29 +4725,21 @@ def test_workspace_service_extract_office_text_reads_legacy_doc(
         lambda _path: "Legacy document text",
     )
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        extracted = workspace_service.extract_office_text(doc_path, OfficeType.WORD)
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
+    with _managed_workspace_service(name="workspace-legacy-doc") as managed:
+        doc_path = managed.workspace_dir / "legacy.doc"
+        doc_path.write_bytes(b"legacy")
+        extracted = managed.workspace_service.extract_office_text(doc_path, OfficeType.WORD)
 
     assert extracted == "Legacy document text"
 
 
 def test_workspace_service_extract_word_content_skips_docx_image_materialization_when_disabled():
-    workspace_dir = _make_workspace("workspace-docx-no-image-materialize")
-    executor = ThreadPoolExecutor(max_workers=1)
-    docx_path = workspace_dir / "image-report.docx"
-    image_path = workspace_dir / "embedded.png"
-
-    try:
+    with _managed_workspace_service(
+        name="workspace-docx-no-image-materialize",
+        office_libs={"docx": object()},
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         docx = _import_docx()
 
         _write_png(image_path)
@@ -4860,21 +4749,10 @@ def test_workspace_service_extract_word_content_skips_docx_image_materialization
         document.add_paragraph("图后说明")
         document.save(docx_path)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-
-        extracted = workspace_service.extract_word_content(
+        extracted = managed.workspace_service.extract_word_content(
             docx_path,
             include_images=False,
         )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert extracted is not None
     assert extracted.image_count == 1
@@ -4883,12 +4761,12 @@ def test_workspace_service_extract_word_content_skips_docx_image_materialization
 
 
 def test_workspace_service_extract_word_content_formats_relative_image_paths_when_enabled():
-    workspace_dir = _make_workspace("workspace-docx-image-materialize")
-    executor = ThreadPoolExecutor(max_workers=1)
-    docx_path = workspace_dir / "image-report.docx"
-    image_path = workspace_dir / "embedded.png"
-
-    try:
+    with _managed_workspace_service(
+        name="workspace-docx-image-materialize",
+        office_libs={"docx": object()},
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         docx = _import_docx()
 
         _write_png(image_path)
@@ -4898,25 +4776,14 @@ def test_workspace_service_extract_word_content_formats_relative_image_paths_whe
         document.add_paragraph("图后说明")
         document.save(docx_path)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-
-        extracted = workspace_service.extract_word_content(
+        extracted = managed.workspace_service.extract_word_content(
             docx_path,
             include_images=True,
         )
-        formatted = workspace_service.format_word_content(
+        formatted = managed.workspace_service.format_word_content(
             extracted,
             include_image_paths=True,
         )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert extracted is not None
     assert extracted.image_count == 1
@@ -4926,19 +4793,20 @@ def test_workspace_service_extract_word_content_formats_relative_image_paths_whe
     assert "图后说明" in formatted
     assert "[插图1]" in formatted
     assert ".read_assets/" in formatted
-    assert str(workspace_dir) not in formatted
-    assert str(workspace_dir.resolve()) not in formatted
+    assert str(managed.workspace_dir) not in formatted
+    assert str(managed.workspace_dir.resolve()) not in formatted
 
 
 @pytest.mark.asyncio
 async def test_file_tool_service_streams_docx_images_as_tool_results():
-    workspace_dir = _make_workspace("stream-docx-images")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-report.docx"
-    image_path = workspace_dir / "embedded.png"
 
-    try:
+    with _managed_file_tool_service(
+        workspace_name="stream-docx-images",
+        office_libs={"docx": object()},
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         docx = _import_docx()
 
         _write_png(image_path)
@@ -4948,27 +4816,12 @@ async def test_file_tool_service_streams_docx_images_as_tool_results():
         document.add_paragraph("图片后的说明")
         document.save(docx_path)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert isinstance(results[0], str)
     assert "文档正文" in results[0]
@@ -4983,34 +4836,17 @@ async def test_file_tool_service_streams_docx_images_as_tool_results():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_returns_error_when_docx_library_missing():
-    workspace_dir = _make_workspace("missing-docx-lib")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "missing-lib.docx"
-    docx_path.write_bytes(b"not-a-real-docx")
-
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={},
-        )
+    with _managed_file_tool_service(workspace_name="missing-docx-lib") as managed:
+        docx_path = managed.workspace_dir / "missing-lib.docx"
+        docx_path.write_bytes(b"not-a-real-docx")
 
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert results == ["错误：文件 'missing-lib.docx' 无法读取，可能未安装对应解析库"]
 
@@ -5019,70 +4855,56 @@ async def test_file_tool_service_returns_error_when_docx_library_missing():
 async def test_file_tool_service_skips_unreadable_docx_image_bytes(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    workspace_dir = _make_workspace("broken-docx-image")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "broken-image.docx"
-    docx_path.write_bytes(b"placeholder")
-    broken_image_path = workspace_dir / "broken.png"
-    healthy_image_path = workspace_dir / "healthy.png"
-    broken_image_path.write_bytes(b"broken")
-    _write_png(healthy_image_path)
+    with _managed_file_tool_service(
+        workspace_name="broken-docx-image",
+        office_libs={"docx": object()},
+    ) as managed:
+        docx_path = managed.workspace_dir / "broken-image.docx"
+        docx_path.write_bytes(b"placeholder")
+        broken_image_path = managed.workspace_dir / "broken.png"
+        healthy_image_path = managed.workspace_dir / "healthy.png"
+        broken_image_path.write_bytes(b"broken")
+        _write_png(healthy_image_path)
 
-    extracted = ExtractedWordContent(
-        items=[
-            ExtractedWordItem(type="text", text="文档正文"),
-            ExtractedWordItem(
-                type="image",
-                image_path=broken_image_path,
-                image_index=1,
-            ),
-            ExtractedWordItem(type="text", text="收尾说明"),
-            ExtractedWordItem(
-                type="image",
-                image_path=healthy_image_path,
-                image_index=2,
-            ),
-        ],
-        image_paths=[broken_image_path, healthy_image_path],
-    )
-
-    original_read_bytes = Path.read_bytes
-
-    def fake_read_bytes(path: Path) -> bytes:
-        if path == broken_image_path:
-            raise OSError("broken image")
-        return original_read_bytes(path)
-
-    monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
-
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
+        extracted = ExtractedWordContent(
+            items=[
+                ExtractedWordItem(type="text", text="文档正文"),
+                ExtractedWordItem(
+                    type="image",
+                    image_path=broken_image_path,
+                    image_index=1,
+                ),
+                ExtractedWordItem(type="text", text="收尾说明"),
+                ExtractedWordItem(
+                    type="image",
+                    image_path=healthy_image_path,
+                    image_index=2,
+                ),
+            ],
+            image_paths=[broken_image_path, healthy_image_path],
         )
+
+        original_read_bytes = Path.read_bytes
+
+        def fake_read_bytes(path: Path) -> bytes:
+            if path == broken_image_path:
+                raise OSError("broken image")
+            return original_read_bytes(path)
+
+        monkeypatch.setattr(Path, "read_bytes", fake_read_bytes)
+
         monkeypatch.setattr(
-            workspace_service,
+            managed.workspace_service,
             "extract_word_content",
             lambda _path, include_images=True: extracted,
         )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert len(results) == 2
     assert isinstance(results[0], str)
@@ -5097,26 +4919,21 @@ async def test_file_tool_service_skips_unreadable_docx_image_bytes(
 
 @pytest.mark.asyncio
 async def test_file_tool_service_uses_item_image_index_for_skip_reasons():
-    workspace_dir = _make_workspace("stream-docx-image-index")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-report.docx"
-    large_image = workspace_dir / "embedded-large.png"
-    small_image = workspace_dir / "embedded-small.png"
-
-    try:
+    with _managed_file_tool_service(
+        workspace_name="stream-docx-image-index",
+        office_libs={"docx": object()},
+        max_inline_docx_image_bytes=20,
+        max_inline_docx_image_count=2,
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        large_image = managed.workspace_dir / "embedded-large.png"
+        small_image = managed.workspace_dir / "embedded-small.png"
         docx_path.write_bytes(b"docx")
         large_image.write_bytes(b"a" * 40)
         small_image.write_bytes(b"b" * 10)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        workspace_service.extract_word_content = MagicMock(
+        managed.workspace_service.extract_word_content = MagicMock(
             return_value=SimpleNamespace(
                 text="文档正文",
                 image_paths=[large_image, small_image],
@@ -5138,22 +4955,12 @@ async def test_file_tool_service_uses_item_image_index_for_skip_reasons():
             )
         )
 
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-            max_inline_docx_image_bytes=20,
-            max_inline_docx_image_count=2,
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert isinstance(results[0], str)
     assert "[插图2]" in results[0]
@@ -5165,30 +4972,25 @@ async def test_file_tool_service_uses_item_image_index_for_skip_reasons():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_limits_inline_docx_images():
-    workspace_dir = _make_workspace("stream-docx-image-limits")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-report.docx"
-    small_image_1 = workspace_dir / "embedded-1.png"
-    large_image = workspace_dir / "embedded-large.png"
-    small_image_2 = workspace_dir / "embedded-2.png"
-    small_image_3 = workspace_dir / "embedded-3.png"
-
-    try:
+    with _managed_file_tool_service(
+        workspace_name="stream-docx-image-limits",
+        office_libs={"docx": object()},
+        max_inline_docx_image_bytes=20,
+        max_inline_docx_image_count=2,
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        small_image_1 = managed.workspace_dir / "embedded-1.png"
+        large_image = managed.workspace_dir / "embedded-large.png"
+        small_image_2 = managed.workspace_dir / "embedded-2.png"
+        small_image_3 = managed.workspace_dir / "embedded-3.png"
         docx_path.write_bytes(b"docx")
         small_image_1.write_bytes(b"a" * 10)
         large_image.write_bytes(b"b" * 40)
         small_image_2.write_bytes(b"c" * 10)
         small_image_3.write_bytes(b"d" * 10)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        workspace_service.extract_word_content = MagicMock(
+        managed.workspace_service.extract_word_content = MagicMock(
             return_value=SimpleNamespace(
                 text="文档正文",
                 image_paths=[
@@ -5209,22 +5011,12 @@ async def test_file_tool_service_limits_inline_docx_images():
             )
         )
 
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-            max_inline_docx_image_bytes=20,
-            max_inline_docx_image_count=2,
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert isinstance(results[0], str)
     assert "文档正文" in results[0]
@@ -5242,24 +5034,18 @@ async def test_file_tool_service_limits_inline_docx_images():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_skips_docx_image_review_when_disabled():
-    workspace_dir = _make_workspace("stream-docx-image-review-disabled")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-report.docx"
-    image_path = workspace_dir / "embedded.png"
-
-    try:
+    with _managed_file_tool_service(
+        workspace_name="stream-docx-image-review-disabled",
+        office_libs={"docx": object()},
+        enable_docx_image_review=False,
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-report.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         _write_png(image_path)
         docx_path.write_bytes(b"docx")
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        workspace_service.extract_word_content = MagicMock(
+        managed.workspace_service.extract_word_content = MagicMock(
             return_value=SimpleNamespace(
                 text="文档正文",
                 image_paths=[image_path],
@@ -5276,28 +5062,19 @@ async def test_file_tool_service_skips_docx_image_review_when_disabled():
             )
         )
 
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-            enable_docx_image_review=False,
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert len(results) == 1
     assert isinstance(results[0], str)
     assert "图前说明" in results[0]
     assert "图后说明" in results[0]
     assert "[插图1]" not in results[0]
-    workspace_service.extract_word_content.assert_called_once_with(
+    managed.workspace_service.extract_word_content.assert_called_once_with(
         docx_path,
         include_images=False,
     )
@@ -5305,24 +5082,18 @@ async def test_file_tool_service_skips_docx_image_review_when_disabled():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_returns_message_for_image_only_docx_when_review_disabled():
-    workspace_dir = _make_workspace("stream-docx-image-only-disabled")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
-    docx_path = workspace_dir / "image-only.docx"
-    image_path = workspace_dir / "embedded.png"
-
-    try:
+    with _managed_file_tool_service(
+        workspace_name="stream-docx-image-only-disabled",
+        office_libs={"docx": object()},
+        enable_docx_image_review=False,
+    ) as managed:
+        docx_path = managed.workspace_dir / "image-only.docx"
+        image_path = managed.workspace_dir / "embedded.png"
         _write_png(image_path)
         docx_path.write_bytes(b"docx")
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        workspace_service.extract_word_content = MagicMock(
+        managed.workspace_service.extract_word_content = MagicMock(
             return_value=SimpleNamespace(
                 text=None,
                 image_paths=[image_path],
@@ -5337,27 +5108,18 @@ async def test_file_tool_service_returns_message_for_image_only_docx_when_review
             )
         )
 
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"docx": object()},
-            enable_docx_image_review=False,
-        )
-
         results = [
             result
-            async for result in service.iter_read_file_tool_results(
+            async for result in managed.service.iter_read_file_tool_results(
                 event, docx_path.name
             )
         ]
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert len(results) == 1
     assert isinstance(results[0], str)
     assert "仅包含图片内容" in results[0]
     assert "[插图1]" not in results[0]
-    workspace_service.extract_word_content.assert_called_once_with(
+    managed.workspace_service.extract_word_content.assert_called_once_with(
         docx_path,
         include_images=False,
     )
@@ -5365,26 +5127,12 @@ async def test_file_tool_service_returns_message_for_image_only_docx_when_review
 
 @pytest.mark.asyncio
 async def test_file_tool_service_returns_local_guidance_for_missing_file():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={},
-        )
-
-        result = await service.read_file(event, "CLAUDE.md")
-    finally:
-        executor.shutdown(wait=False)
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent
+    ) as managed:
+        result = await managed.service.read_file(event, "CLAUDE.md")
 
     assert result is not None
     assert "错误：文件 'CLAUDE.md' 不存在。" in result
@@ -5489,13 +5237,14 @@ async def test_file_tool_service_offloads_office_text_extraction_to_thread():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_reads_workbook_with_sheet_sections():
-    workspace_dir = _make_workspace("read-workbook")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
+    with _managed_file_tool_service(
+        workspace_name="read-workbook",
+        office_libs={"openpyxl": object()},
+    ) as managed:
         openpyxl = pytest.importorskip("openpyxl")
-        workbook_path = workspace_dir / "sales.xlsx"
+        workbook_path = managed.workspace_dir / "sales.xlsx"
         workbook = openpyxl.Workbook()
         summary_sheet = workbook.active
         summary_sheet.title = "总表"
@@ -5506,22 +5255,7 @@ async def test_file_tool_service_reads_workbook_with_sheet_sections():
         east_sheet.append(["上海", 80])
         workbook.save(workbook_path)
 
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
-
-        result = await service.read_workbook(event, workbook_path.name)
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
+        result = await managed.service.read_workbook(event, workbook_path.name)
 
     assert result is not None
     assert "[文件信息] 文件名: sales.xlsx" in result
@@ -5535,27 +5269,17 @@ async def test_file_tool_service_reads_workbook_with_sheet_sections():
 @pytest.mark.asyncio
 async def test_file_tool_service_read_workbook_rejects_non_excel_suffix():
     workspace_dir = _make_workspace("read-workbook-invalid")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
     try:
         text_path = workspace_dir / "notes.txt"
         text_path.write_text("demo", encoding="utf-8")
-        workspace_service = WorkspaceService(
+        with _managed_file_tool_service(
             plugin_data_path=workspace_dir,
-            executor=executor,
             office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={},
-        )
-
-        result = await service.read_workbook(event, text_path.name)
+        ) as managed:
+            result = await managed.service.read_workbook(event, text_path.name)
     finally:
-        executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert result is not None
@@ -5566,29 +5290,19 @@ async def test_file_tool_service_read_workbook_rejects_non_excel_suffix():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_text_result():
-    workspace_dir = _make_workspace("execute-excel-script-text")
-    sandbox_dir = workspace_dir / "fake-sandbox"
-    sandbox_dir.mkdir()
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        delivery_service = MagicMock()
-        delivery_service.send_file_with_preview = AsyncMock()
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            delivery_service=delivery_service,
-            office_libs={"openpyxl": object()},
-        )
+    delivery_service = MagicMock()
+    delivery_service.send_file_with_preview = AsyncMock()
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-text",
+        office_libs={"openpyxl": object()},
+        delivery_service=delivery_service,
+    ) as managed:
+        sandbox_dir = managed.workspace_dir / "fake-sandbox"
+        sandbox_dir.mkdir()
         with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
-            result = await service.execute_excel_script(
+            result = await managed.service.execute_excel_script(
                 event,
                 script=(
                     "workbook = Workbook()\n"
@@ -5598,9 +5312,6 @@ async def test_file_tool_service_execute_excel_script_returns_text_result():
                     "result_text = worksheet['A1'].value\n"
                 ),
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -5611,29 +5322,19 @@ async def test_file_tool_service_execute_excel_script_returns_text_result():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_generated_file():
-    workspace_dir = _make_workspace("execute-excel-script-file")
-    sandbox_dir = workspace_dir / "fake-sandbox"
-    sandbox_dir.mkdir()
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        delivery_service = MagicMock()
-        delivery_service.send_file_with_preview = AsyncMock()
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            delivery_service=delivery_service,
-            office_libs={"openpyxl": object()},
-        )
+    delivery_service = MagicMock()
+    delivery_service.send_file_with_preview = AsyncMock()
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-file",
+        office_libs={"openpyxl": object()},
+        delivery_service=delivery_service,
+    ) as managed:
+        sandbox_dir = managed.workspace_dir / "fake-sandbox"
+        sandbox_dir.mkdir()
         with _patch_excel_sandbox(_FakeSandboxBooter(sandbox_dir)):
-            result = await service.execute_excel_script(
+            result = await managed.service.execute_excel_script(
                 event,
                 script=(
                     "workbook = Workbook()\n"
@@ -5643,9 +5344,6 @@ async def test_file_tool_service_execute_excel_script_returns_generated_file():
                 ),
                 output_name="script-output.xlsx",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -5667,24 +5365,15 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
     check_permission,
     expected_error,
 ):
-    workspace_dir = _make_workspace("execute-excel-script-validation-error")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-            is_group_feature_enabled=is_group_feature_enabled,
-            check_permission=check_permission,
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-validation-error",
+        office_libs={"openpyxl": object()},
+        is_group_feature_enabled=is_group_feature_enabled,
+        check_permission=check_permission,
+    ) as managed:
+        service = managed.service
         runner = MagicMock()
         service._excel_script_service._run_script_process = runner
 
@@ -5700,9 +5389,6 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
                 script="result_text = 'ok'",
             )
         )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     assert first["success"] is False
     assert first["error"] == expected_error
@@ -5717,24 +5403,14 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_runs_in_local_runtime():
-    workspace_dir = _make_workspace("execute-excel-script-local-runtime")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=_build_astrbot_context(runtime="local"),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
-
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-local-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_build_astrbot_context(runtime="local"),
+    ) as managed:
+        service = managed.service
         with patch(
             "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
             new=AsyncMock(),
@@ -5743,9 +5419,6 @@ async def test_file_tool_service_execute_excel_script_runs_in_local_runtime():
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -5756,23 +5429,14 @@ async def test_file_tool_service_execute_excel_script_runs_in_local_runtime():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
-    workspace_dir = _make_workspace("execute-excel-script-none-runtime")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=_build_astrbot_context(runtime="none"),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-none-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_build_astrbot_context(runtime="none"),
+    ) as managed:
+        service = managed.service
         runner = AsyncMock()
         service._excel_script_service._run_script_process = runner
 
@@ -5784,9 +5448,6 @@ async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is False
@@ -5799,25 +5460,16 @@ async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_rejects_legacy_none_runtime():
-    workspace_dir = _make_workspace("execute-excel-script-legacy-none-runtime")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=SimpleNamespace(
-                astrbot_config={"provider_settings": {"computer_use_runtime": "none"}}
-            ),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-legacy-none-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=SimpleNamespace(
+            astrbot_config={"provider_settings": {"computer_use_runtime": "none"}}
+        ),
+    ) as managed:
+        service = managed.service
         runner = AsyncMock()
         service._excel_script_service._run_script_process = runner
 
@@ -5829,9 +5481,6 @@ async def test_file_tool_service_execute_excel_script_rejects_legacy_none_runtim
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is False
@@ -5849,23 +5498,14 @@ async def test_file_tool_service_execute_excel_script_returns_structured_error_w
         def get_config(*_args, **_kwargs):
             raise RuntimeError("config backend unavailable")
 
-    workspace_dir = _make_workspace("execute-excel-script-runtime-lookup-failure")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=_BrokenConfigContext(),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-runtime-lookup-failure",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_BrokenConfigContext(),
+    ) as managed:
+        service = managed.service
         runner = AsyncMock()
         service._excel_script_service._run_script_process = runner
 
@@ -5877,9 +5517,6 @@ async def test_file_tool_service_execute_excel_script_returns_structured_error_w
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is False
@@ -5893,25 +5530,16 @@ async def test_file_tool_service_execute_excel_script_returns_structured_error_w
 
 @pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_accepts_legacy_sandbox_runtime():
-    workspace_dir = _make_workspace("execute-excel-script-legacy-sandbox-runtime")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=SimpleNamespace(
-                astrbot_config={"provider_settings": {"computer_use_runtime": "sandbox"}}
-            ),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-legacy-sandbox-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=SimpleNamespace(
+            astrbot_config={"provider_settings": {"computer_use_runtime": "sandbox"}}
+        ),
+    ) as managed:
+        service = managed.service
         service._excel_script_service._run_script_process = AsyncMock(
             return_value=SimpleNamespace(
                 success=True,
@@ -5929,9 +5557,6 @@ async def test_file_tool_service_execute_excel_script_accepts_legacy_sandbox_run
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -5948,23 +5573,14 @@ async def test_file_tool_service_execute_excel_script_accepts_positional_session
             assert session_id == "session-1"
             return {"provider_settings": {"computer_use_runtime": "sandbox"}}
 
-    workspace_dir = _make_workspace("execute-excel-script-positional-config")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=_PositionalSessionContext(),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-positional-config",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_PositionalSessionContext(),
+    ) as managed:
+        service = managed.service
         service._excel_script_service._run_script_process = AsyncMock(
             return_value=SimpleNamespace(
                 success=True,
@@ -5982,9 +5598,6 @@ async def test_file_tool_service_execute_excel_script_accepts_positional_session
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -6000,23 +5613,14 @@ async def test_file_tool_service_execute_excel_script_accepts_noarg_session_conf
         def get_config():
             return {"provider_settings": {"computer_use_runtime": "sandbox"}}
 
-    workspace_dir = _make_workspace("execute-excel-script-noarg-config")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        service = _build_file_tool_service(
-            astrbot_context=_NoArgSessionContext(),
-            workspace_service=workspace_service,
-            office_libs={"openpyxl": object()},
-        )
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-noarg-config",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_NoArgSessionContext(),
+    ) as managed:
+        service = managed.service
         service._excel_script_service._run_script_process = AsyncMock(
             return_value=SimpleNamespace(
                 success=True,
@@ -6037,9 +5641,6 @@ async def test_file_tool_service_execute_excel_script_accepts_noarg_session_conf
                 event,
                 script="result_text = 'ok'",
             )
-    finally:
-        executor.shutdown(wait=False)
-        shutil.rmtree(workspace_dir, ignore_errors=True)
 
     payload = json.loads(result)
     assert payload["success"] is True
@@ -6879,8 +6480,6 @@ async def test_file_tool_service_execute_excel_script_resets_retry_count_after_s
 
 @pytest.mark.asyncio
 async def test_file_tool_service_creates_office_file_via_generator_and_delivery():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     event.send = AsyncMock()
     office_generator = MagicMock()
@@ -6888,30 +6487,20 @@ async def test_file_tool_service_creates_office_file_via_generator_and_delivery(
     delivery_service = MagicMock()
     delivery_service.send_file_with_preview = AsyncMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        office_libs={"docx": object()},
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report.docx",
             content="hello world",
             file_type="word",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     office_generator.generate.assert_awaited_once()
     delivery_service.send_file_with_preview.assert_awaited_once()
@@ -6922,130 +6511,107 @@ async def test_file_tool_service_creates_office_file_via_generator_and_delivery(
 async def test_file_tool_service_create_office_file_exports_word_via_node_backend():
     docx = _import_docx()
     workspace_dir = _make_workspace("create-office-word-node")
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     event.send = AsyncMock()
     delivery_service = MagicMock()
     delivery_service.send_file_with_preview = AsyncMock()
 
     try:
-        workspace_service = WorkspaceService(
+        with _managed_file_tool_service(
             plugin_data_path=workspace_dir,
-            executor=executor,
             office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
             feature_settings={"enable_office_files": True},
-        )
-        office_generator = OfficeGenerator(
-            data_path=workspace_dir,
-            render_backend_config=_node_render_backend_config_for_tests(),
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
+            office_generator=OfficeGenerator(
+                data_path=workspace_dir,
+                render_backend_config=_node_render_backend_config_for_tests(),
+            ),
             pdf_converter=MagicMock(),
             delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.create_office_file(
-            event,
-            filename="report.docx",
-            content={
-                "metadata": {
-                    "title": "Node Legacy Entry",
-                    "document_style": {
-                        "summary_card_defaults": {
-                            "title_align": "center",
-                            "title_emphasis": "strong",
-                            "title_font_scale": 1.2,
-                            "title_space_before": 12,
-                            "title_space_after": 4,
-                            "list_space_after": 8,
+        ) as managed:
+            result = await managed.service.create_office_file(
+                event,
+                filename="report.docx",
+                content={
+                    "metadata": {
+                        "title": "Node Legacy Entry",
+                        "document_style": {
+                            "summary_card_defaults": {
+                                "title_align": "center",
+                                "title_emphasis": "strong",
+                                "title_font_scale": 1.2,
+                                "title_space_before": 12,
+                                "title_space_after": 4,
+                                "list_space_after": 8,
+                            }
                         }
                     },
+                    "blocks": [
+                        {"type": "heading", "text": "一、经营总览", "level": 1},
+                        {
+                            "type": "table",
+                            "headers": ["日期", "时间", "内容"],
+                            "rows": [
+                                ["第一天", "09:00", "课程 A"],
+                                ["第二天", "13:00", "课程 B"],
+                            ],
+                        },
+                        {
+                            "type": "summary_card",
+                            "title": "Highlights",
+                            "items": ["Stable revenue", "Lower churn"],
+                            "variant": "conclusion",
+                        },
+                    ],
                 },
-                "blocks": [
-                    {"type": "heading", "text": "一、经营总览", "level": 1},
-                    {
-                        "type": "table",
-                        "headers": ["日期", "时间", "内容"],
-                        "rows": [
-                            ["第一天", "09:00", "课程 A"],
-                            ["第二天", "13:00", "课程 B"],
-                        ],
-                    },
-                    {
-                        "type": "summary_card",
-                        "title": "Highlights",
-                        "items": ["Stable revenue", "Lower churn"],
-                        "variant": "conclusion",
-                    },
-                ],
-            },
-            file_type="word",
-        )
-        assert result is None
-        delivery_service.send_file_with_preview.assert_awaited_once()
-        delivered_path = Path(delivery_service.send_file_with_preview.await_args.args[1])
-        loaded_doc = docx.Document(delivered_path)
-        table = loaded_doc.tables[0]
+                file_type="word",
+            )
+            assert result is None
+            delivery_service.send_file_with_preview.assert_awaited_once()
+            delivered_path = Path(delivery_service.send_file_with_preview.await_args.args[1])
+            loaded_doc = docx.Document(delivered_path)
+            table = loaded_doc.tables[0]
 
-        assert any(
-            paragraph.text == "Node Legacy Entry" for paragraph in loaded_doc.paragraphs
-        )
-        assert any(
-            paragraph.text == "一、经营总览" for paragraph in loaded_doc.paragraphs
-        )
-        from docx.enum.text import WD_ALIGN_PARAGRAPH
+            assert any(
+                paragraph.text == "Node Legacy Entry" for paragraph in loaded_doc.paragraphs
+            )
+            assert any(
+                paragraph.text == "一、经营总览" for paragraph in loaded_doc.paragraphs
+            )
+            from docx.enum.text import WD_ALIGN_PARAGRAPH
 
-        summary_title = _find_paragraph(loaded_doc, "Highlights")
-        summary_item = _find_paragraph(loaded_doc, "• Stable revenue")
-        assert summary_title.alignment == WD_ALIGN_PARAGRAPH.CENTER
-        assert summary_title.runs[0].bold is True
-        assert summary_title.paragraph_format.space_before.pt == pytest.approx(12, abs=0.5)
-        assert summary_title.paragraph_format.space_after.pt == pytest.approx(4, abs=0.5)
-        assert summary_item.paragraph_format.space_after.pt == pytest.approx(8, abs=0.5)
-        assert table.rows[0].cells[0].text == "日期"
-        assert len(table.rows) >= 3
+            summary_title = _find_paragraph(loaded_doc, "Highlights")
+            summary_item = _find_paragraph(loaded_doc, "• Stable revenue")
+            assert summary_title.alignment == WD_ALIGN_PARAGRAPH.CENTER
+            assert summary_title.runs[0].bold is True
+            assert summary_title.paragraph_format.space_before.pt == pytest.approx(12, abs=0.5)
+            assert summary_title.paragraph_format.space_after.pt == pytest.approx(4, abs=0.5)
+            assert summary_item.paragraph_format.space_after.pt == pytest.approx(8, abs=0.5)
+            assert table.rows[0].cells[0].text == "日期"
+            assert len(table.rows) >= 3
     finally:
-        executor.shutdown(wait=False)
         shutil.rmtree(workspace_dir, ignore_errors=True)
 
 
 @pytest.mark.asyncio
 async def test_file_tool_service_create_office_file_returns_error_without_sending():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     event.send = AsyncMock()
     office_generator = MagicMock()
     delivery_service = MagicMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report.unsupported",
             content="hello world",
             file_type="unknown",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     assert result == "错误：不支持的文件类型 'unknown'。允许值：excel/powerpoint"
     event.send.assert_not_called()
@@ -7055,38 +6621,26 @@ async def test_file_tool_service_create_office_file_returns_error_without_sendin
 
 @pytest.mark.asyncio
 async def test_file_tool_service_create_office_file_returns_error_when_generated_file_missing():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     office_generator = MagicMock()
     office_generator.generate = AsyncMock(return_value=None)
     delivery_service = MagicMock()
     delivery_service.send_file_with_preview = AsyncMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        office_libs={"docx": object()},
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report.docx",
             content="hello world",
             file_type="word",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     assert result == "错误：文件生成失败，未找到输出文件"
     delivery_service.send_file_with_preview.assert_not_called()
@@ -7094,36 +6648,24 @@ async def test_file_tool_service_create_office_file_returns_error_when_generated
 
 @pytest.mark.asyncio
 async def test_file_tool_service_create_office_file_requires_explicit_type_without_suffix():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     office_generator = MagicMock()
     delivery_service = MagicMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"openpyxl": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={"openpyxl": object()},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        office_libs={"openpyxl": object()},
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report",
             content="hello world",
             file_type="",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     assert (
         result
@@ -7135,36 +6677,24 @@ async def test_file_tool_service_create_office_file_requires_explicit_type_witho
 
 @pytest.mark.asyncio
 async def test_file_tool_service_create_office_file_rejects_word_fallback_without_suffix():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     office_generator = MagicMock()
     delivery_service = MagicMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        office_libs={"docx": object()},
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report",
             content="hello world",
             file_type="word",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     assert (
         result
@@ -7177,8 +6707,6 @@ async def test_file_tool_service_create_office_file_rejects_word_fallback_withou
 
 @pytest.mark.asyncio
 async def test_file_tool_service_create_office_file_returns_direct_result_for_explicit_tool_error():
-    workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     event.get_extra.side_effect = lambda key, default=None: {
         EXPLICIT_FILE_TOOL_EVENT_KEY: "create_office_file"
@@ -7187,30 +6715,20 @@ async def test_file_tool_service_create_office_file_returns_direct_result_for_ex
     office_generator = MagicMock()
     delivery_service = MagicMock()
 
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
-            feature_settings={"enable_office_files": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
-            office_generator=office_generator,
-            pdf_converter=MagicMock(),
-            delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.create_office_file(
+    with _managed_file_tool_service(
+        plugin_data_path=Path(__file__).resolve().parent,
+        office_libs={"docx": object()},
+        feature_settings={"enable_office_files": True},
+        office_generator=office_generator,
+        pdf_converter=MagicMock(),
+        delivery_service=delivery_service,
+    ) as managed:
+        result = await managed.service.create_office_file(
             event,
             filename="report",
             content="hello world",
             file_type="word",
         )
-    finally:
-        executor.shutdown(wait=False)
 
     assert (
         result
@@ -7225,7 +6743,6 @@ async def test_file_tool_service_create_office_file_returns_direct_result_for_ex
 @pytest.mark.asyncio
 async def test_file_tool_service_convert_to_pdf_returns_none_after_delivery():
     workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     source_path = workspace_dir / "convert-source.docx"
     source_path.write_text("demo", encoding="utf-8")
@@ -7237,30 +6754,22 @@ async def test_file_tool_service_convert_to_pdf_returns_none_after_delivery():
     delivery_service.send_file_with_preview = AsyncMock()
 
     try:
-        workspace_service = WorkspaceService(
+        with _managed_file_tool_service(
             plugin_data_path=workspace_dir,
-            executor=executor,
             office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
             feature_settings={"enable_pdf_conversion": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
             office_generator=MagicMock(),
             pdf_converter=pdf_converter,
             delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-        output_path.write_text("pdf", encoding="utf-8")
-
-        result = await service.convert_to_pdf(
-            event,
-            filename=source_path.name,
-        )
+        ) as managed:
+            output_path.write_text("pdf", encoding="utf-8")
+            result = await managed.service.convert_to_pdf(
+                event,
+                filename=source_path.name,
+            )
     finally:
         source_path.unlink(missing_ok=True)
         output_path.unlink(missing_ok=True)
-        executor.shutdown(wait=False)
 
     pdf_converter.office_to_pdf.assert_awaited_once_with(source_path)
     delivery_service.send_file_with_preview.assert_awaited_once()
@@ -7270,7 +6779,6 @@ async def test_file_tool_service_convert_to_pdf_returns_none_after_delivery():
 @pytest.mark.asyncio
 async def test_file_tool_service_convert_to_pdf_returns_error_when_generated_file_missing():
     workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     source_path = workspace_dir / "convert-source-missing.docx"
     source_path.write_text("demo", encoding="utf-8")
@@ -7281,28 +6789,20 @@ async def test_file_tool_service_convert_to_pdf_returns_error_when_generated_fil
     delivery_service.send_file_with_preview = AsyncMock()
 
     try:
-        workspace_service = WorkspaceService(
+        with _managed_file_tool_service(
             plugin_data_path=workspace_dir,
-            executor=executor,
             office_libs={"docx": object()},
-            max_file_size=1024 * 1024,
             feature_settings={"enable_pdf_conversion": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
             office_generator=MagicMock(),
             pdf_converter=pdf_converter,
             delivery_service=delivery_service,
-            office_libs={"docx": object()},
-        )
-
-        result = await service.convert_to_pdf(
-            event,
-            filename=source_path.name,
-        )
+        ) as managed:
+            result = await managed.service.convert_to_pdf(
+                event,
+                filename=source_path.name,
+            )
     finally:
         source_path.unlink(missing_ok=True)
-        executor.shutdown(wait=False)
 
     assert result == "错误：PDF 转换失败，未找到生成的 PDF 文件"
     delivery_service.send_file_with_preview.assert_not_called()
@@ -7311,7 +6811,6 @@ async def test_file_tool_service_convert_to_pdf_returns_error_when_generated_fil
 @pytest.mark.asyncio
 async def test_file_tool_service_convert_from_pdf_returns_error_when_generated_file_missing():
     workspace_dir = Path(__file__).resolve().parent
-    executor = ThreadPoolExecutor(max_workers=1)
     event = _build_event()
     source_path = workspace_dir / "convert-back-missing.pdf"
     source_path.write_text("pdf", encoding="utf-8")
@@ -7323,29 +6822,20 @@ async def test_file_tool_service_convert_from_pdf_returns_error_when_generated_f
     delivery_service.send_file_with_preview = AsyncMock()
 
     try:
-        workspace_service = WorkspaceService(
+        with _managed_file_tool_service(
             plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
             feature_settings={"enable_pdf_conversion": True},
-        )
-        service = _build_file_tool_service(
-            workspace_service=workspace_service,
             office_generator=MagicMock(),
             pdf_converter=pdf_converter,
             delivery_service=delivery_service,
-            office_libs={},
-        )
-
-        result = await service.convert_from_pdf(
-            event,
-            filename=source_path.name,
-            target_format="word",
-        )
+        ) as managed:
+            result = await managed.service.convert_from_pdf(
+                event,
+                filename=source_path.name,
+                target_format="word",
+            )
     finally:
         source_path.unlink(missing_ok=True)
-        executor.shutdown(wait=False)
 
     assert result == "错误：PDF→Word 文档 转换失败，未找到生成的文件"
     delivery_service.send_file_with_preview.assert_not_called()
@@ -7357,56 +6847,26 @@ def test_command_service_lists_office_files_in_workspace():
     sample_file = workspace_dir / "report.docx"
     sample_file.write_text("demo", encoding="utf-8")
 
-    executor = ThreadPoolExecutor(max_workers=1)
     try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=workspace_dir,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
-        pdf_converter = MagicMock()
-        pdf_converter.capabilities = {
-            "office_to_pdf": False,
-            "pdf_to_word": False,
-            "pdf_to_excel": False,
-        }
-        service = CommandService(
-            workspace_service=workspace_service,
-            pdf_converter=pdf_converter,
-            plugin_data_path=workspace_dir,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
-            upload_session_service=MagicMock(),
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
-        )
+        with _managed_workspace_service(plugin_data_path=workspace_dir) as managed:
+            service = _build_command_service(
+                workspace_service=managed.workspace_service,
+                plugin_data_path=workspace_dir,
+            )
 
-        result = service.list_files(_build_event())
+            result = service.list_files(_build_event())
     finally:
         sample_file.unlink(missing_ok=True)
         workspace_dir.rmdir()
-        executor.shutdown(wait=False)
 
     assert "机器人工作区 Office 文件列表" in result
     assert "report.docx" in result
 
 
 def test_command_service_builds_pdf_status_summary():
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=Path(__file__).resolve().parent,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
+    with _managed_workspace_service(
+        plugin_data_path=Path(__file__).resolve().parent
+    ) as managed:
         pdf_converter = MagicMock()
         pdf_converter.get_detailed_status.return_value = {
             "capabilities": {
@@ -7423,24 +6883,13 @@ def test_command_service_builds_pdf_status_summary():
             "libs": {"pdf2docx": False, "tabula-py": True},
         }
         pdf_converter.get_missing_dependencies.return_value = ["pdf2docx"]
-        service = CommandService(
-            workspace_service=workspace_service,
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
             pdf_converter=pdf_converter,
             plugin_data_path=Path(__file__).resolve().parent,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
-            upload_session_service=MagicMock(),
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
         )
 
         result = service.pdf_status(_build_event())
-    finally:
-        executor.shutdown(wait=False)
 
     assert "Office→PDF: ✅ 可用 (libreoffice)" in result
     assert "PDF→Excel:  ✅ 可用 (tabula)" in result
@@ -7449,34 +6898,19 @@ def test_command_service_builds_pdf_status_summary():
 
 
 def test_command_service_fileinfo_reports_word_toolchain_available():
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=Path(__file__).resolve().parent,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
+    with _managed_workspace_service(
+        plugin_data_path=Path(__file__).resolve().parent
+    ) as managed:
         pdf_converter = MagicMock()
         pdf_converter.capabilities = {
             "office_to_pdf": False,
             "pdf_to_word": False,
             "pdf_to_excel": False,
         }
-        service = CommandService(
-            workspace_service=workspace_service,
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
             pdf_converter=pdf_converter,
             plugin_data_path=Path(__file__).resolve().parent,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
-            upload_session_service=MagicMock(),
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
             node_renderer_entry="D:/custom/renderer.js",
         )
 
@@ -7485,42 +6919,25 @@ def test_command_service_fileinfo_reports_word_toolchain_available():
             return_value=True,
         ):
             result = service.fileinfo(_build_event())
-    finally:
-        executor.shutdown(wait=False)
 
     assert "Word工具链: ✅ Node 渲染可用" in result
     assert "renderer.js" in result
 
 
 def test_command_service_fileinfo_reports_word_toolchain_unavailable():
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        workspace_service = WorkspaceService(
-            plugin_data_path=Path(__file__).resolve().parent,
-            executor=executor,
-            office_libs={},
-            max_file_size=1024 * 1024,
-            feature_settings={},
-        )
+    with _managed_workspace_service(
+        plugin_data_path=Path(__file__).resolve().parent
+    ) as managed:
         pdf_converter = MagicMock()
         pdf_converter.capabilities = {
             "office_to_pdf": False,
             "pdf_to_word": False,
             "pdf_to_excel": False,
         }
-        service = CommandService(
-            workspace_service=workspace_service,
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
             pdf_converter=pdf_converter,
             plugin_data_path=Path(__file__).resolve().parent,
-            auto_delete=False,
-            allow_external_input_files=False,
-            enable_features_in_group=True,
-            auto_block_execution_tools=True,
-            reply_to_user=True,
-            upload_session_service=MagicMock(),
-            is_group_feature_enabled=lambda _event: True,
-            check_permission=lambda _event: True,
-            group_feature_disabled_error=lambda: "group disabled",
             node_renderer_entry="D:/custom/missing-renderer.js",
         )
 
@@ -7529,8 +6946,6 @@ def test_command_service_fileinfo_reports_word_toolchain_unavailable():
             return_value=False,
         ):
             result = service.fileinfo(_build_event())
-    finally:
-        executor.shutdown(wait=False)
 
     assert "Word工具链: ❌ Node 渲染不可用" in result
     assert "missing-renderer.js" in result

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1629,6 +1629,30 @@ async def test_request_hook_service_hides_execute_excel_script_for_legacy_none_r
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_hides_execute_excel_script_for_unsupported_runtime():
+    request = _build_provider_request(
+        "请生成一个带公式的 Excel 报表",
+        tool_names=[
+            "read_workbook",
+            "execute_excel_script",
+            "astrbot_execute_shell",
+        ],
+    )
+    service = _build_request_hook_service(
+        astrbot_context=_build_astrbot_context(runtime="sandbx"),
+    )
+    context = _build_tool_exposure_context(request)
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_workbook" in tool_names
+    assert "execute_excel_script" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_keeps_execute_excel_script_when_runtime_lookup_fails():
     class _BrokenConfigContext:
         @staticmethod
@@ -3098,6 +3122,19 @@ def test_excel_intent_router_ignores_output_filename_when_upload_present():
     assert decision is not None
     assert decision.route == "read_existing"
     assert decision.matched_files == ("input.xlsx",)
+
+
+def test_excel_intent_router_keeps_output_worded_existing_filename():
+    decision = ExcelIntentRouter.decide(
+        request_text="请输出 report.xlsx 的内容并总结",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook"},
+    )
+
+    assert decision is not None
+    assert decision.route == "read_existing"
+    assert decision.matched_files == ("report.xlsx",)
 
 
 def test_excel_intent_router_prefers_read_for_update_record_query():
@@ -5416,7 +5453,7 @@ async def test_file_tool_service_execute_excel_script_returns_generated_file():
         (lambda _event: True, lambda _event: False, "错误：权限不足"),
     ],
 )
-async def test_file_tool_service_execute_excel_script_validation_errors_do_not_consume_retry_budget(
+async def test_file_tool_service_execute_excel_script_system_errors_stop_retry_without_consuming_budget(
     is_group_feature_enabled,
     check_permission,
     expected_error,
@@ -5449,11 +5486,11 @@ async def test_file_tool_service_execute_excel_script_validation_errors_do_not_c
     assert first["success"] is False
     assert first["error"] == expected_error
     assert first["retry_count"] == 0
-    assert first["retry_exhausted"] is False
+    assert first["retry_exhausted"] is True
     assert second["success"] is False
     assert second["error"] == expected_error
     assert second["retry_count"] == 0
-    assert second["retry_exhausted"] is False
+    assert second["retry_exhausted"] is True
     assert runner.call_count == 0
 
 
@@ -5509,7 +5546,7 @@ async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
     assert payload["success"] is False
     assert "computer runtime 为 none" in payload["error"]
     assert payload["retry_count"] == 0
-    assert payload["retry_exhausted"] is False
+    assert payload["retry_exhausted"] is True
     runner.assert_not_awaited()
     mocked_get_booter.assert_not_awaited()
 
@@ -5542,7 +5579,38 @@ async def test_file_tool_service_execute_excel_script_rejects_legacy_none_runtim
     assert payload["success"] is False
     assert "computer runtime 为 none" in payload["error"]
     assert payload["retry_count"] == 0
-    assert payload["retry_exhausted"] is False
+    assert payload["retry_exhausted"] is True
+    runner.assert_not_awaited()
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_unsupported_runtime():
+    event = _build_event()
+
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-unsupported-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_build_astrbot_context(runtime="sandbx"),
+    ) as managed:
+        service = managed.service
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "不支持的 computer runtime 配置：sandbx" in payload["error"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is True
     runner.assert_not_awaited()
     mocked_get_booter.assert_not_awaited()
 
@@ -5579,7 +5647,7 @@ async def test_file_tool_service_execute_excel_script_returns_structured_error_w
     assert payload["error"] == "错误：读取当前会话 computer runtime 失败"
     assert "config backend unavailable" in payload["traceback"]
     assert payload["retry_count"] == 0
-    assert payload["retry_exhausted"] is False
+    assert payload["retry_exhausted"] is True
     runner.assert_not_awaited()
     mocked_get_booter.assert_not_awaited()
 
@@ -5750,10 +5818,10 @@ async def test_file_tool_service_execute_excel_script_rejects_sandbox_missing_ca
     assert first["success"] is False
     assert "当前 sandbox profile 缺少必要能力：filesystem" in first["error"]
     assert first["retry_count"] == 0
-    assert first["retry_exhausted"] is False
+    assert first["retry_exhausted"] is True
     assert second["success"] is False
     assert second["retry_count"] == 0
-    assert second["retry_exhausted"] is False
+    assert second["retry_exhausted"] is True
     runner.assert_not_awaited()
 
 
@@ -5814,7 +5882,7 @@ async def test_file_tool_service_execute_excel_script_handles_sandbox_exec_excep
 
 
 @pytest.mark.asyncio
-async def test_file_tool_service_execute_excel_script_upload_failure_does_not_consume_retry_budget():
+async def test_file_tool_service_execute_excel_script_upload_failure_stops_retry_without_consuming_budget():
     class _UploadFailureSandboxBooter(_FakeSandboxBooter):
         async def upload_file(self, path: str, file_name: str) -> dict[str, object]:
             _ = path
@@ -5867,11 +5935,11 @@ async def test_file_tool_service_execute_excel_script_upload_failure_does_not_co
     assert first["success"] is False
     assert first["error"] == "Excel 输入文件上传失败"
     assert first["retry_count"] == 0
-    assert first["retry_exhausted"] is False
+    assert first["retry_exhausted"] is True
     assert second["success"] is False
     assert second["error"] == "Excel 输入文件上传失败"
     assert second["retry_count"] == 0
-    assert second["retry_exhausted"] is False
+    assert second["retry_exhausted"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1371,6 +1371,50 @@ async def test_request_hook_service_hides_execute_excel_script_for_none_runtime(
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_keeps_execute_excel_script_when_runtime_lookup_fails():
+    class _BrokenConfigContext:
+        @staticmethod
+        def get_config(*_args, **_kwargs):
+            raise RuntimeError("config backend unavailable")
+
+    request = ProviderRequest(
+        prompt="请生成一个带公式的 Excel 报表",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_workbook"),
+                _tool("execute_excel_script"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+    service = RequestHookService(
+        astrbot_context=_BrokenConfigContext(),
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=_build_event(),
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+    )
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_workbook" in tool_names
+    assert "execute_excel_script" in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_skips_explicit_restriction_for_unavailable_workbook_tool():
     request = ProviderRequest(
         prompt="请调用 create_workbook",
@@ -5652,6 +5696,55 @@ async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
     payload = json.loads(result)
     assert payload["success"] is False
     assert "computer runtime 为 none" in payload["error"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is False
+    runner.assert_not_awaited()
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_returns_structured_error_when_runtime_lookup_fails():
+    class _BrokenConfigContext:
+        @staticmethod
+        def get_config(*_args, **_kwargs):
+            raise RuntimeError("config backend unavailable")
+
+    workspace_dir = _make_workspace("execute-excel-script-runtime-lookup-failure")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=_BrokenConfigContext(),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert payload["error"] == "错误：读取当前会话 computer runtime 失败"
+    assert "config backend unavailable" in payload["traceback"]
     assert payload["retry_count"] == 0
     assert payload["retry_exhausted"] is False
     runner.assert_not_awaited()

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -2870,6 +2870,48 @@ async def test_request_hook_service_prefers_excel_read_notice_for_update_record_
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_prefers_excel_script_notice_for_update_data_query():
+    service = RequestHookService(
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [
+            {
+                "original_name": "report.xlsx",
+                "file_suffix": ".xlsx",
+                "stored_name": "report.xlsx",
+                "source_path": "",
+                "is_supported": True,
+            }
+        ],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+
+    context = await service.append_document_tool_guide_notice(
+        NoticeBuildContext(
+            event=_build_event(),
+            request=ProviderRequest(
+                prompt="请更新 report.xlsx 中的数据并保存",
+                system_prompt="base",
+                func_tool=ToolSet([_tool("read_workbook"), _tool("execute_excel_script")]),
+            ),
+            should_expose=True,
+            can_process_upload=True,
+            explicit_tool_name=None,
+            notices=[],
+        )
+    )
+
+    assert context.section_names == [
+        SECTION_STATIC_EXCEL_ROUTING,
+        SECTION_STATIC_EXCEL_SCRIPT,
+    ]
+    assert SECTION_STATIC_EXCEL_READ not in context.section_names
+    assert "execute_excel_script" in context.notices[1]
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_skips_workbook_guide_for_xlsx_to_pdf_conversion_requests():
     service = RequestHookService(
         auto_block_execution_tools=True,
@@ -3069,6 +3111,20 @@ def test_excel_intent_router_prefers_read_for_update_record_query():
     assert decision is not None
     assert decision.route == "read_existing"
     assert decision.requires_script is False
+    assert decision.should_inject_guide is True
+
+
+def test_excel_intent_router_treats_update_data_prompt_as_modify_existing():
+    decision = ExcelIntentRouter.decide(
+        request_text="请更新 report.xlsx 中的数据并保存",
+        upload_infos=[],
+        explicit_tool_name=None,
+        exposed_tool_names={"read_workbook", "execute_excel_script"},
+    )
+
+    assert decision is not None
+    assert decision.route == "modify_existing"
+    assert decision.requires_script is True
     assert decision.should_inject_guide is True
 
 

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -72,6 +72,7 @@ from astrbot_plugin_office_assistant.services.prompt_context_service import (
 )
 from astrbot_plugin_office_assistant.services.runtime_config import (
     get_session_config,
+    resolve_computer_runtime_mode,
 )
 from astrbot_plugin_office_assistant.services.excel_script_service import (
     ExcelScriptService,
@@ -408,6 +409,28 @@ def test_get_session_config_reraises_internal_typeerror_when_signature_unavailab
         get_session_config(_get_config, "session-1")
 
     assert calls == ["session-1"]
+
+
+@pytest.mark.parametrize(
+    ("runtime", "expected"),
+    [
+        (False, "false"),
+        (None, "null"),
+        ("", "<empty>"),
+    ],
+)
+def test_resolve_computer_runtime_mode_marks_non_string_or_empty_values_invalid(
+    runtime,
+    expected,
+):
+    event = _build_event()
+
+    context = MagicMock()
+    context.get_config.side_effect = lambda *args, **kwargs: {
+        "provider_settings": {"computer_use_runtime": runtime}
+    }
+
+    assert resolve_computer_runtime_mode(context, event) == expected
 
 
 def test_excel_script_service_join_sandbox_path_uses_windows_path_semantics():
@@ -1656,6 +1679,30 @@ async def test_request_hook_service_hides_execute_excel_script_for_unsupported_r
     )
     service = _build_request_hook_service(
         astrbot_context=_build_astrbot_context(runtime="sandbx"),
+    )
+    context = _build_tool_exposure_context(request)
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_workbook" in tool_names
+    assert "execute_excel_script" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_hides_execute_excel_script_for_false_runtime_value():
+    request = _build_provider_request(
+        "请生成一个带公式的 Excel 报表",
+        tool_names=[
+            "read_workbook",
+            "execute_excel_script",
+            "astrbot_execute_shell",
+        ],
+    )
+    service = _build_request_hook_service(
+        astrbot_context=_build_astrbot_context(runtime=False),
     )
     context = _build_tool_exposure_context(request)
 
@@ -5699,6 +5746,37 @@ async def test_file_tool_service_execute_excel_script_rejects_unsupported_runtim
     payload = json.loads(result)
     assert payload["success"] is False
     assert "不支持的 computer runtime 配置：sandbx" in payload["error"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is True
+    runner.assert_not_awaited()
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_false_runtime_value():
+    event = _build_event()
+
+    with _managed_file_tool_service(
+        workspace_name="execute-excel-script-false-runtime",
+        office_libs={"openpyxl": object()},
+        astrbot_context=_build_astrbot_context(runtime=False),
+    ) as managed:
+        service = managed.service
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "不支持的 computer runtime 配置：false" in payload["error"]
     assert payload["retry_count"] == 0
     assert payload["retry_exhausted"] is True
     runner.assert_not_awaited()

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -70,6 +70,9 @@ from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_STATIC_WORKBOOK_TOOLS_DETAIL,
     PromptContextService,
 )
+from astrbot_plugin_office_assistant.services.runtime_config import (
+    get_session_config,
+)
 from astrbot_plugin_office_assistant.utils import (
     ExtractedWordContent,
     ExtractedWordItem,
@@ -154,6 +157,32 @@ def _build_astrbot_context(*, runtime: str = "sandbox"):
         "provider_settings": {"computer_use_runtime": runtime}
     }
     return context
+
+
+def test_get_session_config_prefers_positional_before_umo_keyword():
+    calls: list[tuple[str, str | None]] = []
+
+    def _get_config(config, *, umo=None):
+        calls.append((config, umo))
+        return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    result = get_session_config(_get_config, "session-1")
+
+    assert result == {"provider_settings": {"computer_use_runtime": "sandbox"}}
+    assert calls == [("session-1", None)]
+
+
+def test_get_session_config_accepts_positional_with_var_keyword():
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def _get_config(session_id, **kwargs):
+        calls.append((session_id, kwargs))
+        return {"provider_settings": {"computer_use_runtime": "sandbox"}}
+
+    result = get_session_config(_get_config, "session-1")
+
+    assert result == {"provider_settings": {"computer_use_runtime": "sandbox"}}
+    assert calls == [("session-1", {})]
 
 
 class _FakeSandboxPython:

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1371,6 +1371,47 @@ async def test_request_hook_service_hides_execute_excel_script_for_none_runtime(
 
 
 @pytest.mark.asyncio
+async def test_request_hook_service_hides_execute_excel_script_for_legacy_none_runtime():
+    request = ProviderRequest(
+        prompt="请生成一个带公式的 Excel 报表",
+        system_prompt="base",
+        func_tool=ToolSet(
+            [
+                _tool("read_workbook"),
+                _tool("execute_excel_script"),
+                _tool("astrbot_execute_shell"),
+            ]
+        ),
+    )
+    service = RequestHookService(
+        astrbot_context=SimpleNamespace(
+            astrbot_config={"provider_settings": {"computer_use_runtime": "none"}}
+        ),
+        auto_block_execution_tools=True,
+        get_cached_upload_infos=lambda _event: [],
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+        consume_session_notice_once=_build_notice_once_callback(),
+        allow_external_input_files=False,
+    )
+    context = SimpleNamespace(
+        event=_build_event(),
+        request=request,
+        should_expose=True,
+        can_process_upload=True,
+        explicit_tool_name=None,
+    )
+
+    for hook in service.build_tool_exposure_hooks():
+        context = await hook(context)
+
+    tool_names = set(request.func_tool.names())
+    assert "read_workbook" in tool_names
+    assert "execute_excel_script" not in tool_names
+    assert "astrbot_execute_shell" not in tool_names
+
+
+@pytest.mark.asyncio
 async def test_request_hook_service_keeps_execute_excel_script_when_runtime_lookup_fails():
     class _BrokenConfigContext:
         @staticmethod
@@ -5703,6 +5744,51 @@ async def test_file_tool_service_execute_excel_script_rejects_none_runtime():
 
 
 @pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_rejects_legacy_none_runtime():
+    workspace_dir = _make_workspace("execute-excel-script-legacy-none-runtime")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=SimpleNamespace(
+                astrbot_config={"provider_settings": {"computer_use_runtime": "none"}}
+            ),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        runner = AsyncMock()
+        service._excel_script_service._run_script_process = runner
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is False
+    assert "computer runtime 为 none" in payload["error"]
+    assert payload["retry_count"] == 0
+    assert payload["retry_exhausted"] is False
+    runner.assert_not_awaited()
+    mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_file_tool_service_execute_excel_script_returns_structured_error_when_runtime_lookup_fails():
     class _BrokenConfigContext:
         @staticmethod
@@ -5749,6 +5835,55 @@ async def test_file_tool_service_execute_excel_script_returns_structured_error_w
     assert payload["retry_exhausted"] is False
     runner.assert_not_awaited()
     mocked_get_booter.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_file_tool_service_execute_excel_script_accepts_legacy_sandbox_runtime():
+    workspace_dir = _make_workspace("execute-excel-script-legacy-sandbox-runtime")
+    executor = ThreadPoolExecutor(max_workers=1)
+    event = _build_event()
+
+    try:
+        workspace_service = WorkspaceService(
+            plugin_data_path=workspace_dir,
+            executor=executor,
+            office_libs={"openpyxl": object()},
+            max_file_size=1024 * 1024,
+            feature_settings={},
+        )
+        service = _build_file_tool_service(
+            astrbot_context=SimpleNamespace(
+                astrbot_config={"provider_settings": {"computer_use_runtime": "sandbox"}}
+            ),
+            workspace_service=workspace_service,
+            office_libs={"openpyxl": object()},
+        )
+        service._excel_script_service._run_script_process = AsyncMock(
+            return_value=SimpleNamespace(
+                success=True,
+                mode="text",
+                result_text="ok",
+                output_path=None,
+            )
+        )
+
+        with patch(
+            "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",
+            new=AsyncMock(return_value=MagicMock(capabilities=("python", "filesystem"))),
+        ) as mocked_get_booter:
+            result = await service.execute_excel_script(
+                event,
+                script="result_text = 'ok'",
+            )
+    finally:
+        executor.shutdown(wait=False)
+        shutil.rmtree(workspace_dir, ignore_errors=True)
+
+    payload = json.loads(result)
+    assert payload["success"] is True
+    assert payload["mode"] == "text"
+    assert payload["result_text"] == "ok"
+    mocked_get_booter.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -5838,7 +5973,7 @@ async def test_file_tool_service_execute_excel_script_accepts_noarg_session_conf
         )
 
         with patch(
-            "astrbot_plugin_office_assistant.services.excel_script_service.inspect.signature",
+            "astrbot_plugin_office_assistant.services.runtime_config.inspect.signature",
             side_effect=ValueError("signature unavailable"),
         ), patch(
             "astrbot_plugin_office_assistant.services.excel_script_service._get_computer_booter",

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -6,7 +6,7 @@ import shutil
 import traceback
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -72,6 +72,9 @@ from astrbot_plugin_office_assistant.services.prompt_context_service import (
 )
 from astrbot_plugin_office_assistant.services.runtime_config import (
     get_session_config,
+)
+from astrbot_plugin_office_assistant.services.excel_script_service import (
+    ExcelScriptService,
 )
 from astrbot_plugin_office_assistant.utils import (
     ExtractedWordContent,
@@ -183,6 +186,28 @@ def test_get_session_config_accepts_positional_with_var_keyword():
 
     assert result == {"provider_settings": {"computer_use_runtime": "sandbox"}}
     assert calls == [("session-1", {})]
+
+
+def test_excel_script_service_join_sandbox_path_uses_windows_path_semantics():
+    joined = ExcelScriptService._join_sandbox_path(
+        "C:\\sandbox",
+        PurePosixPath(".office_assistant/excel_scripts/run/result.json"),
+    )
+
+    assert joined == "C:\\sandbox\\.office_assistant\\excel_scripts\\run\\result.json"
+
+
+def test_excel_script_service_build_prepare_script_uses_file_parent_in_sandbox():
+    script = ExcelScriptService._build_prepare_script(
+        [
+            "C:\\sandbox\\.office_assistant\\excel_scripts\\run\\result.json",
+            "/workspace/.office_assistant/excel_scripts/run/input.xlsx",
+        ]
+    )
+
+    assert "Path(raw_path).parent.mkdir(parents=True, exist_ok=True)" in script
+    assert "result.json" in script
+    assert "/workspace/.office_assistant/excel_scripts/run/input.xlsx" in script
 
 
 class _FakeSandboxPython:


### PR DESCRIPTION
## 概述

把 `execute_excel_script` 调整为按 AstrBot 的 `computer_use_runtime` 运行：

- `sandbox`：继续走 AstrBot computer sandbox
- `local`：走宿主机本地子进程执行
- `none`：不提供脚本执行能力

同时补齐 Excel 路由上的几个误判，避免把读取类请求误导到脚本修改路径。

## 改动类型

- [x] Bug 修复
- [x] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [x] 安全相关

## 关键改动

- `execute_excel_script` 不再固定要求 `sandbox`，而是按当前会话的 `computer_use_runtime` 选择执行方式
- `sandbox` 模式下继续使用 AstrBot computer sandbox，并保留对 `python` / `filesystem` 能力的校验
- `local` 模式下恢复本地子进程执行，沿用现有脚本返回契约、输入文件副本、结果解析和文件回传逻辑
- `none` 模式下不再暴露 `execute_excel_script`，显式调用时也会返回明确的非重试错误
- 将 AstrBot `context` 注入到 Excel 脚本服务和请求提示链路，用于按会话读取 runtime 并控制工具暴露
- 修正 Excel 意图路由：
  - 混合“读取 + 明确修改”请求仍然进入 `modify_existing`
  - 像“读取 report.xlsx 更新记录并总结”这类读取请求回到 `read_existing`
  - 仅输出文件名的 `.xlsx` 不会再被误判为已有输入文件

## 影响范围

- `execute_excel_script` 的运行方式与可用性
- 复杂 Excel 新建场景
- 已有 Excel 修改场景
- Excel 相关提示词注入与工具暴露逻辑
- AstrBot `computer_use_runtime` 对插件行为的影响

## 测试情况

- [x] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了核心场景

<details>
<summary>测试记录</summary>

```bash
$env:PYTHONPATH='D:\aobo\open_source\AstrBot'; pytest -q tests/test_office_assistant_services.py tests/test_office_assistant_before_llm_chat.py
- 238 passed
- 7 warnings（均为已有 create_office_file 弃用提示）
```
</details>

### 破坏性变更

> [!WARNING]

以下行为与之前不同：

- execute_excel_script 现在跟随 AstrBot 的 computer_use_runtime
- 当 runtime 为 none 时，模型侧不会再拿到 execute_excel_script
- 当 runtime 为 sandbox 时，仍然要求当前 sandbox profile 具备 python 与 filesystem 能力
- 部署侧如果依赖某一种固定执行方式，需要显式配置对应 runtime

### 备注

- 这个 PR 的目标是让插件行为与 AstrBot runtime 语义保持一致，而不是把所有环境统一改成 sandbox-only
- 如果部署方希望复杂 Excel 脚本始终在隔离环境执行，应将 runtime 设为 sandbox
- 如果部署方希望完全关闭复杂 Excel 脚本能力，应将 runtime 设为 none

## Summary by Sourcery

通过 AstrBot 的沙盒运行时来执行 Excel 脚本，而不是使用本地主机进程，从而收紧执行边界，并使行为与 AstrBot 的电脑使用设置保持一致，同时保留现有的工具契约。

New Features:
- 让 `execute_excel_script` 能够从 AstrBot 会话配置中获取其运行时，并在已配置的情况下在电脑沙盒中运行脚本。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示中保持一致。

Bug Fixes:
- 调整 Excel 意图路由，使混合读取/修改请求以及仅导出场景中的文件名提及能够被正确分类，而不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，改为依赖已解析的目标，而不是过早对目标为 `None` 进行检查，从而确保底层路径解析错误能够正确向上抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理和 Excel 脚本服务中，以在执行脚本前解析运行模式并验证沙盒能力。
- 优化 Excel 脚本结果处理逻辑，以验证文件模式输出路径，区分可重试与不可重试的失败，并避免在验证或传输错误上消耗重试预算。

Tests:
- 扩展 office assistant 的测试，用假的沙盒引导程序/上下文来覆盖沙盒化 Excel 脚本执行、能力验证、重试语义以及改进后的 Excel 意图路由行为。
- 更新 `execute_excel_script` 测试，使其通过沙盒抽象层运行，包括上传/下载失败、结果负载格式错误以及沙盒初始化错误等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route Excel script execution through AstrBot’s sandbox runtime instead of the local host process, tightening execution boundaries and aligning behavior with AstrBot’s computer use settings while preserving existing tool contracts.

New Features:
- Enable execute_excel_script to derive its runtime from AstrBot session configuration and run scripts inside the computer sandbox when configured.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.

Bug Fixes:
- Adjust Excel intent routing so mixed read/modify requests and export-only filename mentions are classified correctly without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets instead of early target-None checks, ensuring underlying path resolution errors surface properly.

Enhancements:
- Inject AstrBot context into file processing and Excel script services to resolve runtime mode and validate sandbox capabilities before executing scripts.
- Refine Excel script result handling to validate file-mode output paths, distinguish retryable from non-retryable failures, and avoid consuming retry budget on validation or transfer errors.

Tests:
- Extend office assistant tests with a fake sandbox booter/context to cover sandboxed Excel script execution, capability validation, retry semantics, and improved Excel intent routing behavior.
- Update execute_excel_script tests to operate through the sandbox abstraction, including upload/download failures, malformed result payloads, and sandbox initialization errors.

</details>

新增功能：
- 允许 `execute_excel_script` 使用会话配置的 `computer_use_runtime`，通过 AstrBot 的计算机沙箱运行时执行。
- 通过共享常量 `EXCEL_SUFFIXES` 统一各服务和提示中的 Excel 文件后缀处理。

Bug 修复：
- 改进 Excel 意图路由，使混合读取/修改请求和仅输出文件名的请求被分类到合适的路由中，并避免将输出文件名误解为已存在的文件。
- 修复工作簿读取行为，避免过早的空目标处理，从而不再掩盖底层路径解析错误。

增强改进：
- 将 AstrBot 上下文注入到文件处理服务中，以在执行 Excel 脚本之前推导运行时模式并验证沙箱能力。
- 优化 Excel 脚本结果处理，以验证文件模式输出，并区分可重试和不可重试的失败，避免在验证或传输错误上消耗重试配额。

测试：
- 扩展 office assistant 测试，加入假的沙箱启动器和上下文助手，以覆盖沙箱环境下的 Excel 脚本执行、沙箱能力验证、重试语义以及改进后的 Excel 意图路由行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过 AstrBot 的沙盒运行时来执行 Excel 脚本，而不是使用本地主机进程，从而收紧执行边界，并使行为与 AstrBot 的电脑使用设置保持一致，同时保留现有的工具契约。

New Features:
- 让 `execute_excel_script` 能够从 AstrBot 会话配置中获取其运行时，并在已配置的情况下在电脑沙盒中运行脚本。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示中保持一致。

Bug Fixes:
- 调整 Excel 意图路由，使混合读取/修改请求以及仅导出场景中的文件名提及能够被正确分类，而不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，改为依赖已解析的目标，而不是过早对目标为 `None` 进行检查，从而确保底层路径解析错误能够正确向上抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理和 Excel 脚本服务中，以在执行脚本前解析运行模式并验证沙盒能力。
- 优化 Excel 脚本结果处理逻辑，以验证文件模式输出路径，区分可重试与不可重试的失败，并避免在验证或传输错误上消耗重试预算。

Tests:
- 扩展 office assistant 的测试，用假的沙盒引导程序/上下文来覆盖沙盒化 Excel 脚本执行、能力验证、重试语义以及改进后的 Excel 意图路由行为。
- 更新 `execute_excel_script` 测试，使其通过沙盒抽象层运行，包括上传/下载失败、结果负载格式错误以及沙盒初始化错误等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route Excel script execution through AstrBot’s sandbox runtime instead of the local host process, tightening execution boundaries and aligning behavior with AstrBot’s computer use settings while preserving existing tool contracts.

New Features:
- Enable execute_excel_script to derive its runtime from AstrBot session configuration and run scripts inside the computer sandbox when configured.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.

Bug Fixes:
- Adjust Excel intent routing so mixed read/modify requests and export-only filename mentions are classified correctly without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets instead of early target-None checks, ensuring underlying path resolution errors surface properly.

Enhancements:
- Inject AstrBot context into file processing and Excel script services to resolve runtime mode and validate sandbox capabilities before executing scripts.
- Refine Excel script result handling to validate file-mode output paths, distinguish retryable from non-retryable failures, and avoid consuming retry budget on validation or transfer errors.

Tests:
- Extend office assistant tests with a fake sandbox booter/context to cover sandboxed Excel script execution, capability validation, retry semantics, and improved Excel intent routing behavior.
- Update execute_excel_script tests to operate through the sandbox abstraction, including upload/download failures, malformed result payloads, and sandbox initialization errors.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过 AstrBot 的沙盒运行时来执行 Excel 脚本，而不是使用本地主机进程，从而收紧执行边界，并使行为与 AstrBot 的电脑使用设置保持一致，同时保留现有的工具契约。

New Features:
- 让 `execute_excel_script` 能够从 AstrBot 会话配置中获取其运行时，并在已配置的情况下在电脑沙盒中运行脚本。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示中保持一致。

Bug Fixes:
- 调整 Excel 意图路由，使混合读取/修改请求以及仅导出场景中的文件名提及能够被正确分类，而不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，改为依赖已解析的目标，而不是过早对目标为 `None` 进行检查，从而确保底层路径解析错误能够正确向上抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理和 Excel 脚本服务中，以在执行脚本前解析运行模式并验证沙盒能力。
- 优化 Excel 脚本结果处理逻辑，以验证文件模式输出路径，区分可重试与不可重试的失败，并避免在验证或传输错误上消耗重试预算。

Tests:
- 扩展 office assistant 的测试，用假的沙盒引导程序/上下文来覆盖沙盒化 Excel 脚本执行、能力验证、重试语义以及改进后的 Excel 意图路由行为。
- 更新 `execute_excel_script` 测试，使其通过沙盒抽象层运行，包括上传/下载失败、结果负载格式错误以及沙盒初始化错误等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route Excel script execution through AstrBot’s sandbox runtime instead of the local host process, tightening execution boundaries and aligning behavior with AstrBot’s computer use settings while preserving existing tool contracts.

New Features:
- Enable execute_excel_script to derive its runtime from AstrBot session configuration and run scripts inside the computer sandbox when configured.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.

Bug Fixes:
- Adjust Excel intent routing so mixed read/modify requests and export-only filename mentions are classified correctly without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets instead of early target-None checks, ensuring underlying path resolution errors surface properly.

Enhancements:
- Inject AstrBot context into file processing and Excel script services to resolve runtime mode and validate sandbox capabilities before executing scripts.
- Refine Excel script result handling to validate file-mode output paths, distinguish retryable from non-retryable failures, and avoid consuming retry budget on validation or transfer errors.

Tests:
- Extend office assistant tests with a fake sandbox booter/context to cover sandboxed Excel script execution, capability validation, retry semantics, and improved Excel intent routing behavior.
- Update execute_excel_script tests to operate through the sandbox abstraction, including upload/download failures, malformed result payloads, and sandbox initialization errors.

</details>

新增功能：
- 允许 `execute_excel_script` 使用会话配置的 `computer_use_runtime`，通过 AstrBot 的计算机沙箱运行时执行。
- 通过共享常量 `EXCEL_SUFFIXES` 统一各服务和提示中的 Excel 文件后缀处理。

Bug 修复：
- 改进 Excel 意图路由，使混合读取/修改请求和仅输出文件名的请求被分类到合适的路由中，并避免将输出文件名误解为已存在的文件。
- 修复工作簿读取行为，避免过早的空目标处理，从而不再掩盖底层路径解析错误。

增强改进：
- 将 AstrBot 上下文注入到文件处理服务中，以在执行 Excel 脚本之前推导运行时模式并验证沙箱能力。
- 优化 Excel 脚本结果处理，以验证文件模式输出，并区分可重试和不可重试的失败，避免在验证或传输错误上消耗重试配额。

测试：
- 扩展 office assistant 测试，加入假的沙箱启动器和上下文助手，以覆盖沙箱环境下的 Excel 脚本执行、沙箱能力验证、重试语义以及改进后的 Excel 意图路由行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过 AstrBot 的沙盒运行时来执行 Excel 脚本，而不是使用本地主机进程，从而收紧执行边界，并使行为与 AstrBot 的电脑使用设置保持一致，同时保留现有的工具契约。

New Features:
- 让 `execute_excel_script` 能够从 AstrBot 会话配置中获取其运行时，并在已配置的情况下在电脑沙盒中运行脚本。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示中保持一致。

Bug Fixes:
- 调整 Excel 意图路由，使混合读取/修改请求以及仅导出场景中的文件名提及能够被正确分类，而不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，改为依赖已解析的目标，而不是过早对目标为 `None` 进行检查，从而确保底层路径解析错误能够正确向上抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理和 Excel 脚本服务中，以在执行脚本前解析运行模式并验证沙盒能力。
- 优化 Excel 脚本结果处理逻辑，以验证文件模式输出路径，区分可重试与不可重试的失败，并避免在验证或传输错误上消耗重试预算。

Tests:
- 扩展 office assistant 的测试，用假的沙盒引导程序/上下文来覆盖沙盒化 Excel 脚本执行、能力验证、重试语义以及改进后的 Excel 意图路由行为。
- 更新 `execute_excel_script` 测试，使其通过沙盒抽象层运行，包括上传/下载失败、结果负载格式错误以及沙盒初始化错误等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Route Excel script execution through AstrBot’s sandbox runtime instead of the local host process, tightening execution boundaries and aligning behavior with AstrBot’s computer use settings while preserving existing tool contracts.

New Features:
- Enable execute_excel_script to derive its runtime from AstrBot session configuration and run scripts inside the computer sandbox when configured.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.

Bug Fixes:
- Adjust Excel intent routing so mixed read/modify requests and export-only filename mentions are classified correctly without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets instead of early target-None checks, ensuring underlying path resolution errors surface properly.

Enhancements:
- Inject AstrBot context into file processing and Excel script services to resolve runtime mode and validate sandbox capabilities before executing scripts.
- Refine Excel script result handling to validate file-mode output paths, distinguish retryable from non-retryable failures, and avoid consuming retry budget on validation or transfer errors.

Tests:
- Extend office assistant tests with a fake sandbox booter/context to cover sandboxed Excel script execution, capability validation, retry semantics, and improved Excel intent routing behavior.
- Update execute_excel_script tests to operate through the sandbox abstraction, including upload/download failures, malformed result payloads, and sandbox initialization errors.

</details>

</details>

</details>

## Summary by Sourcery

使 Excel 脚本的执行与暴露方式与 AstrBot 的计算机运行时模式对齐，并优化与 Excel 相关的路由和错误处理。

New Features:
- 从 AstrBot 会话配置中推导 Excel 脚本执行运行时（local、sandbox、none），并据此路由 `execute_excel_script`。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示词中保持一致。
- 在 pre-LLM 阶段和请求钩子阶段，新增基于运行时和上下文的控制逻辑，用于决定是否向模型暴露 `execute_excel_script`。

Bug Fixes:
- 修正 Excel 意图路由，使混合读取/修改的提示词、记录更新类查询以及仅导出文件名提及的场景，能被正确归类为读取或修改路由，并且不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，使其依赖于已解析的目标，而不是过早进行 `None` 检查，从而使底层路径解析错误能够被正确抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理、Excel 脚本服务以及请求钩子中，用于解析运行时模式、校验沙箱能力，并集中处理运行时配置。
- 优化 Excel 脚本执行逻辑，以同时支持本地子进程和沙箱执行，并提供结构化错误报告、超时处理、文件模式输出路径校验，以及对可重试和不可重试失败的清晰区分。
- 通过辅助引导器统一 Excel 脚本的沙箱交互，包括一致的临时工作空间布局，以及对输入/输出文件健壮的上传/下载处理。
- 在各服务和提示词之间共享 Excel 后缀逻辑，以确保对 Excel 文件的路由和工具使用指引保持一致。

Tests:
- 扩展 office assistant 和 before-LLM 测试，以覆盖基于运行时的 `execute_excel_script` 暴露行为以及更新后的 Excel 意图路由行为。
- 为沙箱和本地模式下的 Excel 脚本执行新增大量测试，涵盖校验失败、权限和功能门控、运行时查找失败、沙箱能力检查、上传/下载错误、异常结果负载以及重试语义等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Excel script execution and exposure with AstrBot computer runtime modes and refine Excel-related routing and error handling.

New Features:
- Derive the Excel script execution runtime (local, sandbox, none) from AstrBot session configuration and route execute_excel_script accordingly.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.
- Add runtime- and context-aware control over whether execute_excel_script is exposed to the model in pre-LLM and request hook stages.

Bug Fixes:
- Correct Excel intent routing so mixed read/modify prompts, record-update style queries, and export-only filename mentions are classified into appropriate read or modify routes without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets rather than early None checks, allowing underlying path resolution errors to surface properly.

Enhancements:
- Inject AstrBot context into file processing, Excel script services, and request hooks to resolve runtime mode, validate sandbox capabilities, and centralize runtime configuration handling.
- Refine Excel script execution to support both local subprocess and sandboxed execution, with structured error reporting, timeout handling, validation of file-mode output paths, and clear separation of retryable vs non-retryable failures.
- Unify sandbox interaction for Excel scripts via helper booters, consistent temp workspace layout, and robust upload/download handling for input and output files.
- Share Excel suffix logic across services and prompts to keep routing and tool guidance consistent for Excel files.

Tests:
- Extend office assistant and before-LLM tests to cover runtime-based exposure of execute_excel_script and updated Excel intent routing behavior.
- Add extensive Excel script execution tests for sandbox and local modes, covering validation failures, permission and feature gating, runtime lookup failures, sandbox capability checks, upload/download errors, malformed result payloads, and retry semantics.

</details>

新功能：
- 根据 AstrBot 会话配置推导 Excel 脚本执行运行时（本地、沙箱、无），并相应路由脚本，包括在启用时通过 AstrBot 电脑沙箱进行沙箱化执行。
- 在各服务和提示词中共享统一的 `EXCEL_SUFFIXES` 常量，以保持 Excel 文件后缀处理的一致性。

缺陷修复：
- 调整 Excel 意图路由，使混合读/写查询、仅导出文件名提及以及更新记录类提示能够被正确分类为读取或修改路由，同时避免将输出文件名误解为已存在文件。
- 修复工作簿读取逻辑，使其依赖已解析的目标而不是提前对 `None` 进行检查，从而让底层路径解析错误能够被正确暴露。

改进：
- 将 AstrBot 上下文注入到文件处理、Excel 脚本服务和请求钩子中，用于解析运行模式、验证沙箱能力，并控制 `execute_excel_script` 工具的暴露。
- 优化本地和沙箱模式下的 Excel 脚本结果处理，对文件模式输出路径进行校验，区分可重试和不可重试的失败，并标准化结构化错误响应。

测试：
- 大幅扩展 office assistant 测试范围，以覆盖沙箱化 Excel 脚本执行路径、运行时解析、能力验证、重试语义、上传/下载失败、结果解析边界情况，以及更新后的 Excel 路由与工具暴露行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 Excel 脚本的执行与暴露方式与 AstrBot 的计算机运行时模式对齐，并优化与 Excel 相关的路由和错误处理。

New Features:
- 从 AstrBot 会话配置中推导 Excel 脚本执行运行时（local、sandbox、none），并据此路由 `execute_excel_script`。
- 引入共享的 `EXCEL_SUFFIXES` 常量，使 Excel 文件后缀的处理在各个服务和提示词中保持一致。
- 在 pre-LLM 阶段和请求钩子阶段，新增基于运行时和上下文的控制逻辑，用于决定是否向模型暴露 `execute_excel_script`。

Bug Fixes:
- 修正 Excel 意图路由，使混合读取/修改的提示词、记录更新类查询以及仅导出文件名提及的场景，能被正确归类为读取或修改路由，并且不会将输出文件名误认为是已存在的文件。
- 修复工作簿读取行为，使其依赖于已解析的目标，而不是过早进行 `None` 检查，从而使底层路径解析错误能够被正确抛出。

Enhancements:
- 将 AstrBot 上下文注入到文件处理、Excel 脚本服务以及请求钩子中，用于解析运行时模式、校验沙箱能力，并集中处理运行时配置。
- 优化 Excel 脚本执行逻辑，以同时支持本地子进程和沙箱执行，并提供结构化错误报告、超时处理、文件模式输出路径校验，以及对可重试和不可重试失败的清晰区分。
- 通过辅助引导器统一 Excel 脚本的沙箱交互，包括一致的临时工作空间布局，以及对输入/输出文件健壮的上传/下载处理。
- 在各服务和提示词之间共享 Excel 后缀逻辑，以确保对 Excel 文件的路由和工具使用指引保持一致。

Tests:
- 扩展 office assistant 和 before-LLM 测试，以覆盖基于运行时的 `execute_excel_script` 暴露行为以及更新后的 Excel 意图路由行为。
- 为沙箱和本地模式下的 Excel 脚本执行新增大量测试，涵盖校验失败、权限和功能门控、运行时查找失败、沙箱能力检查、上传/下载错误、异常结果负载以及重试语义等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Excel script execution and exposure with AstrBot computer runtime modes and refine Excel-related routing and error handling.

New Features:
- Derive the Excel script execution runtime (local, sandbox, none) from AstrBot session configuration and route execute_excel_script accordingly.
- Introduce shared EXCEL_SUFFIXES constants so Excel file suffix handling is consistent across services and prompts.
- Add runtime- and context-aware control over whether execute_excel_script is exposed to the model in pre-LLM and request hook stages.

Bug Fixes:
- Correct Excel intent routing so mixed read/modify prompts, record-update style queries, and export-only filename mentions are classified into appropriate read or modify routes without treating output filenames as existing files.
- Fix workbook read behavior to rely on resolved targets rather than early None checks, allowing underlying path resolution errors to surface properly.

Enhancements:
- Inject AstrBot context into file processing, Excel script services, and request hooks to resolve runtime mode, validate sandbox capabilities, and centralize runtime configuration handling.
- Refine Excel script execution to support both local subprocess and sandboxed execution, with structured error reporting, timeout handling, validation of file-mode output paths, and clear separation of retryable vs non-retryable failures.
- Unify sandbox interaction for Excel scripts via helper booters, consistent temp workspace layout, and robust upload/download handling for input and output files.
- Share Excel suffix logic across services and prompts to keep routing and tool guidance consistent for Excel files.

Tests:
- Extend office assistant and before-LLM tests to cover runtime-based exposure of execute_excel_script and updated Excel intent routing behavior.
- Add extensive Excel script execution tests for sandbox and local modes, covering validation failures, permission and feature gating, runtime lookup failures, sandbox capability checks, upload/download errors, malformed result payloads, and retry semantics.

</details>

</details>