### PR TITLE
fix: simplify add_blocks public schema

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -197,21 +197,9 @@ _TABLE_CELL_SCHEMA = {
     },
 }
 
-_LIST_ITEM_PUBLIC_SCHEMA = {
-    "type": ["string", "object"],
-    "properties": {
-        "text": {"type": "string"},
-        "runs": {
-            "type": "array",
-            "items": _schema_copy(_INLINE_RUN_SCHEMA),
-        },
-    },
-}
+_LIST_ITEM_PUBLIC_SCHEMA = {"type": "string"}
 
-_TABLE_CELL_PUBLIC_SCHEMA = {
-    **_schema_copy(_TABLE_CELL_SCHEMA),
-    "type": ["string", "object"],
-}
+_TABLE_CELL_PUBLIC_SCHEMA = {"type": "string"}
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -472,14 +460,14 @@ class AddBlocksTool(DocumentToolBase):
         "Append one or more blocks in order. Use this for mixed content such as "
         "page_template, hero_banner, heading, paragraph, accent_box, metric_cards, list, table, image, summary_card, page_break, section_break, toc, group, or columns. "
         "For heading blocks, use text instead of title. "
-        "For paragraph, list, or table-cell runs, use color instead of text_color. "
+        "For paragraph runs, use color instead of text_color. "
         "For table blocks, if the user asks for a table title or 表格标题, put it in the table "
         "block's caption/title field so it renders as the first merged row inside the table, "
         "not as a separate heading block. For table styling, use table-specific fields like "
         "header_fill, header_text_color, header_bold, banded_rows, first_column_bold, table_align, "
-        "border_style, caption_emphasis, cell border, and cell fill when the user requests a custom visual style. "
+        "border_style, and caption_emphasis when the user requests a custom visual style. "
         "Do not pass row_span or col_span in public table payloads. "
-        "Table body cell objects must not include type=cell. "
+        "Use plain strings for table body cells. "
         "Use paragraph border via border.top/bottom/left/right. bottom_border, bottom_border_color, "
         "and bottom_border_size_pt are heading-only fields. header_fill_enabled and header_bold are "
         "table block fields, not document_style.table_defaults fields."

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -559,21 +559,7 @@ class AddBlocksTool(DocumentToolBase):
                                                             "subtitle": {"type": "string"},
                                                             "details": {
                                                                 "type": "array",
-                                                                "items": {
-                                                                    "anyOf": [
-                                                                        {"type": "string"},
-                                                                        {
-                                                                            "type": "object",
-                                                                            "properties": {
-                                                                                "text": {"type": "string"},
-                                                                                "runs": {
-                                                                                    "type": "array",
-                                                                                    "items": _schema_copy(_INLINE_RUN_SCHEMA),
-                                                                                },
-                                                                            },
-                                                                        },
-                                                                    ]
-                                                                },
+                                                                "items": {"type": "string"},
                                                             },
                                                         },
                                                         "required": ["heading"],
@@ -581,21 +567,7 @@ class AddBlocksTool(DocumentToolBase):
                                                 },
                                                 "lines": {
                                                     "type": "array",
-                                                    "items": {
-                                                        "anyOf": [
-                                                            {"type": "string"},
-                                                            {
-                                                                "type": "object",
-                                                                "properties": {
-                                                                    "text": {"type": "string"},
-                                                                    "runs": {
-                                                                        "type": "array",
-                                                                        "items": _schema_copy(_INLINE_RUN_SCHEMA),
-                                                                    },
-                                                                },
-                                                            },
-                                                        ]
-                                                    },
+                                                    "items": {"type": "string"},
                                                 },
                                             },
                                         },
@@ -622,21 +594,7 @@ class AddBlocksTool(DocumentToolBase):
                             },
                             "items": {
                                 "type": "array",
-                                "items": {
-                                    "anyOf": [
-                                        {"type": "string"},
-                                        {
-                                            "type": "object",
-                                            "properties": {
-                                                "text": {"type": "string"},
-                                                "runs": {
-                                                    "type": "array",
-                                                    "items": _schema_copy(_INLINE_RUN_SCHEMA),
-                                                },
-                                            },
-                                        },
-                                    ]
-                                },
+                                "items": {"type": "string"},
                             },
                             "ordered": {"type": "boolean"},
                             "headers": {
@@ -647,12 +605,7 @@ class AddBlocksTool(DocumentToolBase):
                                 "type": "array",
                                 "items": {
                                     "type": "array",
-                                    "items": {
-                                        "anyOf": [
-                                            {"type": "string"},
-                                            _schema_copy(_TABLE_CELL_SCHEMA),
-                                        ]
-                                    },
+                                    "items": {"type": "string"},
                                 },
                             },
                             "header_groups": {

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -197,6 +197,22 @@ _TABLE_CELL_SCHEMA = {
     },
 }
 
+_LIST_ITEM_PUBLIC_SCHEMA = {
+    "type": ["string", "object"],
+    "properties": {
+        "text": {"type": "string"},
+        "runs": {
+            "type": "array",
+            "items": _schema_copy(_INLINE_RUN_SCHEMA),
+        },
+    },
+}
+
+_TABLE_CELL_PUBLIC_SCHEMA = {
+    **_schema_copy(_TABLE_CELL_SCHEMA),
+    "type": ["string", "object"],
+}
+
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class DocumentToolBase(FunctionTool[AstrAgentContext]):
@@ -559,7 +575,9 @@ class AddBlocksTool(DocumentToolBase):
                                                             "subtitle": {"type": "string"},
                                                             "details": {
                                                                 "type": "array",
-                                                                "items": {"type": "string"},
+                                                                "items": _schema_copy(
+                                                                    _LIST_ITEM_PUBLIC_SCHEMA
+                                                                ),
                                                             },
                                                         },
                                                         "required": ["heading"],
@@ -567,7 +585,9 @@ class AddBlocksTool(DocumentToolBase):
                                                 },
                                                 "lines": {
                                                     "type": "array",
-                                                    "items": {"type": "string"},
+                                                    "items": _schema_copy(
+                                                        _LIST_ITEM_PUBLIC_SCHEMA
+                                                    ),
                                                 },
                                             },
                                         },
@@ -594,7 +614,7 @@ class AddBlocksTool(DocumentToolBase):
                             },
                             "items": {
                                 "type": "array",
-                                "items": {"type": "string"},
+                                "items": _schema_copy(_LIST_ITEM_PUBLIC_SCHEMA),
                             },
                             "ordered": {"type": "boolean"},
                             "headers": {
@@ -605,7 +625,7 @@ class AddBlocksTool(DocumentToolBase):
                                 "type": "array",
                                 "items": {
                                     "type": "array",
-                                    "items": {"type": "string"},
+                                    "items": _schema_copy(_TABLE_CELL_PUBLIC_SCHEMA),
                                 },
                             },
                             "header_groups": {

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -197,9 +197,7 @@ _TABLE_CELL_SCHEMA = {
     },
 }
 
-_LIST_ITEM_PUBLIC_SCHEMA = {"type": "string"}
-
-_TABLE_CELL_PUBLIC_SCHEMA = {"type": "string"}
+_STRING_PUBLIC_SCHEMA = {"type": "string"}
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -564,7 +562,7 @@ class AddBlocksTool(DocumentToolBase):
                                                             "details": {
                                                                 "type": "array",
                                                                 "items": _schema_copy(
-                                                                    _LIST_ITEM_PUBLIC_SCHEMA
+                                                                    _STRING_PUBLIC_SCHEMA
                                                                 ),
                                                             },
                                                         },
@@ -574,7 +572,7 @@ class AddBlocksTool(DocumentToolBase):
                                                 "lines": {
                                                     "type": "array",
                                                     "items": _schema_copy(
-                                                        _LIST_ITEM_PUBLIC_SCHEMA
+                                                        _STRING_PUBLIC_SCHEMA
                                                     ),
                                                 },
                                             },
@@ -602,7 +600,7 @@ class AddBlocksTool(DocumentToolBase):
                             },
                             "items": {
                                 "type": "array",
-                                "items": _schema_copy(_LIST_ITEM_PUBLIC_SCHEMA),
+                                "items": _schema_copy(_STRING_PUBLIC_SCHEMA),
                             },
                             "ordered": {"type": "boolean"},
                             "headers": {
@@ -613,7 +611,7 @@ class AddBlocksTool(DocumentToolBase):
                                 "type": "array",
                                 "items": {
                                     "type": "array",
-                                    "items": _schema_copy(_TABLE_CELL_PUBLIC_SCHEMA),
+                                    "items": _schema_copy(_STRING_PUBLIC_SCHEMA),
                                 },
                             },
                             "header_groups": {

--- a/tests/_docx_test_helpers.py
+++ b/tests/_docx_test_helpers.py
@@ -72,6 +72,23 @@ def _find_paragraph(doc, text: str):
     return next(paragraph for paragraph in doc.paragraphs if paragraph.text == text)
 
 
+def _schema_contains_key(schema: object, key: str) -> bool:
+    if isinstance(schema, dict):
+        return key in schema or any(
+            _schema_contains_key(value, key) for value in schema.values()
+        )
+    if isinstance(schema, list):
+        return any(_schema_contains_key(value, key) for value in schema)
+    return False
+
+
+def _schema_type_allows(schema: dict, expected_type: str) -> bool:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        return expected_type in schema_type
+    return schema_type == expected_type
+
+
 def _paragraph_field_codes(paragraph) -> list[str]:
     from docx.oxml.ns import qn
 

--- a/tests/_docx_test_helpers.py
+++ b/tests/_docx_test_helpers.py
@@ -89,6 +89,16 @@ def _schema_type_allows(schema: dict, expected_type: str) -> bool:
     return schema_type == expected_type
 
 
+def _schema_contains_type_list(schema: object) -> bool:
+    if isinstance(schema, dict):
+        if isinstance(schema.get("type"), list):
+            return True
+        return any(_schema_contains_type_list(value) for value in schema.values())
+    if isinstance(schema, list):
+        return any(_schema_contains_type_list(value) for value in schema)
+    return False
+
+
 def _paragraph_field_codes(paragraph) -> list[str]:
     from docx.oxml.ns import qn
 

--- a/tests/_docx_test_helpers.py
+++ b/tests/_docx_test_helpers.py
@@ -72,33 +72,6 @@ def _find_paragraph(doc, text: str):
     return next(paragraph for paragraph in doc.paragraphs if paragraph.text == text)
 
 
-def _schema_contains_key(schema: object, key: str) -> bool:
-    if isinstance(schema, dict):
-        return key in schema or any(
-            _schema_contains_key(value, key) for value in schema.values()
-        )
-    if isinstance(schema, list):
-        return any(_schema_contains_key(value, key) for value in schema)
-    return False
-
-
-def _schema_type_allows(schema: dict, expected_type: str) -> bool:
-    schema_type = schema.get("type")
-    if isinstance(schema_type, list):
-        return expected_type in schema_type
-    return schema_type == expected_type
-
-
-def _schema_contains_type_list(schema: object) -> bool:
-    if isinstance(schema, dict):
-        if isinstance(schema.get("type"), list):
-            return True
-        return any(_schema_contains_type_list(value) for value in schema.values())
-    if isinstance(schema, list):
-        return any(_schema_contains_type_list(value) for value in schema)
-    return False
-
-
 def _paragraph_field_codes(paragraph) -> list[str]:
     from docx.oxml.ns import qn
 

--- a/tests/_schema_test_helpers.py
+++ b/tests/_schema_test_helpers.py
@@ -1,0 +1,18 @@
+def _schema_contains_key(schema: object, key: str) -> bool:
+    if isinstance(schema, dict):
+        return key in schema or any(
+            _schema_contains_key(value, key) for value in schema.values()
+        )
+    if isinstance(schema, list):
+        return any(_schema_contains_key(value, key) for value in schema)
+    return False
+
+
+def _schema_contains_type_list(schema: object) -> bool:
+    if isinstance(schema, dict):
+        if isinstance(schema.get("type"), list):
+            return True
+        return any(_schema_contains_type_list(value) for value in schema.values())
+    if isinstance(schema, list):
+        return any(_schema_contains_type_list(value) for value in schema)
+    return False

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -115,6 +115,7 @@ from astrbot.core.utils.astrbot_path import get_astrbot_plugin_data_path
 
 
 from tests._docx_test_helpers import *  # noqa: F401,F403
+from tests._schema_test_helpers import _schema_contains_key, _schema_contains_type_list
 
 
 

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -1881,19 +1881,24 @@ async def test_add_blocks_tool_marks_standard_header_row_as_repeated_and_non_spl
 def test_add_blocks_tool_schema_hides_table_cell_spans():
     toolset = build_document_toolset()
     add_blocks_tool = next(tool for tool in toolset.tools if tool.name == "add_blocks")
-    table_schema = add_blocks_tool.parameters["properties"]["blocks"]["items"]["properties"][
-        "rows"
-    ]["items"]["items"]["anyOf"][1]["properties"]
-    run_schema = table_schema["runs"]["items"]["properties"]
+    block_schema = add_blocks_tool.parameters["properties"]["blocks"]["items"]
+    properties = block_schema["properties"]
+    row_cell_schema = properties["rows"]["items"]["items"]
 
-    assert "row_span" not in table_schema
-    assert "col_span" not in table_schema
-    assert table_schema["font_name"]["type"] == "string"
-    assert table_schema["font_scale"]["type"] == "number"
-    assert table_schema["border"]["type"] == "object"
-    assert table_schema["runs"]["type"] == "array"
-    assert run_schema["url"]["type"] == "string"
-    assert run_schema["strikethrough"]["type"] == "boolean"
+    def _contains_key(schema: object, key: str) -> bool:
+        if isinstance(schema, dict):
+            return key in schema or any(
+                _contains_key(value, key) for value in schema.values()
+            )
+        if isinstance(schema, list):
+            return any(_contains_key(value, key) for value in schema)
+        return False
+
+    assert row_cell_schema == {"type": "string"}
+    assert properties["items"]["items"] == {"type": "string"}
+    assert not _contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _contains_key(row_cell_schema, "row_span")
+    assert not _contains_key(row_cell_schema, "col_span")
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -1886,16 +1886,11 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
     list_item_schema = properties["items"]["items"]
     row_cell_schema = properties["rows"]["items"]["items"]
 
-    assert _schema_type_allows(row_cell_schema, "string")
-    assert _schema_type_allows(row_cell_schema, "object")
-    assert _schema_type_allows(list_item_schema, "string")
-    assert _schema_type_allows(list_item_schema, "object")
-    assert list_item_schema["properties"]["runs"]["items"]["properties"]["color"][
-        "type"
-    ] == "string"
-    assert row_cell_schema["properties"]["fill"]["type"] == "string"
-    assert row_cell_schema["properties"]["border"]["type"] == "object"
+    assert row_cell_schema == {"type": "string"}
+    assert list_item_schema == {"type": "string"}
     assert not _schema_contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _schema_contains_key(add_blocks_tool.parameters, "oneOf")
+    assert not _schema_contains_type_list(add_blocks_tool.parameters)
     assert not _schema_contains_key(row_cell_schema, "row_span")
     assert not _schema_contains_key(row_cell_schema, "col_span")
 

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -1883,22 +1883,21 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
     add_blocks_tool = next(tool for tool in toolset.tools if tool.name == "add_blocks")
     block_schema = add_blocks_tool.parameters["properties"]["blocks"]["items"]
     properties = block_schema["properties"]
+    list_item_schema = properties["items"]["items"]
     row_cell_schema = properties["rows"]["items"]["items"]
 
-    def _contains_key(schema: object, key: str) -> bool:
-        if isinstance(schema, dict):
-            return key in schema or any(
-                _contains_key(value, key) for value in schema.values()
-            )
-        if isinstance(schema, list):
-            return any(_contains_key(value, key) for value in schema)
-        return False
-
-    assert row_cell_schema == {"type": "string"}
-    assert properties["items"]["items"] == {"type": "string"}
-    assert not _contains_key(add_blocks_tool.parameters, "anyOf")
-    assert not _contains_key(row_cell_schema, "row_span")
-    assert not _contains_key(row_cell_schema, "col_span")
+    assert _schema_type_allows(row_cell_schema, "string")
+    assert _schema_type_allows(row_cell_schema, "object")
+    assert _schema_type_allows(list_item_schema, "string")
+    assert _schema_type_allows(list_item_schema, "object")
+    assert list_item_schema["properties"]["runs"]["items"]["properties"]["color"][
+        "type"
+    ] == "string"
+    assert row_cell_schema["properties"]["fill"]["type"] == "string"
+    assert row_cell_schema["properties"]["border"]["type"] == "object"
+    assert not _schema_contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _schema_contains_key(row_cell_schema, "row_span")
+    assert not _schema_contains_key(row_cell_schema, "col_span")
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -202,15 +202,6 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         "properties"
     ]
 
-    def _contains_key(schema: object, key: str) -> bool:
-        if isinstance(schema, dict):
-            return key in schema or any(
-                _contains_key(value, key) for value in schema.values()
-            )
-        if isinstance(schema, list):
-            return any(_contains_key(value, key) for value in schema)
-        return False
-
     assert block_properties["blocks"]["type"] == "array"
     assert block_properties["blocks"]["items"]["type"] == "object"
     assert block_properties["blocks"]["items"]["additionalProperties"] is True
@@ -308,12 +299,23 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert block_properties["restart_page_numbering"]["type"] == "boolean"
     assert block_properties["page_number_start"]["type"] == "integer"
     assert block_properties["header_footer"]["type"] == "object"
-    assert block_properties["items"]["items"] == {"type": "string"}
+    list_item_schema = block_properties["items"]["items"]
+    assert _schema_type_allows(list_item_schema, "string")
+    assert _schema_type_allows(list_item_schema, "object")
+    assert (
+        list_item_schema["properties"]["runs"]["items"]["properties"]["color"]["type"]
+        == "string"
+    )
     assert block_properties["rows"]["items"]["type"] == "array"
-    assert block_properties["rows"]["items"]["items"] == {"type": "string"}
-    assert not _contains_key(add_blocks_tool.parameters, "anyOf")
-    assert not _contains_key(block_properties["rows"]["items"]["items"], "row_span")
-    assert not _contains_key(block_properties["rows"]["items"]["items"], "col_span")
+    row_cell_schema = block_properties["rows"]["items"]["items"]
+    assert _schema_type_allows(row_cell_schema, "string")
+    assert _schema_type_allows(row_cell_schema, "object")
+    assert row_cell_schema["properties"]["text"]["type"] == "string"
+    assert row_cell_schema["properties"]["fill"]["type"] == "string"
+    assert row_cell_schema["properties"]["border"]["type"] == "object"
+    assert not _schema_contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _schema_contains_key(row_cell_schema, "row_span")
+    assert not _schema_contains_key(row_cell_schema, "col_span")
     assert block_properties["theme_color"]["type"] == "string"
     assert block_properties["text_color"]["type"] == "string"
     assert block_properties["subtitle_color"]["type"] == "string"

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -300,20 +300,13 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert block_properties["page_number_start"]["type"] == "integer"
     assert block_properties["header_footer"]["type"] == "object"
     list_item_schema = block_properties["items"]["items"]
-    assert _schema_type_allows(list_item_schema, "string")
-    assert _schema_type_allows(list_item_schema, "object")
-    assert (
-        list_item_schema["properties"]["runs"]["items"]["properties"]["color"]["type"]
-        == "string"
-    )
+    assert list_item_schema == {"type": "string"}
     assert block_properties["rows"]["items"]["type"] == "array"
     row_cell_schema = block_properties["rows"]["items"]["items"]
-    assert _schema_type_allows(row_cell_schema, "string")
-    assert _schema_type_allows(row_cell_schema, "object")
-    assert row_cell_schema["properties"]["text"]["type"] == "string"
-    assert row_cell_schema["properties"]["fill"]["type"] == "string"
-    assert row_cell_schema["properties"]["border"]["type"] == "object"
+    assert row_cell_schema == {"type": "string"}
     assert not _schema_contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _schema_contains_key(add_blocks_tool.parameters, "oneOf")
+    assert not _schema_contains_type_list(add_blocks_tool.parameters)
     assert not _schema_contains_key(row_cell_schema, "row_span")
     assert not _schema_contains_key(row_cell_schema, "col_span")
     assert block_properties["theme_color"]["type"] == "string"

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -201,6 +201,16 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     block_properties = add_blocks_tool.parameters["properties"]["blocks"]["items"][
         "properties"
     ]
+
+    def _contains_key(schema: object, key: str) -> bool:
+        if isinstance(schema, dict):
+            return key in schema or any(
+                _contains_key(value, key) for value in schema.values()
+            )
+        if isinstance(schema, list):
+            return any(_contains_key(value, key) for value in schema)
+        return False
+
     assert block_properties["blocks"]["type"] == "array"
     assert block_properties["blocks"]["items"]["type"] == "object"
     assert block_properties["blocks"]["items"]["additionalProperties"] is True
@@ -298,32 +308,12 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert block_properties["restart_page_numbering"]["type"] == "boolean"
     assert block_properties["page_number_start"]["type"] == "integer"
     assert block_properties["header_footer"]["type"] == "object"
-    assert block_properties["items"]["items"]["anyOf"][0]["type"] == "string"
-    assert (
-        block_properties["items"]["items"]["anyOf"][1]["properties"]["runs"]["items"][
-            "properties"
-        ]["color"]["type"]
-        == "string"
-    )
-    assert block_properties["rows"]["items"]["items"]["anyOf"][0]["type"] == "string"
-    row_cell_properties = block_properties["rows"]["items"]["items"]["anyOf"][1][
-        "properties"
-    ]
-    assert row_cell_properties["text"]["type"] == "string"
-    assert "row_span" not in row_cell_properties
-    assert "col_span" not in row_cell_properties
-    assert row_cell_properties["fill"]["type"] == "string"
-    assert row_cell_properties["text_color"]["type"] == "string"
-    assert row_cell_properties["bold"]["type"] == "boolean"
-    assert row_cell_properties["italic"]["type"] == "boolean"
-    assert row_cell_properties["underline"]["type"] == "boolean"
-    assert row_cell_properties["strikethrough"]["type"] == "boolean"
-    assert row_cell_properties["align"]["enum"] == ["left", "center", "right"]
-    assert row_cell_properties["font_scale"]["type"] == "number"
-    assert row_cell_properties["font_name"]["type"] == "string"
-    assert row_cell_properties["runs"]["items"]["properties"]["font_name"]["type"] == "string"
-    assert row_cell_properties["runs"]["items"]["properties"]["strikethrough"]["type"] == "boolean"
-    assert row_cell_properties["border"]["type"] == "object"
+    assert block_properties["items"]["items"] == {"type": "string"}
+    assert block_properties["rows"]["items"]["type"] == "array"
+    assert block_properties["rows"]["items"]["items"] == {"type": "string"}
+    assert not _contains_key(add_blocks_tool.parameters, "anyOf")
+    assert not _contains_key(block_properties["rows"]["items"]["items"], "row_span")
+    assert not _contains_key(block_properties["rows"]["items"]["items"], "col_span")
     assert block_properties["theme_color"]["type"] == "string"
     assert block_properties["text_color"]["type"] == "string"
     assert block_properties["subtitle_color"]["type"] == "string"

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -108,6 +108,7 @@ from astrbot.core.utils.astrbot_path import get_astrbot_plugin_data_path
 
 from tests._docx_test_helpers import *  # noqa: F401,F403
 from tests._docx_test_helpers import _technical_resume_block
+from tests._schema_test_helpers import _schema_contains_key, _schema_contains_type_list
 
 
 
@@ -239,6 +240,15 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         block_properties["data"]["properties"]["auto_page_break"]["type"]
         == "boolean"
     )
+    resume_section_schema = block_properties["data"]["properties"]["sections"]["items"][
+        "properties"
+    ]
+    resume_detail_schema = resume_section_schema["entries"]["items"]["properties"][
+        "details"
+    ]["items"]
+    resume_line_schema = resume_section_schema["lines"]["items"]
+    assert resume_detail_schema == {"type": "string"}
+    assert resume_line_schema == {"type": "string"}
     assert block_properties["text"]["type"] == "string"
     assert block_properties["subtitle"]["type"] == "string"
     assert block_properties["runs"]["type"] == "array"


### PR DESCRIPTION
## 概述

简化 `add_blocks` 暴露给模型的公开参数 Schema，降低 DeepSeek/Gemini 等模型在工具调用时生成非法 JSON 或被接口拒绝的概率。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 将 `add_blocks` 公开 Schema 中的列表项、简历明细、表格单元格收敛为字符串数组，移除公开参数里的 `anyOf`
- 保留运行时 `AddBlocksRequest` 对富文本表格、单元格样式等高级结构的支持
- 更新 Schema 测试，确认公开参数不再包含 `anyOf`

## 影响范围

- 影响 LLM 自动调用 `add_blocks` 时看到的参数结构
- 普通文档、标题、段落、列表、普通表格、整体表格样式流程不受影响
- 代码层直接传复杂 block 的能力不受影响

## 测试情况

- [x] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了核心场景

<details>
<summary>测试记录</summary>

```powershell
pytest tests\test_office_assistant_agent_tools.py::test_add_blocks_tool_schema_hides_table_cell_spans tests\test_office_assistant_agent_tools.py::test_add_blocks_tool_supports_enhanced_tables tests\test_office_assistant_agent_tools.py::test_add_blocks_tool_supports_rich_text_list_items tests\test_office_assistant_contracts.py::test_add_blocks_request_accepts_accent_box_metric_cards_and_table_cell_styles tests\test_office_assistant_contracts.py::test_add_blocks_request_accepts_page_template_technical_resume -q
结果：5 passed。

```
</details>

Fixes #58

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

Bug Fixes（错误修复）:
- 在公共 `add_blocks` schema 中，将列表项、简历详情以及表格单元格内容限制为纯字符串数组，以避免无效 JSON 以及在 LLM 工具调用中使用存在问题的 `anyOf`。

Enhancements（改进）:
- 在工具描述中明确 `add_blocks` 的使用说明，包括简化后的表格样式指导，以及表格正文单元格必须使用纯字符串的要求。

Tests（测试）:
- 更新并扩展以 schema 为重点的测试和共享的 schema 辅助工具，确保公共 `add_blocks` 参数不再使用 `anyOf`/`oneOf`、类型列表，也不再暴露单元格跨度字段，同时仍然校验数组结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

</details>

Bug 修复：
- 在公共的 `add_blocks` schema 中，将列表项、简历详情和表格单元格内容限制为纯字符串数组，以避免模型产生无效的 JSON 和导致 schema 被拒绝。
- 确保在工具 schema 中不暴露表格单元格跨行/跨列（span）以及其他高级单元格样式字段，同时在内部的 `AddBlocksRequest` 合同中仍然支持这些字段。

测试：
- 更新以 schema 为重点的测试，断言 `add_blocks` 工具不再暴露 `anyOf` 结构和高级单元格属性，同时在合同层面仍然接受增强表格和富文本结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

Bug Fixes（错误修复）:
- 在公共 `add_blocks` schema 中，将列表项、简历详情以及表格单元格内容限制为纯字符串数组，以避免无效 JSON 以及在 LLM 工具调用中使用存在问题的 `anyOf`。

Enhancements（改进）:
- 在工具描述中明确 `add_blocks` 的使用说明，包括简化后的表格样式指导，以及表格正文单元格必须使用纯字符串的要求。

Tests（测试）:
- 更新并扩展以 schema 为重点的测试和共享的 schema 辅助工具，确保公共 `add_blocks` 参数不再使用 `anyOf`/`oneOf`、类型列表，也不再暴露单元格跨度字段，同时仍然校验数组结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

Bug Fixes（错误修复）:
- 在公共 `add_blocks` schema 中，将列表项、简历详情以及表格单元格内容限制为纯字符串数组，以避免无效 JSON 以及在 LLM 工具调用中使用存在问题的 `anyOf`。

Enhancements（改进）:
- 在工具描述中明确 `add_blocks` 的使用说明，包括简化后的表格样式指导，以及表格正文单元格必须使用纯字符串的要求。

Tests（测试）:
- 更新并扩展以 schema 为重点的测试和共享的 schema 辅助工具，确保公共 `add_blocks` 参数不再使用 `anyOf`/`oneOf`、类型列表，也不再暴露单元格跨度字段，同时仍然校验数组结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

</details>

Bug 修复：
- 在公共的 `add_blocks` schema 中，将列表项、简历详情和表格单元格内容限制为纯字符串数组，以避免模型产生无效的 JSON 和导致 schema 被拒绝。
- 确保在工具 schema 中不暴露表格单元格跨行/跨列（span）以及其他高级单元格样式字段，同时在内部的 `AddBlocksRequest` 合同中仍然支持这些字段。

测试：
- 更新以 schema 为重点的测试，断言 `add_blocks` 工具不再暴露 `anyOf` 结构和高级单元格属性，同时在合同层面仍然接受增强表格和富文本结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

Bug Fixes（错误修复）:
- 在公共 `add_blocks` schema 中，将列表项、简历详情以及表格单元格内容限制为纯字符串数组，以避免无效 JSON 以及在 LLM 工具调用中使用存在问题的 `anyOf`。

Enhancements（改进）:
- 在工具描述中明确 `add_blocks` 的使用说明，包括简化后的表格样式指导，以及表格正文单元格必须使用纯字符串的要求。

Tests（测试）:
- 更新并扩展以 schema 为重点的测试和共享的 schema 辅助工具，确保公共 `add_blocks` 参数不再使用 `anyOf`/`oneOf`、类型列表，也不再暴露单元格跨度字段，同时仍然校验数组结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在保持内部对富表格和富文本结构支持的同时，简化 `add_blocks` 工具的公共 JSON Schema。

Bug 修复：
- 将公共 `add_blocks` Schema 中的列表项、简历详情和表格主体单元格限制为纯字符串数组，以避免在 LLM 工具调用中出现无效 JSON 以及有问题的 `anyOf`/`oneOf` 用法。
- 在公共 `add_blocks` 参数中隐藏高级表格单元格属性（如行跨距和列跨距），同时在内部的 `AddBlocksRequest` 合同中继续支持这些属性。

增强：
- 明确 `add_blocks` 工具文档中关于段落颜色、表格样式选项以及表格主体单元格必须使用纯字符串的要求的说明。

测试：
- 更新并扩展以 Schema 为重点的测试（包括共享的 Schema 辅助工具），以断言简化后的公共 Schema（无 `anyOf`/`oneOf`、无类型列表、无暴露的单元格跨距），同时确保增强表格和富文本结构在合同层面仍然被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the public JSON schema for the add_blocks tool while preserving internal support for rich table and text structures.

Bug Fixes:
- Restrict list items, resume details, and table body cells in the public add_blocks schema to plain string arrays to avoid invalid JSON and problematic anyOf/oneOf usage in LLM tool calls.
- Hide advanced table cell properties such as row and column spans from the public add_blocks parameters while keeping them supported in the internal AddBlocksRequest contract.

Enhancements:
- Clarify add_blocks tool documentation text around paragraph colors, table styling options, and the requirement to use plain strings for table body cells.

Tests:
- Update and extend schema-focused tests, including shared schema helper utilities, to assert the simplified public schema (no anyOf/oneOf, no type lists, no exposed cell spans) while ensuring enhanced tables and rich text structures remain accepted at the contract level.

</details>

</details>

</details>

</details>