### PR TITLE
fix: accept stringified Word tool payloads

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -38,9 +38,7 @@ def _dump_result(result: ToolResult) -> str:
 _CONTINUE_UNTIL_EXPORT = (
     "请继续调用文档工具，直到 export_document 成功。中途不要发自然语言回复。"
 )
-_FINALIZE_PROMPT = (
-    "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document，也不要发自然语言回复。"
-)
+_FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document，也不要发自然语言回复。"
 
 
 _STYLE_SCHEMA = {
@@ -198,6 +196,17 @@ _TABLE_CELL_SCHEMA = {
 }
 
 _STRING_PUBLIC_SCHEMA = {"type": "string"}
+_RICH_LIST_ITEM_PUBLIC_SCHEMA = {
+    "description": "Plain string, or rich list item object with text/runs.",
+    "properties": {
+        "text": {"type": "string"},
+        "runs": {
+            "type": "array",
+            "description": "Optional inline rich-text runs for this list item.",
+            "items": _schema_copy(_INLINE_RUN_SCHEMA),
+        },
+    },
+}
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -556,13 +565,17 @@ class AddBlocksTool(DocumentToolBase):
                                                     "items": {
                                                         "type": "object",
                                                         "properties": {
-                                                            "heading": {"type": "string"},
+                                                            "heading": {
+                                                                "type": "string"
+                                                            },
                                                             "date": {"type": "string"},
-                                                            "subtitle": {"type": "string"},
+                                                            "subtitle": {
+                                                                "type": "string"
+                                                            },
                                                             "details": {
                                                                 "type": "array",
                                                                 "items": _schema_copy(
-                                                                    _STRING_PUBLIC_SCHEMA
+                                                                    _RICH_LIST_ITEM_PUBLIC_SCHEMA
                                                                 ),
                                                             },
                                                         },
@@ -572,7 +585,7 @@ class AddBlocksTool(DocumentToolBase):
                                                 "lines": {
                                                     "type": "array",
                                                     "items": _schema_copy(
-                                                        _STRING_PUBLIC_SCHEMA
+                                                        _RICH_LIST_ITEM_PUBLIC_SCHEMA
                                                     ),
                                                 },
                                             },
@@ -876,7 +889,7 @@ class AddBlocksTool(DocumentToolBase):
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
         try:
-            raw_blocks = normalize_raw_block_payloads(list(kwargs.get("blocks") or []))
+            raw_blocks = normalize_raw_block_payloads(kwargs.get("blocks") or [])
             request = AddBlocksRequest(
                 document_id=str(kwargs.get("document_id") or ""),
                 blocks=raw_blocks,
@@ -992,8 +1005,7 @@ class ExportDocumentTool(DocumentToolBase):
             resolved_render_backends = (
                 build_document_render_backends(
                     document_for_routing.format,
-                    self.render_backend_config
-                    or get_render_backend_config(self.store),
+                    self.render_backend_config or get_render_backend_config(self.store),
                 )
                 if self.render_backend_config is not None
                 or document_for_routing.format != "word"

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -36,7 +36,7 @@ def _dump_result(result: ToolResult) -> str:
 
 
 _CONTINUE_UNTIL_EXPORT = (
-    "请继续调用文档工具，直到 export_document 成功。中途不要发自然语言回复。"
+    "请继续调用文档工具，直到 export_document 成功"
 )
 _FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document"
 

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -35,9 +35,7 @@ def _dump_result(result: ToolResult) -> str:
     return result.model_dump_json(exclude_none=True)
 
 
-_CONTINUE_UNTIL_EXPORT = (
-    "请继续调用文档工具，直到 export_document 成功"
-)
+_CONTINUE_UNTIL_EXPORT = "请继续调用文档工具，直到 export_document 成功"
 _FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document"
 
 
@@ -197,7 +195,7 @@ _TABLE_CELL_SCHEMA = {
 
 _STRING_PUBLIC_SCHEMA = {"type": "string"}
 _RICH_LIST_ITEM_PUBLIC_SCHEMA = {
-    "description": "Plain string, or rich list item object with text/runs.",
+    "description": "Rich list item object with text/runs. Plain strings are also accepted by runtime validation.",
     "properties": {
         "text": {"type": "string"},
         "runs": {

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -38,7 +38,7 @@ def _dump_result(result: ToolResult) -> str:
 _CONTINUE_UNTIL_EXPORT = (
     "请继续调用文档工具，直到 export_document 成功。中途不要发自然语言回复。"
 )
-_FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document，也不要发自然语言回复。"
+_FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document"
 
 
 _STYLE_SCHEMA = {
@@ -555,11 +555,14 @@ class AddBlocksTool(DocumentToolBase):
                                     },
                                     "sections": {
                                         "type": "array",
-                                        "description": "Resume sections for technical_resume. Each section needs a title plus entries or lines.",
+                                        "description": "Resume sections for technical_resume. Each section MUST use title for the section name, plus entries or lines.",
                                         "items": {
                                             "type": "object",
                                             "properties": {
-                                                "title": {"type": "string"},
+                                                "title": {
+                                                    "type": "string",
+                                                    "description": "Required section name, such as 项目经历 or 技术栈. Use title here; do not use heading.",
+                                                },
                                                 "entries": {
                                                     "type": "array",
                                                     "items": {
@@ -589,6 +592,7 @@ class AddBlocksTool(DocumentToolBase):
                                                     ),
                                                 },
                                             },
+                                            "required": ["title"],
                                         },
                                     },
                                 },

--- a/document_core/models/blocks.py
+++ b/document_core/models/blocks.py
@@ -248,6 +248,7 @@ class TechnicalResumeData(BaseModel):
     headline: str = ""
     contact_line: str = Field(min_length=1)
     sections: list[ResumeSection] = Field(min_length=1)
+    auto_page_break: bool = False
 
 
 class PageTemplateBlock(BaseModel):

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -580,6 +580,8 @@ def _apply_block_normalization_pipeline(block: dict) -> None:
 
 
 def _coerce_optional_mapping(value: object, field_name: str) -> dict[str, object]:
+    if value is None:
+        return {}
     if isinstance(value, Mapping):
         return dict(value)
     if not isinstance(value, str):
@@ -605,7 +607,10 @@ def normalize_create_document_kwargs(kwargs: Mapping[str, object]) -> dict[str, 
     if "header_footer" in normalized:
         raw_header_footer = normalized.get("header_footer")
         header_footer = _coerce_optional_mapping(raw_header_footer, "header_footer")
-        normalized["header_footer"] = header_footer
+        if header_footer:
+            normalized["header_footer"] = header_footer
+        else:
+            normalized.pop("header_footer", None)
 
     document_style: dict[str, object] = {}
     if "document_style" in normalized:
@@ -616,6 +621,8 @@ def normalize_create_document_kwargs(kwargs: Mapping[str, object]) -> dict[str, 
             document_style[key] = normalized[key]
     if document_style:
         normalized["document_style"] = document_style
+    else:
+        normalized.pop("document_style", None)
     return normalized
 
 

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -194,7 +194,9 @@ def _normalize_table_header_alias(block: dict) -> None:
     if isinstance(raw_headers, list) and raw_headers:
         normalized_headers = [
             text
-            for text in (_extract_text_from_column_alias(header) for header in raw_headers)
+            for text in (
+                _extract_text_from_column_alias(header) for header in raw_headers
+            )
             if text
         ]
         if normalized_headers:
@@ -332,7 +334,11 @@ def _normalize_nested_block_payload_alias(block: dict) -> None:
             block["text"] = content.strip()
     elif block_type == "hero_banner":
         title_color = block.pop("title_color", None)
-        if isinstance(title_color, str) and title_color.strip() and not block.get("text_color"):
+        if (
+            isinstance(title_color, str)
+            and title_color.strip()
+            and not block.get("text_color")
+        ):
             block["text_color"] = title_color.strip()
         text = block.pop("text", None)
         if isinstance(text, str) and text.strip() and not block.get("title"):
@@ -433,7 +439,11 @@ def _normalize_runs_color_aliases(runs: object) -> None:
         if not isinstance(raw_run, dict):
             continue
         text_color = raw_run.pop("text_color", None)
-        if "color" not in raw_run and isinstance(text_color, str) and text_color.strip():
+        if (
+            "color" not in raw_run
+            and isinstance(text_color, str)
+            and text_color.strip()
+        ):
             raw_run["color"] = text_color.strip()
 
 
@@ -455,6 +465,26 @@ def _normalize_block_run_aliases(block: dict) -> None:
         if not isinstance(item, dict):
             continue
         _normalize_runs_color_aliases(item.get("runs"))
+
+
+def _normalize_technical_resume_section_aliases(block: dict) -> None:
+    if (
+        block.get("type") != "page_template"
+        or block.get("template") != "technical_resume"
+    ):
+        return
+    data = block.get("data")
+    if not isinstance(data, Mapping):
+        return
+    sections = data.get("sections")
+    if not isinstance(sections, list):
+        return
+    for section in sections:
+        if not isinstance(section, dict) or section.get("title"):
+            continue
+        heading = section.pop("heading", None)
+        if isinstance(heading, str) and heading.strip():
+            section["title"] = heading.strip()
 
 
 def _normalize_table_cell_aliases(block: dict) -> None:
@@ -490,10 +520,7 @@ def _normalize_legacy_paragraph_border_aliases(block: dict) -> None:
         bottom_border is True
         or bottom_border_color not in (None, "")
         or bottom_border_size_pt is not None
-        or (
-            isinstance(bottom_border_style, str)
-            and bottom_border_style.strip() != ""
-        )
+        or (isinstance(bottom_border_style, str) and bottom_border_style.strip() != "")
     )
     if not has_legacy_border:
         return
@@ -530,6 +557,7 @@ _BLOCK_CONTENT_NORMALIZERS = (
     _normalize_heading_title_alias,
     _normalize_paragraph_items_alias,
     _normalize_block_run_aliases,
+    _normalize_technical_resume_section_aliases,
     _normalize_legacy_paragraph_border_aliases,
 )
 _TABLE_BLOCK_NORMALIZERS = (
@@ -626,7 +654,9 @@ def normalize_raw_block_payloads(
         try:
             blocks = json.loads(blocks)
         except json.JSONDecodeError as exc:
-            raise ValueError("blocks must be a JSON array when passed as a string") from exc
+            raise ValueError(
+                "blocks must be a JSON array when passed as a string"
+            ) from exc
     if not isinstance(blocks, list):
         raise ValueError("blocks must be a list")
 
@@ -726,6 +756,7 @@ def _coerce_table_input_rows_to_runtime(
         ]
         for row in rows
     ]
+
 
 class CreateDocumentRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -1415,7 +1446,9 @@ class SectionPageTemplateInput(BaseModel):
         )
         if isinstance(self.data, expected_type):
             return self
-        raise ValueError(f"page_template data does not match template {self.template!r}")
+        raise ValueError(
+            f"page_template data does not match template {self.template!r}"
+        )
 
 
 class AddSummaryCardRequest(BaseModel):

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -579,42 +579,43 @@ def _apply_block_normalization_pipeline(block: dict) -> None:
             normalizer(block)
 
 
-def _coerce_optional_mapping(value: object) -> dict[str, object]:
+def _coerce_optional_mapping(value: object, field_name: str) -> dict[str, object]:
     if isinstance(value, Mapping):
         return dict(value)
     if not isinstance(value, str):
-        return {}
+        raise ValueError(f"{field_name} must be an object or JSON object string")
 
     text = value.strip()
     if not text:
-        return {}
+        raise ValueError(f"{field_name} must be a JSON object when passed as a string")
     try:
         parsed = json.loads(text)
-    except json.JSONDecodeError:
-        return {}
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"{field_name} must be valid JSON when passed as a string"
+        ) from exc
     if isinstance(parsed, Mapping):
         return dict(parsed)
-    return {}
+    raise ValueError(f"{field_name} must be a JSON object when passed as a string")
 
 
 def normalize_create_document_kwargs(kwargs: Mapping[str, object]) -> dict[str, object]:
     normalized = dict(kwargs)
-    raw_header_footer = normalized.get("header_footer")
-    header_footer = _coerce_optional_mapping(raw_header_footer)
-    if header_footer:
+    header_footer: dict[str, object] = {}
+    if "header_footer" in normalized:
+        raw_header_footer = normalized.get("header_footer")
+        header_footer = _coerce_optional_mapping(raw_header_footer, "header_footer")
         normalized["header_footer"] = header_footer
-    elif "header_footer" in normalized and not isinstance(raw_header_footer, Mapping):
-        normalized.pop("header_footer", None)
 
-    raw_document_style = normalized.get("document_style")
-    document_style = _coerce_optional_mapping(raw_document_style)
+    document_style: dict[str, object] = {}
+    if "document_style" in normalized:
+        raw_document_style = normalized.get("document_style")
+        document_style = _coerce_optional_mapping(raw_document_style, "document_style")
     for key in _DOCUMENT_STYLE_COMPAT_KEYS:
         if key in normalized and key not in document_style:
             document_style[key] = normalized[key]
     if document_style:
         normalized["document_style"] = document_style
-    elif "document_style" in normalized and not isinstance(raw_document_style, Mapping):
-        normalized.pop("document_style", None)
     return normalized
 
 
@@ -655,7 +656,7 @@ def normalize_raw_block_payloads(
             blocks = json.loads(blocks)
         except json.JSONDecodeError as exc:
             raise ValueError(
-                "blocks must be a JSON array when passed as a string"
+                "blocks must be a valid JSON array when passed as a string"
             ) from exc
     if not isinstance(blocks, list):
         raise ValueError("blocks must be a list")

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import json
 import re
 from collections.abc import Mapping
 from pathlib import Path
@@ -550,15 +551,42 @@ def _apply_block_normalization_pipeline(block: dict) -> None:
             normalizer(block)
 
 
+def _coerce_optional_mapping(value: object) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    if not isinstance(value, str):
+        return {}
+
+    text = value.strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(parsed, Mapping):
+        return dict(parsed)
+    return {}
+
+
 def normalize_create_document_kwargs(kwargs: Mapping[str, object]) -> dict[str, object]:
     normalized = dict(kwargs)
+    raw_header_footer = normalized.get("header_footer")
+    header_footer = _coerce_optional_mapping(raw_header_footer)
+    if header_footer:
+        normalized["header_footer"] = header_footer
+    elif "header_footer" in normalized and not isinstance(raw_header_footer, Mapping):
+        normalized.pop("header_footer", None)
+
     raw_document_style = normalized.get("document_style")
-    document_style = dict(raw_document_style) if isinstance(raw_document_style, Mapping) else {}
+    document_style = _coerce_optional_mapping(raw_document_style)
     for key in _DOCUMENT_STYLE_COMPAT_KEYS:
         if key in normalized and key not in document_style:
             document_style[key] = normalized[key]
     if document_style:
         normalized["document_style"] = document_style
+    elif "document_style" in normalized and not isinstance(raw_document_style, Mapping):
+        normalized.pop("document_style", None)
     return normalized
 
 
@@ -586,7 +614,7 @@ def _extract_compat_section_break(block: dict) -> dict | None:
 
 
 def normalize_raw_block_payloads(
-    blocks: list[object],
+    blocks: object,
     *,
     _depth: int = 0,
 ) -> list[object]:
@@ -594,6 +622,14 @@ def normalize_raw_block_payloads(
         raise ValueError(
             f"block payload nesting exceeds limit ({MAX_BLOCK_NORMALIZE_DEPTH})"
         )
+    if isinstance(blocks, str):
+        try:
+            blocks = json.loads(blocks)
+        except json.JSONDecodeError as exc:
+            raise ValueError("blocks must be a JSON array when passed as a string") from exc
+    if not isinstance(blocks, list):
+        raise ValueError("blocks must be a list")
+
     normalized_blocks: list[object] = []
     for raw_block in blocks:
         block = _copy_raw_block(raw_block)
@@ -1348,6 +1384,7 @@ class TechnicalResumeDataInput(BaseModel):
     headline: str = ""
     contact_line: str = Field(min_length=1)
     sections: list[ResumeSectionInput] = Field(min_length=1)
+    auto_page_break: bool = False
 
 
 class SectionPageTemplateInput(BaseModel):

--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -420,6 +420,7 @@ class DocumentSessionStore:
                         name=block.data.name,
                         headline=block.data.headline,
                         contact_line=block.data.contact_line,
+                        auto_page_break=block.data.auto_page_break,
                         sections=[
                             ResumeSection(
                                 title=section.title,

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -465,6 +465,53 @@ async def test_add_blocks_failure_message_keeps_model_on_same_tool(
 
 
 @pytest.mark.asyncio
+async def test_add_blocks_tool_accepts_json_string_blocks(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-agent-tools-json-blocks")
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            output_name="json-blocks.docx",
+        )
+    )
+
+    added = json.loads(
+        await tool_by_name["add_blocks"].call(
+            None,
+            document_id=created["document"]["document_id"],
+            blocks='[{"type": "paragraph", "text": "正文"}]',
+        )
+    )
+
+    assert added["success"] is True
+    assert added["document"]["block_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_document_tool_accepts_json_string_document_style(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(workspace_root, "pytest-agent-tools-json-style")
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            output_name="json-style.docx",
+            document_style=(
+                '{"font_name": "Microsoft YaHei", "heading_color": "1F4E79"}'
+            ),
+        )
+    )
+
+    assert created["success"] is True
+    assert created["document"]["document_style"]["heading_color"] == "1F4E79"
+
+
+@pytest.mark.asyncio
 async def test_create_document_tool_returns_incrementing_short_document_ids():
     tool = CreateDocumentTool()
 
@@ -1887,9 +1934,28 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
     properties = block_schema["properties"]
     list_item_schema = properties["items"]["items"]
     row_cell_schema = properties["rows"]["items"]["items"]
+    resume_sections = properties["data"]["properties"]["sections"]["items"][
+        "properties"
+    ]
+    resume_detail_schema = resume_sections["entries"]["items"]["properties"]["details"][
+        "items"
+    ]
+    resume_line_schema = resume_sections["lines"]["items"]
 
     assert row_cell_schema == {"type": "string"}
     assert list_item_schema == {"type": "string"}
+    assert "type" not in resume_detail_schema
+    assert (
+        resume_detail_schema["properties"]["runs"]["items"]["properties"]["bold"][
+            "type"
+        ]
+        == "boolean"
+    )
+    assert "type" not in resume_line_schema
+    assert (
+        resume_line_schema["properties"]["runs"]["items"]["properties"]["bold"]["type"]
+        == "boolean"
+    )
     assert not _schema_contains_key(add_blocks_tool.parameters, "anyOf")
     assert not _schema_contains_key(add_blocks_tool.parameters, "oneOf")
     assert not _schema_contains_type_list(add_blocks_tool.parameters)

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -534,6 +534,30 @@ async def test_create_document_tool_accepts_json_string_header_footer(
 
 
 @pytest.mark.asyncio
+async def test_create_document_tool_treats_null_style_and_footer_as_absent(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-null-style-footer"
+    )
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            output_name="null-style-footer.docx",
+            document_style=None,
+            header_footer=None,
+        )
+    )
+
+    assert created["success"] is True
+    assert created["document"]["header_footer"] == {}
+    assert isinstance(created["document"]["document_style"], dict)
+
+
+@pytest.mark.asyncio
 async def test_create_document_tool_returns_incrementing_short_document_ids():
     tool = CreateDocumentTool()
 

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -1937,6 +1937,7 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
     resume_sections = properties["data"]["properties"]["sections"]["items"][
         "properties"
     ]
+    resume_section_schema = properties["data"]["properties"]["sections"]["items"]
     resume_detail_schema = resume_sections["entries"]["items"]["properties"]["details"][
         "items"
     ]
@@ -1944,6 +1945,10 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
 
     assert row_cell_schema == {"type": "string"}
     assert list_item_schema == {"type": "string"}
+    assert resume_section_schema["required"] == ["title"]
+    assert resume_sections["title"]["description"].endswith(
+        "Use title here; do not use heading."
+    )
     assert "type" not in resume_detail_schema
     assert (
         resume_detail_schema["properties"]["runs"]["items"]["properties"]["bold"][

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -512,6 +512,28 @@ async def test_create_document_tool_accepts_json_string_document_style(
 
 
 @pytest.mark.asyncio
+async def test_create_document_tool_accepts_json_string_header_footer(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-json-header-footer"
+    )
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            output_name="json-header-footer.docx",
+            header_footer='{"footer_text": "Page footer"}',
+        )
+    )
+
+    assert created["success"] is True
+    assert created["document"]["header_footer"]["footer_text"] == "Page footer"
+
+
+@pytest.mark.asyncio
 async def test_create_document_tool_returns_incrementing_short_document_ids():
     tool = CreateDocumentTool()
 

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -242,10 +242,15 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     resume_section_schema = block_properties["data"]["properties"]["sections"]["items"][
         "properties"
     ]
+    resume_section_item_schema = block_properties["data"]["properties"]["sections"][
+        "items"
+    ]
     resume_detail_schema = resume_section_schema["entries"]["items"]["properties"][
         "details"
     ]["items"]
     resume_line_schema = resume_section_schema["lines"]["items"]
+    assert resume_section_item_schema["required"] == ["title"]
+    assert resume_section_schema["title"]["type"] == "string"
     assert "type" not in resume_detail_schema
     assert resume_detail_schema["properties"]["text"]["type"] == "string"
     assert resume_detail_schema["properties"]["runs"]["type"] == "array"
@@ -587,6 +592,29 @@ def test_normalize_raw_block_payloads_accepts_json_string_array():
     normalized = normalize_raw_block_payloads('[{"type": "paragraph", "text": "正文"}]')
 
     assert normalized == [{"type": "paragraph", "text": "正文"}]
+
+
+def test_normalize_raw_block_payloads_repairs_technical_resume_section_heading_alias():
+    normalized = normalize_raw_block_payloads(
+        [
+            _technical_resume_block(
+                sections=[
+                    {
+                        "heading": "项目经历",
+                        "entries": [
+                            {
+                                "heading": "Office Assistant Word 输出验证",
+                                "details": [{"text": "普通字符串 detail 保持可渲染。"}],
+                            }
+                        ],
+                    }
+                ]
+            )
+        ]
+    )
+
+    assert normalized[0]["data"]["sections"][0]["title"] == "项目经历"
+    assert "heading" not in normalized[0]["data"]["sections"][0]
 
 
 def test_normalize_raw_block_payloads_repairs_paragraph_items_alias():

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -789,6 +789,29 @@ def test_normalize_create_document_kwargs_accepts_json_string_objects():
     assert normalized["header_footer"]["footer_text"] == "内部资料"
 
 
+def test_normalize_create_document_kwargs_treats_none_optional_objects_as_absent():
+    normalized = normalize_create_document_kwargs(
+        {
+            "document_style": None,
+            "header_footer": None,
+        }
+    )
+
+    assert "document_style" not in normalized
+    assert "header_footer" not in normalized
+
+
+def test_normalize_create_document_kwargs_merges_style_aliases_when_style_is_none():
+    normalized = normalize_create_document_kwargs(
+        {
+            "document_style": None,
+            "heading_color": "1F4E79",
+        }
+    )
+
+    assert normalized["document_style"]["heading_color"] == "1F4E79"
+
+
 @pytest.mark.parametrize("field_name", ["document_style", "header_footer"])
 def test_normalize_create_document_kwargs_rejects_invalid_json_string(field_name: str):
     with pytest.raises(ValueError, match=f"{field_name} must be valid JSON"):

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -111,7 +111,6 @@ from tests._docx_test_helpers import _technical_resume_block
 from tests._schema_test_helpers import _schema_contains_key, _schema_contains_type_list
 
 
-
 def test_create_document_tool_schema_exposes_document_style():
     toolset = build_document_toolset()
     create_document_tool = next(
@@ -195,6 +194,7 @@ def test_create_document_tool_schema_exposes_document_style():
     ]
     assert table_defaults["cell_align"]["enum"] == ["left", "center", "right"]
 
+
 def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     toolset = build_document_toolset()
     add_blocks_tool = next(tool for tool in toolset.tools if tool.name == "add_blocks")
@@ -237,8 +237,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         == "string"
     )
     assert (
-        block_properties["data"]["properties"]["auto_page_break"]["type"]
-        == "boolean"
+        block_properties["data"]["properties"]["auto_page_break"]["type"] == "boolean"
     )
     resume_section_schema = block_properties["data"]["properties"]["sections"]["items"][
         "properties"
@@ -247,17 +246,30 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         "details"
     ]["items"]
     resume_line_schema = resume_section_schema["lines"]["items"]
-    assert resume_detail_schema == {"type": "string"}
-    assert resume_line_schema == {"type": "string"}
+    assert "type" not in resume_detail_schema
+    assert resume_detail_schema["properties"]["text"]["type"] == "string"
+    assert resume_detail_schema["properties"]["runs"]["type"] == "array"
+    assert (
+        resume_detail_schema["properties"]["runs"]["items"]["properties"]["bold"][
+            "type"
+        ]
+        == "boolean"
+    )
+    assert "type" not in resume_line_schema
+    assert resume_line_schema["properties"]["text"]["type"] == "string"
+    assert resume_line_schema["properties"]["runs"]["type"] == "array"
+    assert (
+        resume_line_schema["properties"]["runs"]["items"]["properties"]["bold"]["type"]
+        == "boolean"
+    )
     assert block_properties["text"]["type"] == "string"
     assert block_properties["subtitle"]["type"] == "string"
     assert block_properties["runs"]["type"] == "array"
     assert block_properties["runs"]["items"]["type"] == "object"
     assert block_properties["border"]["type"] == "object"
-    assert (
-        block_properties["border"]["properties"]["bottom"]["properties"]["style"]["enum"]
-        == ["single", "double", "dashed", "dotted", "none"]
-    )
+    assert block_properties["border"]["properties"]["bottom"]["properties"]["style"][
+        "enum"
+    ] == ["single", "double", "dashed", "dotted", "none"]
     assert block_properties["bottom_border"]["type"] == "boolean"
     assert block_properties["bottom_border_color"]["type"] == "string"
     assert block_properties["bottom_border_size_pt"]["type"] == "number"
@@ -336,8 +348,14 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert block_properties["title_font_scale"]["type"] == "number"
     assert block_properties["body_font_scale"]["type"] == "number"
     assert block_properties["metrics"]["items"]["required"] == ["label", "value"]
-    assert block_properties["metrics"]["items"]["properties"]["label_color"]["type"] == "string"
-    assert block_properties["metrics"]["items"]["properties"]["note_color"]["type"] == "string"
+    assert (
+        block_properties["metrics"]["items"]["properties"]["label_color"]["type"]
+        == "string"
+    )
+    assert (
+        block_properties["metrics"]["items"]["properties"]["note_color"]["type"]
+        == "string"
+    )
     assert (
         block_properties["metrics"]["items"]["properties"]["value_font_scale"]["type"]
         == "number"
@@ -372,6 +390,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     )
     assert block_properties["levels"]["type"] == "integer"
     assert block_properties["start_on_new_page"]["type"] == "boolean"
+
 
 def test_create_document_request_accepts_header_footer_defaults():
     request = CreateDocumentRequest(
@@ -423,6 +442,7 @@ def test_create_document_request_accepts_header_footer_defaults():
     assert request.header_footer.page_number_align == "center"
     assert request.header_footer.page_number_format == "upperRoman"
 
+
 def test_section_break_block_rejects_page_number_start_without_restart():
     with pytest.raises(
         ValidationError,
@@ -431,6 +451,7 @@ def test_section_break_block_rejects_page_number_start_without_restart():
         SectionBreakBlock(
             page_number_start=2,
         )
+
 
 def test_add_blocks_request_rejects_section_page_number_start_without_restart():
     with pytest.raises(
@@ -447,9 +468,11 @@ def test_add_blocks_request_rejects_section_page_number_start_without_restart():
             ],
         )
 
+
 def test_section_margins_config_rejects_zero_margin():
     with pytest.raises(ValidationError):
         SectionMarginsConfig(top_cm=0, bottom_cm=2, left_cm=2, right_cm=2)
+
 
 def test_section_break_block_rejects_margin_greater_than_ten():
     with pytest.raises(ValidationError):
@@ -461,6 +484,7 @@ def test_section_break_block_rejects_margin_greater_than_ten():
                 "right_cm": 2,
             }
         )
+
 
 def test_add_blocks_request_rejects_invalid_section_margins():
     with pytest.raises(ValidationError):
@@ -478,6 +502,7 @@ def test_add_blocks_request_rejects_invalid_section_margins():
                 }
             ],
         )
+
 
 def test_normalize_raw_block_payloads_repairs_section_toc_and_table_aliases():
     normalized = normalize_raw_block_payloads(
@@ -544,6 +569,7 @@ def test_normalize_raw_block_payloads_repairs_section_toc_and_table_aliases():
     assert normalized[6]["layout"]["spacing_before"] == pytest.approx(72.0)
     assert normalized[6]["layout"]["spacing_after"] == pytest.approx(0.0)
 
+
 def test_normalize_raw_block_payloads_strips_markdown_table_edge_pipes():
     normalized = normalize_raw_block_payloads(
         [
@@ -555,6 +581,13 @@ def test_normalize_raw_block_payloads_strips_markdown_table_edge_pipes():
     )
 
     assert normalized[0]["rows"] == [["单元格1", "单元格2", "单元格3"]]
+
+
+def test_normalize_raw_block_payloads_accepts_json_string_array():
+    normalized = normalize_raw_block_payloads('[{"type": "paragraph", "text": "正文"}]')
+
+    assert normalized == [{"type": "paragraph", "text": "正文"}]
+
 
 def test_normalize_raw_block_payloads_repairs_paragraph_items_alias():
     normalized = normalize_raw_block_payloads(
@@ -689,6 +722,7 @@ def test_normalize_raw_block_payloads_unwraps_singleton_list_items():
         "runs": [{"text": "库存健康：建立动态安全库存模型。"}]
     }
 
+
 def test_normalize_create_document_kwargs_moves_top_level_style_fields():
     normalized = normalize_create_document_kwargs(
         {
@@ -701,6 +735,22 @@ def test_normalize_create_document_kwargs_moves_top_level_style_fields():
     assert normalized["document_style"]["heading_color"] == "000000"
     assert normalized["document_style"]["title_align"] == "center"
 
+
+def test_normalize_create_document_kwargs_accepts_json_string_objects():
+    normalized = normalize_create_document_kwargs(
+        {
+            "document_style": (
+                '{"font_name": "Microsoft YaHei", "heading_color": "1F4E79"}'
+            ),
+            "header_footer": '{"footer_text": "内部资料"}',
+        }
+    )
+
+    assert normalized["document_style"]["font_name"] == "Microsoft YaHei"
+    assert normalized["document_style"]["heading_color"] == "1F4E79"
+    assert normalized["header_footer"]["footer_text"] == "内部资料"
+
+
 def test_normalize_raw_block_payloads_rejects_excessive_nesting():
     nested_block: dict[str, object] = {"type": "paragraph", "text": "leaf"}
     for _ in range(34):
@@ -709,15 +759,18 @@ def test_normalize_raw_block_payloads_rejects_excessive_nesting():
     with pytest.raises(ValueError, match="nesting exceeds limit"):
         normalize_raw_block_payloads([nested_block])
 
+
 def test_create_document_request_normalizes_separator_only_output_name():
     request = CreateDocumentRequest(output_name="//")
 
     assert request.output_name == "document.docx"
 
+
 def test_export_document_request_normalizes_dot_only_output_name():
     request = ExportDocumentRequest(document_id="doc-1", output_name=".")
 
     assert request.output_name == "document.docx"
+
 
 def test_paragraph_schema_requires_text_or_runs():
     with pytest.raises(ValidationError, match="paragraph requires text or runs"):
@@ -728,6 +781,7 @@ def test_paragraph_schema_requires_text_or_runs():
                 "runs": [],
             }
         )
+
 
 def test_build_document_render_payload_preserves_runs_when_text_and_runs_exist():
     block = ParagraphBlock(
@@ -843,6 +897,7 @@ def test_paragraph_run_accepts_scheme_only_https_url():
 
     assert run.url == "https://example.com/"
 
+
 def test_build_document_render_payload_keeps_default_metadata_fields():
     document = DocumentModel(
         document_id="doc-1",
@@ -857,6 +912,7 @@ def test_build_document_render_payload_keeps_default_metadata_fields():
     assert payload["metadata"]["theme_name"] == "business_report"
     assert payload["metadata"]["table_template"] == "report_grid"
     assert payload["metadata"]["density"] == "comfortable"
+
 
 def test_build_document_render_payload_keeps_page_template_required_defaults():
     document = DocumentModel(
@@ -906,8 +962,13 @@ def test_build_document_render_payload_omits_none_in_page_template_runs():
                                     details=[
                                         ListItem(
                                             runs=[
-                                                ParagraphRun(text="主导优化推荐引擎召回模块，", bold=True),
-                                                ParagraphRun(text="将离线索引构建耗时压缩到 1/4。"),
+                                                ParagraphRun(
+                                                    text="主导优化推荐引擎召回模块，",
+                                                    bold=True,
+                                                ),
+                                                ParagraphRun(
+                                                    text="将离线索引构建耗时压缩到 1/4。"
+                                                ),
                                             ]
                                         )
                                     ],
@@ -921,7 +982,9 @@ def test_build_document_render_payload_omits_none_in_page_template_runs():
     )
 
     payload = build_document_render_payload(document)
-    runs = payload["blocks"][0]["data"]["sections"][0]["entries"][0]["details"][0]["runs"]
+    runs = payload["blocks"][0]["data"]["sections"][0]["entries"][0]["details"][0][
+        "runs"
+    ]
 
     assert all("color" not in run for run in runs)
     assert all("url" not in run for run in runs)
@@ -939,6 +1002,7 @@ def test_build_document_render_payload_omits_none_in_page_template_runs():
 def test_paragraph_run_rejects_invalid_hyperlink_url(url: str):
     with pytest.raises(ValidationError, match="http, https, or mailto"):
         ParagraphRun(text="错误链接", url=url)
+
 
 def test_build_document_render_payload_omits_unset_heading_bottom_border():
     document = DocumentModel(
@@ -985,6 +1049,7 @@ def test_build_document_render_payload_omits_none_hero_banner_fields():
     assert "subtitle_color" not in hero_banner
     assert "min_height_pt" not in hero_banner
 
+
 def test_normalize_raw_block_payloads_moves_legacy_layout_alignment_into_style():
     normalized = normalize_raw_block_payloads(
         [
@@ -1000,6 +1065,7 @@ def test_normalize_raw_block_payloads_moves_legacy_layout_alignment_into_style()
     assert normalized[0]["type"] == "paragraph"
     assert normalized[0]["style"]["align"] == "right"
     assert normalized[0]["layout"] == {"spacing_after": 6}
+
 
 def test_create_document_request_normalizes_document_style():
     request = CreateDocumentRequest(
@@ -1070,6 +1136,7 @@ def test_create_document_request_normalizes_document_style():
     assert request.document_style.table_defaults.caption_emphasis == "strong"
     assert request.document_style.table_defaults.cell_align == "center"
 
+
 def test_create_document_request_rejects_invalid_document_style_heading_color():
     with pytest.raises(ValidationError):
         CreateDocumentRequest(
@@ -1079,6 +1146,7 @@ def test_create_document_request_rejects_invalid_document_style_heading_color():
                 "heading_color": "blue",
             },
         )
+
 
 def test_create_document_request_rejects_invalid_table_defaults_header_fill():
     with pytest.raises(ValidationError):
@@ -1091,6 +1159,7 @@ def test_create_document_request_rejects_invalid_table_defaults_header_fill():
                 },
             },
         )
+
 
 def test_add_blocks_request_rejects_invalid_hero_banner_colors():
     with pytest.raises(ValidationError, match="6-digit hex color"):
@@ -1105,6 +1174,7 @@ def test_add_blocks_request_rejects_invalid_hero_banner_colors():
             ],
         )
 
+
 def test_create_document_request_defaults_nested_document_style_sections():
     request = CreateDocumentRequest(
         title="Nested Defaults",
@@ -1117,6 +1187,7 @@ def test_create_document_request_defaults_nested_document_style_sections():
     assert request.document_style.table_defaults is not None
     assert request.document_style.summary_card_defaults.title_align is None
     assert request.document_style.table_defaults.header_fill is None
+
 
 def test_create_document_request_normalizes_blank_document_style_colors_to_none():
     request = CreateDocumentRequest(
@@ -1136,6 +1207,7 @@ def test_create_document_request_normalizes_blank_document_style_colors_to_none(
     assert request.document_style.table_defaults.header_fill is None
     assert request.document_style.table_defaults.header_text_color is None
     assert request.document_style.table_defaults.banded_row_fill is None
+
 
 def test_create_document_request_rejects_extra_document_style_keys():
     with pytest.raises(ValidationError):
@@ -1159,6 +1231,7 @@ def test_create_document_request_rejects_extra_document_style_keys():
             },
         )
 
+
 @pytest.mark.parametrize("body_font_size", [8, 17])
 def test_create_document_request_rejects_out_of_range_body_font_size(body_font_size):
     with pytest.raises(ValidationError):
@@ -1169,6 +1242,7 @@ def test_create_document_request_rejects_out_of_range_body_font_size(body_font_s
                 "body_font_size": body_font_size,
             },
         )
+
 
 @pytest.mark.parametrize("body_line_spacing", [0.9, 2.6])
 def test_create_document_request_rejects_out_of_range_body_line_spacing(
@@ -1182,6 +1256,7 @@ def test_create_document_request_rejects_out_of_range_body_line_spacing(
                 "body_line_spacing": body_line_spacing,
             },
         )
+
 
 @pytest.mark.parametrize("title_font_scale", [0.5, 2.5])
 def test_create_document_request_rejects_out_of_range_title_font_scale(
@@ -1197,6 +1272,7 @@ def test_create_document_request_rejects_out_of_range_title_font_scale(
                 },
             },
         )
+
 
 @pytest.mark.parametrize(
     "field_name,value",
@@ -1218,6 +1294,7 @@ def test_create_document_request_rejects_out_of_range_document_spacing_fields(
                 field_name: value,
             },
         )
+
 
 @pytest.mark.parametrize(
     "field_name,value",
@@ -1243,6 +1320,7 @@ def test_create_document_request_rejects_out_of_range_summary_card_spacing_field
                 },
             },
         )
+
 
 def test_table_schema_normalizers_are_shared():
     request = AddTableRequest(
@@ -1304,6 +1382,7 @@ def test_table_schema_normalizers_are_shared():
     assert section.border_style == "minimal"
     assert section.caption_emphasis == "normal"
 
+
 def test_add_table_request_rejects_grouped_header_span_total_mismatch():
     with pytest.raises(
         ValidationError,
@@ -1316,6 +1395,7 @@ def test_add_table_request_rejects_grouped_header_span_total_mismatch():
             header_groups=[{"title": "经营数据", "span": 1}],
         )
 
+
 def test_section_table_input_rejects_grouped_header_span_below_minimum():
     with pytest.raises(ValidationError, match="greater than or equal to 1"):
         SectionTableInput(
@@ -1323,6 +1403,7 @@ def test_section_table_input_rejects_grouped_header_span_below_minimum():
             rows=[["华东", "120"]],
             header_groups=[{"title": "经营数据", "span": 0}],
         )
+
 
 @pytest.mark.parametrize(
     "field_name", ["header_fill", "header_text_color", "banded_row_fill"]
@@ -1349,6 +1430,7 @@ def test_add_table_request_rejects_invalid_color_fields(
     with pytest.raises(ValidationError, match="6-digit hex color"):
         AddTableRequest(**kwargs)
 
+
 @pytest.mark.parametrize(
     "field_name", ["header_fill", "header_text_color", "banded_row_fill"]
 )
@@ -1373,6 +1455,7 @@ def test_section_table_input_rejects_invalid_color_fields(
     with pytest.raises(ValidationError, match="6-digit hex color"):
         SectionTableInput(**kwargs)
 
+
 def test_section_table_input_rejects_invalid_border_style():
     with pytest.raises(ValidationError):
         SectionTableInput(
@@ -1381,12 +1464,14 @@ def test_section_table_input_rejects_invalid_border_style():
             border_style="heavy",
         )
 
+
 def test_table_block_rejects_header_groups_without_columns():
     with pytest.raises(
         ValidationError,
         match=r"header_groups require at least one column from headers or rows \(column_count=0\)",
     ):
         TableBlock(header_groups=[{"title": "经营数据", "span": 1}])
+
 
 def test_table_schema_allows_empty_placeholder_tables():
     request = AddTableRequest(document_id="doc-1", headers=[], rows=[])
@@ -1399,6 +1484,7 @@ def test_table_schema_allows_empty_placeholder_tables():
     assert section.rows == []
     assert block.headers == []
     assert block.rows == []
+
 
 def test_add_table_request_rejects_row_span_cells():
     with pytest.raises(ValidationError, match="row_span"):
@@ -1485,6 +1571,7 @@ def test_add_table_request_accepts_cells_with_both_text_and_runs():
     assert course_cell.text == "课程 A"
     assert "".join(run.text for run in course_cell.runs) == "课程 A"
 
+
 def test_add_table_request_rejects_underfilled_rows():
     with pytest.raises(ValidationError, match="table row 1 is missing cells"):
         AddTableRequest(
@@ -1492,6 +1579,7 @@ def test_add_table_request_rejects_underfilled_rows():
             headers=["日期", "时间", "课程"],
             rows=[["第一天", "09:00"]],
         )
+
 
 def test_add_blocks_request_accepts_accent_box_metric_cards_and_table_cell_styles():
     request = AddBlocksRequest(
@@ -1543,7 +1631,11 @@ def test_add_blocks_request_accepts_accent_box_metric_cards_and_table_cell_style
                             "align": "right",
                             "font_name": "Source Han Sans SC",
                             "border": {
-                                "top": {"style": "single", "color": "1F4E79", "width_pt": 0.75}
+                                "top": {
+                                    "style": "single",
+                                    "color": "1F4E79",
+                                    "width_pt": 0.75,
+                                }
                             },
                         },
                     ]
@@ -1718,6 +1810,7 @@ def test_build_document_render_payload_preserves_empty_border_side_objects():
     assert payload["blocks"][0]["border"]["bottom"] == {}
     assert payload["blocks"][1]["rows"][0][1]["border"]["top"] == {}
 
+
 def test_normalize_raw_block_payloads_flattens_nested_block_aliases():
     normalized = normalize_raw_block_payloads(
         [
@@ -1800,6 +1893,7 @@ def test_normalize_raw_block_payloads_flattens_nested_block_aliases():
     assert table["rows"][0][2]["text"] == "重点项目提前交付"
     assert paragraph["runs"][0]["text"] == "供应链风险："
     assert paragraph["style"]["align"] == "right"
+
 
 def test_add_blocks_request_accepts_hero_banner_and_report_style_fields():
     request = AddBlocksRequest(
@@ -1901,6 +1995,7 @@ def test_add_blocks_request_accepts_hero_banner_and_report_style_fields():
     assert table.cell_padding_horizontal_pt == pytest.approx(8)
     assert table.rows[0][1].font_scale == pytest.approx(1.2)
 
+
 def test_add_blocks_request_accepts_page_template_business_review_cover():
     request = AddBlocksRequest(
         document_id="doc-1",
@@ -1933,38 +2028,54 @@ def test_add_blocks_request_accepts_page_template_business_review_cover():
 
 
 def test_add_blocks_request_accepts_page_template_technical_resume():
-    request = AddBlocksRequest(
-        document_id="doc-1",
-        blocks=[
-            _technical_resume_block(
-                sections=[
+    resume_block = _technical_resume_block(
+        sections=[
+            {
+                "title": "教育背景",
+                "entries": [
                     {
-                        "title": "教育背景",
-                        "entries": [
+                        "heading": "北京大学",
+                        "date": "2019.09 – 2023.06",
+                        "subtitle": "计算机科学与技术  |  工学学士",
+                        "details": [
                             {
-                                "heading": "北京大学",
-                                "date": "2019.09 – 2023.06",
-                                "subtitle": "计算机科学与技术  |  工学学士",
-                                "details": [
-                                    "GPA 3.86/4.0，连续三年一等奖学金，排名前 5%"
-                                ],
+                                "runs": [
+                                    {"text": "GPA 3.86/4.0，", "bold": True},
+                                    {"text": "连续三年一等奖学金，排名前 5%"},
+                                ]
                             }
                         ],
-                    },
+                    }
+                ],
+            },
+            {
+                "title": "技术栈",
+                "lines": [
                     {
-                        "title": "技术栈",
-                        "lines": ["语言：Go（熟练）、Java（熟练）、Python、SQL"],
-                    },
-                ]
-            )
-        ],
+                        "runs": [
+                            {"text": "语言：Go（熟练）", "bold": True},
+                            {"text": "、Java（熟练）、Python、SQL"},
+                        ]
+                    }
+                ],
+            },
+        ]
+    )
+    resume_block["data"]["auto_page_break"] = True
+
+    request = AddBlocksRequest(
+        document_id="doc-1",
+        blocks=[resume_block],
     )
 
     block = request.blocks[0]
     assert block.template == "technical_resume"
     assert block.data.name == "张明远"
+    assert block.data.auto_page_break is True
     assert block.data.sections[0].entries[0].heading == "北京大学"
-    assert block.data.sections[1].lines[0] == "语言：Go（熟练）、Java（熟练）、Python、SQL"
+    assert block.data.sections[0].entries[0].details[0].runs[0].bold is True
+    assert block.data.sections[1].lines[0].runs[0].bold is True
+
 
 def test_add_blocks_request_rejects_table_cell_col_span():
     with pytest.raises(ValidationError, match="col_span"):

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -594,6 +594,16 @@ def test_normalize_raw_block_payloads_accepts_json_string_array():
     assert normalized == [{"type": "paragraph", "text": "正文"}]
 
 
+def test_normalize_raw_block_payloads_rejects_invalid_json_string():
+    with pytest.raises(ValueError, match="valid JSON array"):
+        normalize_raw_block_payloads("not-json")
+
+
+def test_normalize_raw_block_payloads_rejects_non_list_json_string():
+    with pytest.raises(ValueError, match="blocks must be a list"):
+        normalize_raw_block_payloads('{"type": "paragraph"}')
+
+
 def test_normalize_raw_block_payloads_repairs_technical_resume_section_heading_alias():
     normalized = normalize_raw_block_payloads(
         [
@@ -777,6 +787,20 @@ def test_normalize_create_document_kwargs_accepts_json_string_objects():
     assert normalized["document_style"]["font_name"] == "Microsoft YaHei"
     assert normalized["document_style"]["heading_color"] == "1F4E79"
     assert normalized["header_footer"]["footer_text"] == "内部资料"
+
+
+@pytest.mark.parametrize("field_name", ["document_style", "header_footer"])
+def test_normalize_create_document_kwargs_rejects_invalid_json_string(field_name: str):
+    with pytest.raises(ValueError, match=f"{field_name} must be valid JSON"):
+        normalize_create_document_kwargs({field_name: "not-json"})
+
+
+@pytest.mark.parametrize("field_name", ["document_style", "header_footer"])
+def test_normalize_create_document_kwargs_rejects_non_mapping_json_string(
+    field_name: str,
+):
+    with pytest.raises(ValueError, match=f"{field_name} must be a JSON object"):
+        normalize_create_document_kwargs({field_name: '["not", "an", "object"]'})
 
 
 def test_normalize_raw_block_payloads_rejects_excessive_nesting():

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -966,6 +966,54 @@ def test_node_renderer_supports_technical_resume_page_template(
     assert _paragraph_run_size(detail) == pytest.approx(10.0, abs=0.2)
 
 
+def test_node_renderer_supports_technical_resume_auto_page_break(
+    workspace_root: Path,
+):
+    resume_block = _technical_resume_block()
+    resume_block["data"]["auto_page_break"] = True
+
+    loaded_doc, _ = _render_structured_payload_with_node(
+        workspace_root,
+        "pytest-node-renderer-technical-resume-auto-break",
+        {
+            "document_id": "technical-resume-auto-break",
+            "metadata": _business_report_metadata(title=""),
+            "blocks": [resume_block],
+        },
+    )
+
+    assert any(
+        _paragraph_has_page_break(paragraph) for paragraph in loaded_doc.paragraphs
+    )
+
+
+def test_node_renderer_suppresses_technical_resume_auto_page_break_when_body_follows(
+    workspace_root: Path,
+):
+    resume_block = _technical_resume_block()
+    resume_block["data"]["auto_page_break"] = True
+
+    loaded_doc, _ = _render_structured_payload_with_node(
+        workspace_root,
+        "pytest-node-renderer-technical-resume-auto-break-suppressed",
+        {
+            "document_id": "technical-resume-auto-break-suppressed",
+            "metadata": _business_report_metadata(title=""),
+            "blocks": [
+                resume_block,
+                {"type": "heading", "text": "普通 AddBlocks 富文本列表", "level": 1},
+            ],
+        },
+    )
+
+    assert not any(
+        _paragraph_has_page_break(paragraph) for paragraph in loaded_doc.paragraphs
+    )
+    assert _find_paragraph(loaded_doc, "普通 AddBlocks 富文本列表").text == (
+        "普通 AddBlocks 富文本列表"
+    )
+
+
 def test_node_renderer_preserves_multiline_table_cell_text(workspace_root: Path):
     loaded_doc, _ = _render_structured_payload_with_node(
         workspace_root,

--- a/word_renderer_js/src/renderers/structured/page-templates/technical-resume.ts
+++ b/word_renderer_js/src/renderers/structured/page-templates/technical-resume.ts
@@ -2,6 +2,7 @@ import {
   AlignmentType,
   BorderStyle,
   LineRuleType,
+  PageBreak,
   Paragraph,
   TabStopType,
   TextRun,
@@ -13,6 +14,7 @@ import { FileChild, ThemeConfig } from "../types";
 import {
   arrayValue,
   asObject,
+  booleanValue,
   halfPoint,
   point,
   stringValue,
@@ -45,6 +47,14 @@ export function renderTechnicalResume(
 
   for (const rawSection of arrayValue(data.sections)) {
     children.push(...buildResumeSection(asObject(rawSection)));
+  }
+  if (booleanValue(data.auto_page_break) === true) {
+    children.push(
+      new Paragraph({
+        spacing: { before: point(4) },
+        children: [new PageBreak()],
+      }),
+    );
   }
 
   return children;


### PR DESCRIPTION
## 概述

修复 Word 文档工具在 DeepSeek 等模型调用下的参数兼容问题，避免合法的字符串化参数、富文本简历条目和简历 section 字段被验证拦截。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 让 `create_document` 接受 JSON 字符串形式的 `document_style` / `header_footer`，减少模型把对象序列化成字符串时的失败。
- 让 `add_blocks` 接受 JSON 字符串数组，避免逐字符进入 Pydantic 校验。
- 恢复 `technical_resume.details` / `lines` 的富文本对象 schema 提示，使模型可正常传 `runs`。
- 兼容 `technical_resume.sections[].heading`，在验证前转为 `title`，并在公共 schema 中明确要求使用 `title`。
- 让 `technical_resume.auto_page_break` 贯通到运行时模型和 Node 渲染器。

## 影响范围

- Word 文档工具的 `create_document`、`add_blocks`
- `technical_resume` 页面模板
- Node Word 渲染器的技术简历分页行为
- 面向模型的 `add_blocks` 公共 schema

## 测试情况

- [ ] 现有测试通过 (`pytest`)
- [x] 新增 / 更新了相关测试
- [x] 手动验证了核心场景

<details>
<summary>手动测试记录（可选）</summary>

- 使用同模型端到端生成 `add_blocks_schema_e2e.docx`，`add_blocks` 首次通过，没有再因 `technical_resume.sections` 字段失败。
- 检查 `add_blocks_schema_e2e (6).docx`，确认：
  - `technical_resume.details` 中 `富文本 detail：` 为加粗 run，后半句为普通 run。
  - `技术栈` 中 `Python / DOCX` 为加粗 run。
  - 第二页有序列表富文本正常。
  - 表格为 4 行 3 列。
  - 文档包含 1 个分页符。
- 运行过：
  - `ruff check agent_tools\document_tools.py domain\document\contracts.py document_core\models\blocks.py domain\document\session_store.py`
  - `ruff format --check agent_tools\document_tools.py domain\document\contracts.py tests\test_office_assistant_contracts.py tests\test_office_assistant_agent_tools.py`
  - `npm run build`
  - targeted pytest for contracts, agent tools, and Node renderer
  - `git diff --check`

</details>

## 备注

未跑全量 `pytest`。本次验证集中在 Word 工具参数规范化、`technical_resume` schema、富文本条目和 Node 渲染相关回归。

## Summary by Sourcery

放宽 Word 文档工具的输入校验，以更好地处理字符串化的载荷，并增强对技术简历的支持，同时将自动分页能力贯通至 Node 渲染器。

Bug Fixes:
- 允许 `add_blocks` 接受以 JSON 字符串数组形式传入的 blocks，并在校验前安全地对其进行规范化处理。
- 在创建文档时，将字符串化的 `document_style` 和 `header_footer` 对象强制转换为映射（mapping），并丢弃无效的非映射输入。
- 规范化使用 `heading` 字段的 `technical_resume` 区块，使其转换为 `title`，以保证旧版载荷仍能工作。
- 恢复 `technical_resume` 中 `details` 与 `lines` 的富文本兼容 schema，使基于 runs 的内容可以被接受并正确渲染。

Enhancements:
- 通过请求模型、运行时模型以及 Node 渲染器暴露 `technical_resume` 的 `auto_page_break`，从 schema 级数据控制分页行为。
- 收紧并明确 `technical_resume` 各 section 的公共 JSON schema，使模型必须使用 `title` 而非 `heading`，并且可以发送带 `runs` 的富列表项对象。

Tests:
- 扩展契约测试、agent 工具测试以及 Node 渲染器测试，以覆盖 JSON 字符串载荷处理、`technical_resume` 的 schema 预期以及 `auto_page_break` 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax Word document tool input validation to better handle stringified payloads and enrich technical resume support, while wiring auto page breaks through to the Node renderer.

Bug Fixes:
- Allow add_blocks to accept blocks passed as a JSON string array and normalize them safely before validation.
- Coerce stringified document_style and header_footer objects into mappings when creating documents, dropping invalid non-mapping inputs.
- Normalize technical_resume sections that use heading into title to keep legacy payloads working.
- Restore rich-text-compatible schemas for technical_resume details and lines so runs-based content is accepted and rendered correctly.

Enhancements:
- Expose technical_resume auto_page_break through the request models, runtime models, and Node renderer to control page breaks from schema-level data.
- Tighten and clarify the public JSON schema for technical_resume sections so models must use title instead of heading and can send rich list item objects with runs.

Tests:
- Extend contract, agent tool, and Node renderer tests to cover JSON-string payload handling, technical_resume schema expectations, and auto_page_break behavior.

</details>