### PR TITLE
fix: hint add_blocks callers when dispatcher degrades to empty kwargs

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -896,6 +896,11 @@ class AddBlocksTool(DocumentToolBase):
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
         if not kwargs:
+            logger.warning(
+                "add_blocks received empty kwargs; dispatcher likely degraded "
+                "upstream JSON parsing (payload too large or contains unescaped "
+                "characters). Returning split-payload hint to the model."
+            )
             return _dump_result(
                 ToolResult(
                     success=False,

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -37,6 +37,11 @@ def _dump_result(result: ToolResult) -> str:
 
 _CONTINUE_UNTIL_EXPORT = "请继续调用文档工具，直到 export_document 成功"
 _FINALIZE_PROMPT = "文档已定稿。下一步只能调用 export_document 导出文件，不要再调用 add_blocks、create_document 或 finalize_document"
+_ADD_BLOCKS_EMPTY_KWARGS_HINT = (
+    "add_blocks 收到空参数调用。这通常是因为上一轮工具调用的 JSON 过长或含"
+    "未转义字符，在上游解析失败后被降级为空参数。请拆分内容为多次 add_blocks 调用："
+    "每次只放 3-5 个短 block，长段落可分段写入，使用同一个 document_id 继续调用。"
+)
 
 
 _STYLE_SCHEMA = {
@@ -890,6 +895,13 @@ class AddBlocksTool(DocumentToolBase):
     async def call(
         self, context: ContextWrapper[AstrAgentContext], **kwargs
     ) -> ToolExecResult:
+        if not kwargs:
+            return _dump_result(
+                ToolResult(
+                    success=False,
+                    message=_ADD_BLOCKS_EMPTY_KWARGS_HINT,
+                )
+            )
         try:
             raw_blocks = normalize_raw_block_payloads(kwargs.get("blocks") or [])
             request = AddBlocksRequest(

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -465,6 +465,24 @@ async def test_add_blocks_failure_message_keeps_model_on_same_tool(
 
 
 @pytest.mark.asyncio
+async def test_add_blocks_returns_hint_when_dispatcher_degrades_to_empty_kwargs(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-add-blocks-empty-kwargs"
+    )
+    toolset = build_document_toolset(workspace_dir=workspace_dir)
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    result = json.loads(await tool_by_name["add_blocks"].call(None))
+
+    assert result["success"] is False
+    assert "add_blocks 收到空参数调用" in result["message"]
+    assert "拆分" in result["message"]
+    assert "3-5 个短 block" in result["message"]
+
+
+@pytest.mark.asyncio
 async def test_add_blocks_tool_accepts_json_string_blocks(workspace_root: Path):
     workspace_dir = _make_workspace(workspace_root, "pytest-agent-tools-json-blocks")
     toolset = build_document_toolset(workspace_dir=workspace_dir)

--- a/tests/test_office_assistant_agent_tools.py
+++ b/tests/test_office_assistant_agent_tools.py
@@ -467,6 +467,7 @@ async def test_add_blocks_failure_message_keeps_model_on_same_tool(
 @pytest.mark.asyncio
 async def test_add_blocks_returns_hint_when_dispatcher_degrades_to_empty_kwargs(
     workspace_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ):
     workspace_dir = _make_workspace(
         workspace_root, "pytest-agent-tools-add-blocks-empty-kwargs"
@@ -474,12 +475,22 @@ async def test_add_blocks_returns_hint_when_dispatcher_degrades_to_empty_kwargs(
     toolset = build_document_toolset(workspace_dir=workspace_dir)
     tool_by_name = {tool.name: tool for tool in toolset.tools}
 
+    from astrbot_plugin_office_assistant.agent_tools import document_tools
+
+    warning_calls: list[str] = []
+    monkeypatch.setattr(
+        document_tools.logger,
+        "warning",
+        lambda msg, *args, **kwargs: warning_calls.append(str(msg)),
+    )
+
     result = json.loads(await tool_by_name["add_blocks"].call(None))
 
     assert result["success"] is False
     assert "add_blocks 收到空参数调用" in result["message"]
     assert "拆分" in result["message"]
     assert "3-5 个短 block" in result["message"]
+    assert any("add_blocks received empty kwargs" in msg for msg in warning_calls)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #64

## 概述

  `add_blocks` 在上游调度器把参数降级为空 kwargs 时直接返回可操作的中文提示，引导模型拆分
  长内容重新调用，避免反复触发同一解析失败后模型读不出根因。

  ## 改动类型

  - [x] Bug 修复
  - [ ] 新功能
  - [ ] 重构 / 代码优化
  - [ ] 文档 / 注释
  - [ ] 性能优化
  - [x] 测试
  - [ ] 配置 / 构建 / CI
  - [ ] 安全相关

  ## 关键改动

  - **文档工具兜底**：`AddBlocksTool` 在空 kwargs 时短路返回明确的拆分指引（3-5 个 block /
   复用 `document_id`），不再让请求继续跑到下游抛通用校验错误。空 kwargs 通常来自上游 JSON
   过长或未转义字符导致的解析降级，换成可执行提示后模型能直接修正调用策略。
  -
  **回归测试**：补一条空参数用例，固定住兜底提示的文案关键字，避免后续被无意改回通用错误。

  ## 影响范围

  - Agent 侧所有调用 `add_blocks`
  的写入流程：空参数路径从"通用失败"变成"带拆分指引的失败"，正常参数路径完全不变。
  - `AddBlocksTool.call` 的返回契约：仍为 `_dump_result` 序列化的 JSON
  字符串，结构未变，下游解析不受影响。

  ## 测试情况

  - [x] 现有测试通过 (`pytest`)
  - [x] 新增 / 更新了相关测试
  - [ ] 手动验证了核心场景

  <details>
  <summary>手动测试记录（可选）</summary>

  只跑了针对性用例 `pytest tests/test_office_assistant_agent_tools.py -k
  add_blocks`，未做端到端联调。

  </details>

## Summary by Sourcery

在调用 `add_blocks` 文档工具且 `kwargs` 为空时，用带有描述性提示的信息进行处理，而不是返回泛泛的失败结果。

Bug 修复：
- 当以空的 `kwargs` 调用 `AddBlocksTool` 时，返回带有指导信息的结构化失败响应，避免在后续处理过程中出现晦涩难懂的验证错误。

测试：
- 添加回归测试，以验证当调度器退化为一次空 `kwargs` 调用时，`add_blocks` 会返回预期的提示信息并记录一条警告日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty-kwargs invocations of the add_blocks document tool with a descriptive hint instead of a generic failure.

Bug Fixes:
- Return a structured failure response with guidance when AddBlocksTool is called with empty kwargs, avoiding opaque validation errors from downstream processing.

Tests:
- Add a regression test to verify add_blocks returns the expected hint message and logs a warning when the dispatcher degrades to an empty-kwargs call.

</details>

Bug 修复：
- 当以空的 kwargs 调用 AddBlocksTool 时，返回一条描述性指导信息，解释可能的 JSON 解析问题，以及如何通过多次调用来拆分内容

测试：
- 添加回归测试，确保当调度器退化为以空 kwargs 调用时，add_blocks 会返回特定的提示信息

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在调用 `add_blocks` 文档工具且 `kwargs` 为空时，用带有描述性提示的信息进行处理，而不是返回泛泛的失败结果。

Bug 修复：
- 当以空的 `kwargs` 调用 `AddBlocksTool` 时，返回带有指导信息的结构化失败响应，避免在后续处理过程中出现晦涩难懂的验证错误。

测试：
- 添加回归测试，以验证当调度器退化为一次空 `kwargs` 调用时，`add_blocks` 会返回预期的提示信息并记录一条警告日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty-kwargs invocations of the add_blocks document tool with a descriptive hint instead of a generic failure.

Bug Fixes:
- Return a structured failure response with guidance when AddBlocksTool is called with empty kwargs, avoiding opaque validation errors from downstream processing.

Tests:
- Add a regression test to verify add_blocks returns the expected hint message and logs a warning when the dispatcher degrades to an empty-kwargs call.

</details>

</details>