### PR TITLE
fix: add explicit object type to add_blocks rich list schema

### DIFF
--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -201,7 +201,7 @@ _TABLE_CELL_SCHEMA = {
 _STRING_PUBLIC_SCHEMA = {"type": "string"}
 _RICH_LIST_ITEM_PUBLIC_SCHEMA = {
     "type": "object",
-    "description": "Rich list item object with text/runs. Plain strings are also accepted by runtime validation.",
+    "description": "Rich list item object with text and optional inline rich-text runs.",
     "properties": {
         "text": {"type": "string"},
         "runs": {

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -200,6 +200,7 @@ _TABLE_CELL_SCHEMA = {
 
 _STRING_PUBLIC_SCHEMA = {"type": "string"}
 _RICH_LIST_ITEM_PUBLIC_SCHEMA = {
+    "type": "object",
     "description": "Rich list item object with text/runs. Plain strings are also accepted by runtime validation.",
     "properties": {
         "text": {"type": "string"},

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -201,7 +201,7 @@ _TABLE_CELL_SCHEMA = {
 _STRING_PUBLIC_SCHEMA = {"type": "string"}
 _RICH_LIST_ITEM_PUBLIC_SCHEMA = {
     "type": "object",
-    "description": "Rich list item object with text and optional inline rich-text runs.",
+    "description": 'Rich list item object with text and optional inline rich-text runs. Always use this object form in tool calls, for example {"text": "detail"}.',
     "properties": {
         "text": {"type": "string"},
         "runs": {

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -261,6 +261,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert resume_section_item_schema["required"] == ["title"]
     assert resume_section_schema["title"]["type"] == "string"
     assert resume_detail_schema["type"] == "object"
+    assert "Plain strings" not in resume_detail_schema["description"]
     assert resume_detail_schema["properties"]["text"]["type"] == "string"
     assert resume_detail_schema["properties"]["runs"]["type"] == "array"
     assert (
@@ -270,6 +271,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         == "boolean"
     )
     assert resume_line_schema["type"] == "object"
+    assert "Plain strings" not in resume_line_schema["description"]
     assert resume_line_schema["properties"]["text"]["type"] == "string"
     assert resume_line_schema["properties"]["runs"]["type"] == "array"
     assert (

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -260,7 +260,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     resume_line_schema = resume_section_schema["lines"]["items"]
     assert resume_section_item_schema["required"] == ["title"]
     assert resume_section_schema["title"]["type"] == "string"
-    assert "type" not in resume_detail_schema
+    assert resume_detail_schema["type"] == "object"
     assert resume_detail_schema["properties"]["text"]["type"] == "string"
     assert resume_detail_schema["properties"]["runs"]["type"] == "array"
     assert (
@@ -269,7 +269,7 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         ]
         == "boolean"
     )
-    assert "type" not in resume_line_schema
+    assert resume_line_schema["type"] == "object"
     assert resume_line_schema["properties"]["text"]["type"] == "string"
     assert resume_line_schema["properties"]["runs"]["type"] == "array"
     assert (

--- a/tests/test_office_assistant_contracts.py
+++ b/tests/test_office_assistant_contracts.py
@@ -261,7 +261,8 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
     assert resume_section_item_schema["required"] == ["title"]
     assert resume_section_schema["title"]["type"] == "string"
     assert resume_detail_schema["type"] == "object"
-    assert "Plain strings" not in resume_detail_schema["description"]
+    assert "Always use this object form" in resume_detail_schema["description"]
+    assert "legacy plain string values" not in resume_detail_schema["description"]
     assert resume_detail_schema["properties"]["text"]["type"] == "string"
     assert resume_detail_schema["properties"]["runs"]["type"] == "array"
     assert (
@@ -271,7 +272,8 @@ def test_add_blocks_tool_schema_keeps_nested_array_items_for_gemini():
         == "boolean"
     )
     assert resume_line_schema["type"] == "object"
-    assert "Plain strings" not in resume_line_schema["description"]
+    assert "Always use this object form" in resume_line_schema["description"]
+    assert "legacy plain string values" not in resume_line_schema["description"]
     assert resume_line_schema["properties"]["text"]["type"] == "string"
     assert resume_line_schema["properties"]["runs"]["type"] == "array"
     assert (

--- a/tests/test_office_assistant_document_tools.py
+++ b/tests/test_office_assistant_document_tools.py
@@ -1759,14 +1759,14 @@ def test_add_blocks_tool_schema_hides_table_cell_spans():
     assert resume_sections["title"]["description"].endswith(
         "Use title here; do not use heading."
     )
-    assert "type" not in resume_detail_schema
+    assert resume_detail_schema["type"] == "object"
     assert (
         resume_detail_schema["properties"]["runs"]["items"]["properties"]["bold"][
             "type"
         ]
         == "boolean"
     )
-    assert "type" not in resume_line_schema
+    assert resume_line_schema["type"] == "object"
     assert (
         resume_line_schema["properties"]["runs"]["items"]["properties"]["bold"]["type"]
         == "boolean"


### PR DESCRIPTION
## 概述

修复部分 OpenAI-compatible / Gemini 转发端点在普通聊天时也会因 `add_blocks` 工具 schema 校验失败而返回 400 的问题。

该问题不是模型实际调用了 `add_blocks`，而是 provider 在请求阶段校验所有已暴露工具 schema；`_RICH_LIST_ITEM_PUBLIC_SCHEMA` 缺少显式 `"type": "object"`，导致严格 schema provider 拒绝请求。

## 改动类型

- [x] Bug 修复
- [ ] 新功能
- [ ] 重构 / 代码优化
- [ ] 文档 / 注释
- [ ] 性能优化
- [x] 测试
- [ ] 配置 / 构建 / CI
- [ ] 安全相关

## 关键改动

- 为 `_RICH_LIST_ITEM_PUBLIC_SCHEMA` 补充 `"type": "object"`。
- 更新 `add_blocks` schema 相关测试断言，确保 rich list item schema 明确声明 object 类型。

## 影响范围

- `add_blocks` 工具 schema
- 技术简历模板中 `details` / `lines` 的富文本列表项 schema
- 严格校验工具 schema 的 OpenAI-compatible provider

## 测试情况

- [x] 现有相关测试通过
- [x] 新增 / 更新了相关测试
- [ ] 手动验证了真实 provider 请求

- [x] 相关 schema 测试通过
- [x] `ruff check agent_tools/document_tools.py` 通过
- [x] 已遍历 Office 工具 schema，未发现缺少 object `type`、缺少 array `items`、`type` 列表、`anyOf` / `oneOf` / `allOf`
- [x] 已在端到端真实环境里通过

## Summary by Sourcery

确保 `add_blocks` 的富列表项（rich list item）模式架构显式声明对象类型，并使测试与更新后的模式架构保持一致。

Bug Fixes:
- 为 `add_blocks` 使用的富列表项模式架构添加显式的对象类型声明，以满足严格的、兼容 OpenAI 和 Gemini 的工具模式验证要求。

Tests:
- 更新 `add_blocks` 工具模式测试，用于期望富列表项模式为一个对象，而不再描述其可接受纯字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the add_blocks rich list item schema explicitly declares object type and aligns tests with the updated schema.

Bug Fixes:
- Add an explicit object type to the rich list item schema used by add_blocks to satisfy strict OpenAI-compatible and Gemini tool schema validation.

Tests:
- Update add_blocks tool schema tests to expect the rich list item schema to be an object and no longer describe accepting plain strings.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保 `add_blocks` 的富列表项（rich list item）模式架构显式声明对象类型，并使测试与更新后的模式架构保持一致。

Bug Fixes:
- 为 `add_blocks` 使用的富列表项模式架构添加显式的对象类型声明，以满足严格的、兼容 OpenAI 和 Gemini 的工具模式验证要求。

Tests:
- 更新 `add_blocks` 工具模式测试，用于期望富列表项模式为一个对象，而不再描述其可接受纯字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the add_blocks rich list item schema explicitly declares object type and aligns tests with the updated schema.

Bug Fixes:
- Add an explicit object type to the rich list item schema used by add_blocks to satisfy strict OpenAI-compatible and Gemini tool schema validation.

Tests:
- Update add_blocks tool schema tests to expect the rich list item schema to be an object and no longer describe accepting plain strings.

</details>

</details>