### PR TITLE
feat: write_rows 新增 number_formats 列级数字格式

### DIFF
--- a/agent_tools/workbook_tools.py
+++ b/agent_tools/workbook_tools.py
@@ -177,6 +177,11 @@ class WriteRowsTool(WorkbookToolBase):
                             "description": "Column letter to width mapping, e.g. {'A': 20, 'B': 35}.",
                             "additionalProperties": {"type": "number"},
                         },
+                        "number_formats": {
+                            "type": "object",
+                            "description": "Column letter to Excel number format, e.g. {'B': '#,##0.00', 'C': '0.00%', 'D': 'yyyy-mm-dd'}.",
+                            "additionalProperties": {"type": "string"},
+                        },
                         "autofilter": {
                             "type": "boolean",
                             "description": "Enable autofilter on the sheet header row.",

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -150,7 +150,11 @@ class WriteRowsOptions(BaseModel):
                 raise ValueError(
                     f"number_formats key '{key}' exceeds maximum column XFD"
                 )
-            clean_fmt = fmt.strip() if isinstance(fmt, str) else ""
+            if not isinstance(fmt, str):
+                raise ValueError(
+                    f"number_formats value must be a string, got {type(fmt).__name__} for column '{col}'"
+                )
+            clean_fmt = fmt.strip()
             if not clean_fmt:
                 raise ValueError(
                     f"number_formats value must be a non-empty format string, got '{fmt}' for column '{col}'"

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -82,6 +82,7 @@ class WriteRowsOptions(BaseModel):
 
     freeze_panes: str | None = None
     column_widths: dict[str, float] | None = None
+    number_formats: dict[str, str] | None = None
     autofilter: bool | None = None
 
     @field_validator("freeze_panes")
@@ -103,9 +104,7 @@ class WriteRowsOptions(BaseModel):
                 f"freeze_panes column must not exceed XFD ({MAX_EXCEL_COLUMN} columns)"
             )
         if int(row_str) > MAX_EXCEL_ROW:
-            raise ValueError(
-                f"freeze_panes row must not exceed {MAX_EXCEL_ROW}"
-            )
+            raise ValueError(f"freeze_panes row must not exceed {MAX_EXCEL_ROW}")
         return candidate
 
     @field_validator("column_widths")
@@ -131,6 +130,31 @@ class WriteRowsOptions(BaseModel):
                     f"column_widths value must be between 1.0 and 255.0, got {width} for column '{col}'"
                 )
             normalized[col] = width
+        return normalized
+
+    @field_validator("number_formats")
+    @classmethod
+    def validate_number_formats(
+        cls, value: dict[str, str] | None
+    ) -> dict[str, str] | None:
+        if value is None:
+            return None
+        normalized: dict[str, str] = {}
+        for key, fmt in value.items():
+            col = str(key).strip().upper()
+            if not _COLUMN_LETTER_PATTERN.match(col):
+                raise ValueError(
+                    f"number_formats key must be a column letter (A-XFD), got '{key}'"
+                )
+            if _column_letter_to_index(col) > MAX_EXCEL_COLUMN:
+                raise ValueError(
+                    f"number_formats key '{key}' exceeds maximum column XFD"
+                )
+            if not isinstance(fmt, str) or not fmt.strip():
+                raise ValueError(
+                    f"number_formats value must be a non-empty format string, got '{fmt}' for column '{col}'"
+                )
+            normalized[col] = fmt.strip()
         return normalized
 
 

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -154,7 +154,7 @@ class WriteRowsOptions(BaseModel):
                 raise ValueError(
                     f"number_formats value must be a non-empty format string, got '{fmt}' for column '{col}'"
                 )
-            normalized[col] = fmt.strip()
+            normalized[col] = fmt
         return normalized
 
 

--- a/domain/workbook/contracts.py
+++ b/domain/workbook/contracts.py
@@ -150,11 +150,12 @@ class WriteRowsOptions(BaseModel):
                 raise ValueError(
                     f"number_formats key '{key}' exceeds maximum column XFD"
                 )
-            if not isinstance(fmt, str) or not fmt.strip():
+            clean_fmt = fmt.strip() if isinstance(fmt, str) else ""
+            if not clean_fmt:
                 raise ValueError(
                     f"number_formats value must be a non-empty format string, got '{fmt}' for column '{col}'"
                 )
-            normalized[col] = fmt
+            normalized[col] = clean_fmt
         return normalized
 
 

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -21,7 +21,9 @@ def export_workbook_to_xlsx(workbook: WorkbookModel, output_path: Path) -> Path:
         workbook_writer.remove(default_sheet)
         for worksheet_model in workbook.worksheets:
             worksheet = workbook_writer.create_sheet(title=worksheet_model.name)
-            _write_worksheet_rows(worksheet, worksheet_model.rows)
+            _write_worksheet_rows(
+                worksheet, worksheet_model.rows, worksheet_model.header_row
+            )
             _apply_worksheet_options(worksheet, worksheet_model)
     else:
         default_sheet.title = "Sheet1"
@@ -31,12 +33,14 @@ def export_workbook_to_xlsx(workbook: WorkbookModel, output_path: Path) -> Path:
     return output_path
 
 
-def _write_worksheet_rows(worksheet, rows: list[list[object]]) -> None:
+def _write_worksheet_rows(
+    worksheet, rows: list[list[object]], header_row: int = 1
+) -> None:
     for row_index, row in enumerate(rows, start=1):
         for column_index, value in enumerate(row, start=1):
             cell = worksheet.cell(row=row_index, column=column_index, value=value)
             cell.alignment = DEFAULT_ALIGNMENT
-            if row_index == 1:
+            if row_index == header_row:
                 cell.font = HEADER_FONT
                 cell.fill = HEADER_FILL
 
@@ -56,8 +60,9 @@ def _apply_worksheet_options(worksheet, worksheet_model) -> None:
         formats = {
             column_index_from_string(k): v for k, v in options.number_formats.items()
         }
+        header = worksheet_model.header_row
         for row_index, row_data in enumerate(worksheet_model.rows, start=1):
-            if row_index > 1:
+            if row_index != header:
                 for col_idx, fmt in formats.items():
                     if col_idx <= len(row_data):
                         worksheet.cell(

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -52,11 +52,17 @@ def _apply_worksheet_options(worksheet, worksheet_model) -> None:
     for column_letter, width in options.column_widths.items():
         worksheet.column_dimensions[column_letter].width = width
 
-    for column_letter, fmt in options.number_formats.items():
-        col_idx = column_index_from_string(column_letter)
-        for row_index in range(2, len(worksheet_model.rows) + 1):
-            cell = worksheet.cell(row=row_index, column=col_idx)
-            cell.number_format = fmt
+    if options.number_formats:
+        formats = {
+            column_index_from_string(k): v for k, v in options.number_formats.items()
+        }
+        for row_index, row_data in enumerate(worksheet_model.rows, start=1):
+            if row_index > 1:
+                for col_idx, fmt in formats.items():
+                    if col_idx <= len(row_data):
+                        worksheet.cell(
+                            row=row_index, column=col_idx
+                        ).number_format = fmt
 
     if options.autofilter and worksheet_model.rows:
         worksheet.auto_filter.ref = worksheet.dimensions

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import column_index_from_string
 
 from .models import WorkbookModel
 
@@ -50,6 +51,12 @@ def _apply_worksheet_options(worksheet, worksheet_model) -> None:
 
     for column_letter, width in options.column_widths.items():
         worksheet.column_dimensions[column_letter].width = width
+
+    for column_letter, fmt in options.number_formats.items():
+        col_idx = column_index_from_string(column_letter)
+        for row_index in range(2, len(worksheet_model.rows) + 1):
+            cell = worksheet.cell(row=row_index, column=col_idx)
+            cell.number_format = fmt
 
     if options.autofilter and worksheet_model.rows:
         worksheet.auto_filter.ref = worksheet.dimensions

--- a/domain/workbook/exporter.py
+++ b/domain/workbook/exporter.py
@@ -21,10 +21,9 @@ def export_workbook_to_xlsx(workbook: WorkbookModel, output_path: Path) -> Path:
         workbook_writer.remove(default_sheet)
         for worksheet_model in workbook.worksheets:
             worksheet = workbook_writer.create_sheet(title=worksheet_model.name)
-            _write_worksheet_rows(
-                worksheet, worksheet_model.rows, worksheet_model.header_row
-            )
-            _apply_worksheet_options(worksheet, worksheet_model)
+            header = worksheet_model.header_row or 1
+            _write_worksheet_rows(worksheet, worksheet_model.rows, header)
+            _apply_worksheet_options(worksheet, worksheet_model, header)
     else:
         default_sheet.title = "Sheet1"
 
@@ -45,7 +44,7 @@ def _write_worksheet_rows(
                 cell.fill = HEADER_FILL
 
 
-def _apply_worksheet_options(worksheet, worksheet_model) -> None:
+def _apply_worksheet_options(worksheet, worksheet_model, header_row: int = 1) -> None:
     options = getattr(worksheet_model, "options", None)
     if options is None:
         return
@@ -60,9 +59,8 @@ def _apply_worksheet_options(worksheet, worksheet_model) -> None:
         formats = {
             column_index_from_string(k): v for k, v in options.number_formats.items()
         }
-        header = worksheet_model.header_row
         for row_index, row_data in enumerate(worksheet_model.rows, start=1):
-            if row_index != header:
+            if row_index != header_row:
                 for col_idx, fmt in formats.items():
                     if col_idx <= len(row_data):
                         worksheet.cell(

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -37,6 +37,7 @@ class WorksheetOptions(BaseModel):
 
     freeze_panes: str = ""
     column_widths: dict[str, float] = Field(default_factory=dict)
+    number_formats: dict[str, str] = Field(default_factory=dict)
     autofilter: bool = False
 
 

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -47,6 +47,7 @@ class WorksheetModel(BaseModel):
     name: str
     rows: list[list[WorkbookCellValue]] = Field(default_factory=list)
     options: WorksheetOptions = Field(default_factory=WorksheetOptions)
+    header_row: int = 1
 
 
 class WorkbookMetadata(BaseModel):

--- a/domain/workbook/models.py
+++ b/domain/workbook/models.py
@@ -47,7 +47,7 @@ class WorksheetModel(BaseModel):
     name: str
     rows: list[list[WorkbookCellValue]] = Field(default_factory=list)
     options: WorksheetOptions = Field(default_factory=WorksheetOptions)
-    header_row: int = 1
+    header_row: int = 0
 
 
 class WorkbookMetadata(BaseModel):

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -156,6 +156,9 @@ class WorkbookSessionStore:
                 worksheet = WorksheetModel(name=request.sheet)
                 workbook.worksheets.append(worksheet)
 
+            if not worksheet.rows:
+                worksheet.header_row = request.start_row
+
             start_index = request.start_row - 1
             required_size = start_index + len(request.rows)
             while len(worksheet.rows) < required_size:

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -178,6 +178,8 @@ class WorkbookSessionStore:
             worksheet.options.freeze_panes = options.freeze_panes
         if options.column_widths:
             worksheet.options.column_widths.update(options.column_widths)
+        if options.number_formats:
+            worksheet.options.number_formats.update(options.number_formats)
         if options.autofilter is not None:
             worksheet.options.autofilter = options.autofilter
 

--- a/domain/workbook/session_store.py
+++ b/domain/workbook/session_store.py
@@ -156,9 +156,6 @@ class WorkbookSessionStore:
                 worksheet = WorksheetModel(name=request.sheet)
                 workbook.worksheets.append(worksheet)
 
-            if not worksheet.rows:
-                worksheet.header_row = request.start_row
-
             start_index = request.start_row - 1
             required_size = start_index + len(request.rows)
             while len(worksheet.rows) < required_size:
@@ -168,6 +165,8 @@ class WorkbookSessionStore:
                 worksheet.rows[start_index + offset] = list(row)
 
             if request.options is not None:
+                if worksheet.header_row == 0:
+                    worksheet.header_row = request.start_row
                 self._merge_options_locked(worksheet, request.options)
 
             workbook.remember_written_sheet(worksheet.name)

--- a/prompts/static/workbook_tools.py
+++ b/prompts/static/workbook_tools.py
@@ -18,10 +18,11 @@ def build_workbook_tools_core_notice() -> str:
         "\n"
         "[格式选项]\n"
         "- `write_rows` 支持可选 `options` 参数控制 Sheet 显示格式：\n"
-        "  - `freeze_panes`: 冻结窗格位置，如 \"A2\" 冻结首行，\"B3\" 冻结前两行和 A 列\n"
-        "  - `column_widths`: 列宽字典，如 {\"A\": 15, \"B\": 30}；不设置的列使用 Excel 默认宽度\n"
+        '  - `freeze_panes`: 冻结窗格位置，如 "A2" 冻结首行，"B3" 冻结前两行和 A 列\n'
+        '  - `column_widths`: 列宽字典，如 {"A": 15, "B": 30}；不设置的列使用 Excel 默认宽度\n'
+        '  - `number_formats`: 数字格式字典，如 {"B": "#,##0.00", "C": "0.00%", "D": "yyyy-mm-dd", "E": "¥#,##0.00"}；格式应用于数据行（跳过表头）\n'
         "  - `autofilter`: true 启用首行筛选\n"
-        "- 建议：数据表默认带 freeze_panes=\"A2\" + autofilter=true\n"
+        '- 建议：数据表默认带 freeze_panes="A2" + autofilter=true\n'
         "- options 可在任意一次 write_rows 中设置，多次设置同一 Sheet 会合并\n"
         "\n"
         "[边界说明]\n"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1202,3 +1202,45 @@ def test_write_rows_number_formats_skips_header_with_start_row(workspace_root: P
     assert sheet["B5"].number_format == "#,##0.00"
     assert sheet["C4"].number_format == "0.00%"
     assert sheet["C5"].number_format == "0.00%"
+
+
+def test_write_rows_number_formats_skips_header_after_preamble(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            start_row=1,
+            rows=[["Report Title"], ["Generated 2026-01-01"]],
+        )
+    )
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            start_row=3,
+            rows=[
+                ["Name", "Amount"],
+                ["Alice", 100.5],
+                ["Bob", 200.75],
+            ],
+            options=WriteRowsOptions(
+                number_formats={"B": "#,##0.00"},
+            ),
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+
+    assert sheet["B1"].number_format == "General"
+    assert sheet["B2"].number_format == "General"
+    assert sheet["B3"].number_format == "General"
+    assert sheet["B4"].number_format == "#,##0.00"
+    assert sheet["B5"].number_format == "#,##0.00"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1009,3 +1009,51 @@ def test_write_rows_merges_options_number_formats(workspace_root: Path):
     assert sheet["D2"].number_format == "yyyy-mm-dd"
     assert sheet["A2"].number_format == "General"
     assert sheet["B1"].number_format == "General"
+
+
+def test_write_rows_number_formats_merge_across_calls(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="merge_fmt.xlsx"))
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[
+                ["Product", "Price", "Rate", "Date"],
+                ["Widget", 19.99, 0.15, "2026-01-15"],
+                ["Gadget", 1250, 0.08, "2026-02-20"],
+            ],
+            options=WriteRowsOptions(
+                number_formats={"B": "#,##0.00"},
+            ),
+        )
+    )
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            start_row=4,
+            rows=[
+                ["Doohickey", 42.5, 0.25, "2026-03-10"],
+            ],
+            options=WriteRowsOptions(
+                number_formats={"C": "0.00%"},
+            ),
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+
+    assert sheet["B2"].number_format == "#,##0.00"
+    assert sheet["B3"].number_format == "#,##0.00"
+    assert sheet["B4"].number_format == "#,##0.00"
+    assert sheet["C2"].number_format == "0.00%"
+    assert sheet["C3"].number_format == "0.00%"
+    assert sheet["C4"].number_format == "0.00%"
+    assert sheet["A2"].number_format == "General"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1168,3 +1168,37 @@ def test_write_rows_number_formats_multi_letter_column_keys(workspace_root: Path
     assert sheet["AA3"].number_format == "#,##0.00"
     assert sheet["AB2"].number_format == "0.00%"
     assert sheet["AB3"].number_format == "0.00%"
+
+
+def test_write_rows_number_formats_skips_header_with_start_row(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            start_row=3,
+            rows=[
+                ["Name", "Amount", "Rate"],
+                ["Alice", 100.5, 0.12],
+                ["Bob", 200.75, 0.08],
+            ],
+            options=WriteRowsOptions(
+                number_formats={"B": "#,##0.00", "C": "0.00%"},
+            ),
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+
+    assert sheet["B3"].number_format == "General"
+    assert sheet["C3"].number_format == "General"
+    assert sheet["B4"].number_format == "#,##0.00"
+    assert sheet["B5"].number_format == "#,##0.00"
+    assert sheet["C4"].number_format == "0.00%"
+    assert sheet["C5"].number_format == "0.00%"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -978,3 +978,34 @@ def test_full_chain_with_options_produces_correct_xlsx(workspace_root: Path):
     assert sheet.auto_filter.ref == "A1:B3"
     assert sheet["A1"].value == "Name"
     assert sheet["B3"].value == 87
+
+
+def test_write_rows_merges_options_number_formats(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[
+                ["Product", "Price", "Rate", "Date"],
+                ["Widget", 19.99, 0.15, "2026-01-15"],
+                ["Gadget", 1250, 0.08, "2026-02-20"],
+            ],
+            options=WriteRowsOptions(
+                number_formats={"B": "¥#,##0.00", "C": "0.00%", "D": "yyyy-mm-dd"},
+            ),
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+    assert sheet["B2"].number_format == "¥#,##0.00"
+    assert sheet["B3"].number_format == "¥#,##0.00"
+    assert sheet["C2"].number_format == "0.00%"
+    assert sheet["D2"].number_format == "yyyy-mm-dd"
+    assert sheet["A2"].number_format == "General"
+    assert sheet["B1"].number_format == "General"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1133,3 +1133,38 @@ def test_write_rows_number_formats_lowercase_key_normalized(workspace_root: Path
     loaded = load_workbook(output_path)
     sheet = loaded["Data"]
     assert sheet["B2"].number_format == "#,##0.00"
+
+
+def test_write_rows_number_formats_multi_letter_column_keys(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+
+    header_row = [f"Col{idx}" for idx in range(1, 29)]
+    data_row_1 = [None] * 28
+    data_row_2 = [None] * 28
+    data_row_1[26] = 1.23
+    data_row_1[27] = 0.5
+    data_row_2[26] = 4567.89
+    data_row_2[27] = 0.75
+
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[header_row, data_row_1, data_row_2],
+            options=WriteRowsOptions(
+                number_formats={"AA": "#,##0.00", "AB": "0.00%"},
+            ),
+        )
+    )
+
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+
+    assert sheet["AA2"].number_format == "#,##0.00"
+    assert sheet["AA3"].number_format == "#,##0.00"
+    assert sheet["AB2"].number_format == "0.00%"
+    assert sheet["AB3"].number_format == "0.00%"

--- a/tests/test_workbook_domain.py
+++ b/tests/test_workbook_domain.py
@@ -1057,3 +1057,79 @@ def test_write_rows_number_formats_merge_across_calls(workspace_root: Path):
     assert sheet["C3"].number_format == "0.00%"
     assert sheet["C4"].number_format == "0.00%"
     assert sheet["A2"].number_format == "General"
+
+
+def test_write_rows_invalid_number_formats_non_letter_key(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    with pytest.raises(ValidationError):
+        store.write_rows(
+            WriteRowsRequest(
+                workbook_id=workbook.workbook_id,
+                sheet="Data",
+                rows=[["Col1", "Col2"], ["A", 1]],
+                options=WriteRowsOptions(number_formats={"1": "#,##0.00"}),
+            )
+        )
+
+
+def test_write_rows_invalid_number_formats_column_out_of_range(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    with pytest.raises(ValidationError):
+        store.write_rows(
+            WriteRowsRequest(
+                workbook_id=workbook.workbook_id,
+                sheet="Data",
+                rows=[["Col1", "Col2"], ["A", 1]],
+                options=WriteRowsOptions(number_formats={"XFE": "#,##0.00"}),
+            )
+        )
+
+
+def test_write_rows_invalid_number_formats_empty_or_whitespace(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    for fmt in ("", "   "):
+        with pytest.raises(ValidationError):
+            store.write_rows(
+                WriteRowsRequest(
+                    workbook_id=workbook.workbook_id,
+                    sheet="Data",
+                    rows=[["Col1", "Col2"], ["A", 1]],
+                    options=WriteRowsOptions(number_formats={"B": fmt}),
+                )
+            )
+
+
+def test_write_rows_invalid_number_formats_non_string_value(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    with pytest.raises(ValidationError):
+        store.write_rows(
+            WriteRowsRequest(
+                workbook_id=workbook.workbook_id,
+                sheet="Data",
+                rows=[["Col1", "Col2"], ["A", 1]],
+                options=WriteRowsOptions(number_formats={"B": 123}),
+            )
+        )
+
+
+def test_write_rows_number_formats_lowercase_key_normalized(workspace_root: Path):
+    store = WorkbookSessionStore(workspace_dir=workspace_root)
+    workbook = store.create_workbook(CreateWorkbookRequest(filename="fmt.xlsx"))
+    store.write_rows(
+        WriteRowsRequest(
+            workbook_id=workbook.workbook_id,
+            sheet="Data",
+            rows=[["Col1", "Col2"], ["A", 1.23]],
+            options=WriteRowsOptions(number_formats={"b": "#,##0.00"}),
+        )
+    )
+    _, output_path = store.export_workbook(
+        ExportWorkbookRequest(workbook_id=workbook.workbook_id)
+    )
+    loaded = load_workbook(output_path)
+    sheet = loaded["Data"]
+    assert sheet["B2"].number_format == "#,##0.00"


### PR DESCRIPTION
## 概述

  为 write_rows 的 options 参数新增 number_formats
  字段，支持按列设置数字格式（货币、百分比、日期等），格式应用于数据行，跳过表头。

  ## 改动类型

  - [x] 新功能
  - [x] 测试

  ## 关键改动

  - **模型层**：WorksheetOptions 新增 number_formats: dict[str, str] 存储列格式映射
  - **合约层**：WriteRowsOptions 新增 number_formats 字段，验证列名合法性和格式字符串非空
  - **导出层**：_apply_worksheet_options 中遍历 number_formats，对数据行设置
  cell.number_format
  - **工具层**：Agent tool schema 新增 number_formats 属性（additionalProperties: {"type":
   "string"}）
  - **提示词**：格式选项段落补充 number_formats 用法示例

  ## 影响范围

  - write_rows 工具（Agent + MCP）
  - 导出的 .xlsx 文件单元格格式
  - 向后兼容：不传 number_formats 行为与之前完全一致

  ## 测试情况

  - [x] 现有测试通过 (`pytest`) — 42 domain tests passed
  - [x] 新增 / 更新了相关测试
  - [x] 手动验证了核心场景

  <details>
  <summary>手动测试记录</summary>

  - 端到端测试：write_rows(options={number_formats: {"B": "¥#,##0.00", "C": "0.00%", "D":
  "yyyy-mm-dd"}}) → export → openpyxl 验证 B2/C2/D2 格式正确，A2 和 B1（表头）保持 General

  </details>

## 来自 Sourcery 的总结

在 `write_rows` 选项中新增对按列设置 Excel 数字格式的支持，并确保这些格式在工作簿导出过程中能够被正确持久化、合并和应用。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats` 映射，用于按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化 `number_formats`，使列格式能够与工作表模型一起存储，并在导出时应用。
- 在 `write_rows` agent 工具的 schema 中暴露 `number_formats`，并在工作簿工具的提示文档中说明其用法。

增强：
- 在 `WriteRowsOptions` 中对 `number_formats` 的键和值进行规范化和校验，以确保列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失既有配置的前提下扩展现有列格式配置。

测试：
- 添加端到端测试，验证 `number_formats` 会被合并到工作表选项中，只应用于数据行（而非表头），并能在多次调用 `write_rows` 的过程中保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 来自 Sourcery 的总结

在 `write_rows` 选项中新增对按列设置 Excel 数字格式的支持，并确保这些格式在工作簿导出过程中能够被正确持久化、合并和应用。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats` 映射，用于按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化 `number_formats`，使列格式能够与工作表模型一起存储，并在导出时应用。
- 在 `write_rows` agent 工具的 schema 中暴露 `number_formats`，并在工作簿工具的提示文档中说明其用法。

增强：
- 在 `WriteRowsOptions` 中对 `number_formats` 的键和值进行规范化和校验，以确保列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失既有配置的前提下扩展现有列格式配置。

测试：
- 添加端到端测试，验证 `number_formats` 会被合并到工作表选项中，只应用于数据行（而非表头），并能在多次调用 `write_rows` 的过程中保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

</details>

</details>

</details>

**新功能：**
- 允许 `WriteRowsOptions` 接受 `number_formats` 映射，用于为每一列设置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化 `number_formats`，并在导出工作簿时将其应用到数据行。
- 在 `write_rows` agent 工具的 schema 中暴露 `number_formats`，并在工作簿工具的提示中记录其用法。

**增强：**
- 在构造 `WriteRowsOptions` 时，对 `number_formats` 的键和值进行规范化和校验，确保列字母合法且格式字符串非空。

**测试：**
- 添加端到端测试，验证配置的数字格式会合并进工作表选项中，并且只应用到数据行而不会影响表头。

<details>
<summary>Original summary in English</summary>

## 来自 Sourcery 的总结

在 `write_rows` 选项中新增对按列设置 Excel 数字格式的支持，并确保这些格式在工作簿导出过程中能够被正确持久化、合并和应用。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats` 映射，用于按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化 `number_formats`，使列格式能够与工作表模型一起存储，并在导出时应用。
- 在 `write_rows` agent 工具的 schema 中暴露 `number_formats`，并在工作簿工具的提示文档中说明其用法。

增强：
- 在 `WriteRowsOptions` 中对 `number_formats` 的键和值进行规范化和校验，以确保列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失既有配置的前提下扩展现有列格式配置。

测试：
- 添加端到端测试，验证 `number_formats` 会被合并到工作表选项中，只应用于数据行（而非表头），并能在多次调用 `write_rows` 的过程中保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 来自 Sourcery 的总结

在 `write_rows` 选项中新增对按列设置 Excel 数字格式的支持，并确保这些格式在工作簿导出过程中能够被正确持久化、合并和应用。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats` 映射，用于按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化 `number_formats`，使列格式能够与工作表模型一起存储，并在导出时应用。
- 在 `write_rows` agent 工具的 schema 中暴露 `number_formats`，并在工作簿工具的提示文档中说明其用法。

增强：
- 在 `WriteRowsOptions` 中对 `number_formats` 的键和值进行规范化和校验，以确保列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失既有配置的前提下扩展现有列格式配置。

测试：
- 添加端到端测试，验证 `number_formats` 会被合并到工作表选项中，只应用于数据行（而非表头），并能在多次调用 `write_rows` 的过程中保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 `write_rows` 选项添加按列配置的 Excel 数字格式支持，并确保这些格式在导出过程中能够被持久化、合并，同时只应用于数据行。

新功能：
- 允许在 `WriteRowsOptions` 中指定 `number_formats`，以按列字母配置 Excel 数字格式。
- 在 `WorksheetOptions` 中持久化工作表级的 `number_formats`，并通过 `write_rows` 代理工具的 schema 和提示对其进行暴露。

增强点：
- 在 `WriteRowsOptions` 中校验和规范化 `number_formats` 的键和值，强制要求列字母合法且格式字符串非空。
- 在多次调用 `write_rows` 时合并 `number_formats`，使后续调用可以在不丢失已有列格式配置的前提下扩展配置。

测试：
- 添加工作簿领域测试，覆盖以下内容：将 `number_formats` 应用于数据行、多次调用 `write_rows` 时的合并行为、小写列键的规范化处理、以及对非法键或格式值的校验失败情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-column Excel number format support to write_rows options and ensure these formats are persisted, merged, and applied only to data rows during export.

New Features:
- Allow specifying number_formats in WriteRowsOptions to configure Excel number formats per column letter.
- Persist worksheet-level number_formats in WorksheetOptions and expose them through the write_rows agent tool schema and prompts.

Enhancements:
- Validate and normalize number_formats keys and values in WriteRowsOptions, enforcing valid column letters and non-empty format strings.
- Merge number_formats across multiple write_rows calls so later invocations can extend existing column format configuration without losing prior settings.

Tests:
- Add workbook domain tests covering application of number_formats to data rows, merging behavior across multiple write_rows calls, normalization of lowercase column keys, and validation failures for invalid keys or format values.

</details>

</details>

</details>

</details>

</details>