### PR TITLE
feat: add managed image asset pool for documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ npm run build
 | 配置项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | 文件合并等待时间秒 (`message_buffer_seconds`) | float | 4 | 上传文件后等一会儿，把同一波的文件合在一起 |
+| 图片等待 /img add 时间秒 (`image_buffer_seconds`) | float | 4 | 上传图片后等这段时间，期间收到 `/img add` 就注册到资源池，否则把图片释放给 LLM 正常聊天 |
 | 旧流程文本缓存时间秒 (`recent_text_ttl_seconds`) | int | 20 | 主要影响"文件和文字一起进来"的老用法，一般不用动 |
 | 上传文件保留时间秒 (`upload_session_ttl_seconds`) | int | 600 | 上传完文件后在当前会话里保留多久，供 `/doc` 命令使用 |
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ npm run build
 | 配置项 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
 | 文件合并等待时间秒 (`message_buffer_seconds`) | float | 4 | 上传文件后等一会儿，把同一波的文件合在一起 |
-| 图片等待 /img add 时间秒 (`image_buffer_seconds`) | float | 4 | 上传图片后等这段时间，期间收到 `/img add` 就注册到资源池，否则把图片释放给 LLM 正常聊天 |
+| 图片等待 /img add 时间秒 (`image_llm_delay_seconds`) | float | 3 | 上传图片后等这段时间，期间收到 `/img add` 就注册到资源池，否则把图片释放给 LLM 正常聊天 |
 | 旧流程文本缓存时间秒 (`recent_text_ttl_seconds`) | int | 20 | 主要影响"文件和文字一起进来"的老用法，一般不用动 |
 | 上传文件保留时间秒 (`upload_session_ttl_seconds`) | int | 600 | 上传完文件后在当前会话里保留多久，供 `/doc` 命令使用 |
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -104,6 +104,12 @@
                 "hint": "上传文件后，系统会等待这段时间，把期间收到的文件和文本合并成同一批处理。",
                 "default": 4
             },
+            "image_llm_delay_seconds": {
+                "description": "图片 LLM 请求延迟(秒)",
+                "type": "float",
+                "hint": "上传图片后，系统会延迟这段时间再请求 LLM。期间如果收到 /img add 命令则跳过 LLM 请求，避免浪费 token。设为 0 则不延迟。",
+                "default": 3
+            },
             "upload_session_ttl_seconds": {
                 "description": "上传文件保留时间(秒)",
                 "type": "int",

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -19,10 +19,14 @@ from ..domain.document.render_backends import (
 from ..domain.document.session_store import DocumentSessionStore
 from ..domain.document.contracts import (
     AddBlocksRequest,
+    BlockColumnsInput,
+    BlockGroupInput,
     CreateDocumentRequest,
     ExportDocumentRequest,
     ExportDocumentResult,
     FinalizeDocumentRequest,
+    ImageInput,
+    ImageSlideInput,
     ToolResult,
     build_document_summary,
     build_header_footer_schema,
@@ -43,6 +47,23 @@ _ADD_BLOCKS_EMPTY_KWARGS_HINT = (
     "未转义字符，在上游解析失败后被降级为空参数。请拆分内容为多次 add_blocks 调用："
     "每次只放 3-5 个短 block，长段落可分段写入，使用同一个 document_id 继续调用。"
 )
+ImageRefValidator = Callable[[ContextWrapper[AstrAgentContext] | None, str], None]
+
+
+def _iter_image_asset_refs(blocks: list[Any]):
+    for block in blocks:
+        if isinstance(block, ImageInput):
+            yield block.path
+            continue
+        if isinstance(block, ImageSlideInput):
+            yield block.image_path
+            continue
+        if isinstance(block, BlockGroupInput):
+            yield from _iter_image_asset_refs(block.blocks)
+            continue
+        if isinstance(block, BlockColumnsInput):
+            for column in block.columns:
+                yield from _iter_image_asset_refs(column.blocks)
 
 
 _STYLE_SCHEMA = {
@@ -217,6 +238,17 @@ _RICH_LIST_ITEM_PUBLIC_SCHEMA = {
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class DocumentToolBase(FunctionTool[AstrAgentContext]):
     store: DocumentSessionStore = Field(default_factory=DocumentSessionStore)
+    image_ref_validator: ImageRefValidator | None = None
+
+    def _validate_image_refs(
+        self,
+        context: ContextWrapper[AstrAgentContext] | None,
+        blocks: list[Any],
+    ) -> None:
+        if self.image_ref_validator is None:
+            return
+        for ref in _iter_image_asset_refs(blocks):
+            self.image_ref_validator(context, ref)
 
 
 @dataclass(config=ConfigDict(arbitrary_types_allowed=True))
@@ -940,6 +972,7 @@ class AddBlocksTool(DocumentToolBase):
                 document_id=document_id,
                 blocks=raw_blocks,
             )
+            self._validate_image_refs(context, request.blocks)
             document = self.store.add_blocks(request)
         except Exception as exc:
             return _dump_result(
@@ -1056,7 +1089,12 @@ class AddSlidesTool(DocumentToolBase):
     ) -> ToolExecResult:
         document_id = str(kwargs.get("document_id") or "")
         raw_slides = kwargs.get("slides") or []
-        result = execute_add_slides(self.store, document_id, raw_slides)
+        result = execute_add_slides(
+            self.store,
+            document_id,
+            raw_slides,
+            validate_blocks=lambda blocks: self._validate_image_refs(context, blocks),
+        )
         if result.success:
             result.message = (
                 "幻灯片已添加。如果还有更多幻灯片，继续调用 add_slides；"

--- a/agent_tools/document_tools.py
+++ b/agent_tools/document_tools.py
@@ -1037,7 +1037,7 @@ class AddSlidesTool(DocumentToolBase):
                             },
                             "image_path": {
                                 "type": "string",
-                                "description": "Workspace-relative image path for image_slide.",
+                                "description": "Registered image asset reference (images/...) for image_slide. Use /img add to register images first.",
                             },
                             "caption": {
                                 "type": "string",

--- a/agent_tools/factory.py
+++ b/agent_tools/factory.py
@@ -23,6 +23,7 @@ def build_document_toolset(
     after_export_hooks: list[AfterExportHook] | None = None,
     render_backend_config: DocumentRenderBackendConfig | None = None,
     default_document_style: dict[str, object] | None = None,
+    image_ref_validator: Callable[[object, str], None] | None = None,
 ) -> ToolSet:
     return build_document_toolset_from_registry(
         workspace_dir=workspace_dir,
@@ -31,6 +32,7 @@ def build_document_toolset(
         after_export_hooks=after_export_hooks,
         render_backend_config=render_backend_config,
         default_document_style=default_document_style,
+        image_ref_validator=image_ref_validator,
     )
 
 

--- a/app/runtime.py
+++ b/app/runtime.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from .settings import PluginSettings
 
 if TYPE_CHECKING:
+    from ..services.image_asset_service import ImageAssetService
     from ..services.message_buffer import MessageBuffer
     from ..services.office_generator import OfficeGenerator
     from ..services.pdf_converter import PDFConverter
@@ -63,6 +64,7 @@ class PluginRuntimeBundle:
     file_tool_service: FileToolService
     command_service: CommandService
     error_hook_service: ErrorHookService
+    image_asset_service: ImageAssetService
     message_buffer: MessageBuffer
     incoming_message_service: IncomingMessageService
 

--- a/app/settings.py
+++ b/app/settings.py
@@ -21,6 +21,7 @@ class PluginSettings:
     max_excel_preview_chars: int
     max_excel_preview_sheets: int
     buffer_wait: int
+    image_llm_delay: float
     reply_to_user: bool
     require_at_in_group: bool
     enable_features_in_group: bool
@@ -119,6 +120,12 @@ def load_plugin_settings(config) -> PluginSettings:
         "message_buffer_seconds",
         file_settings.get("message_buffer_seconds", 4),
     )
+    image_llm_delay = float(
+        upload_session_settings.get(
+            "image_llm_delay_seconds",
+            file_settings.get("image_llm_delay_seconds", 3.0),
+        )
+    )
     reply_to_user = trigger_settings.get("reply_to_user", True)
     require_at_in_group = trigger_settings.get("require_at_in_group", True)
     enable_features_in_group = trigger_settings.get("enable_features_in_group", False)
@@ -188,6 +195,7 @@ def load_plugin_settings(config) -> PluginSettings:
         max_excel_preview_chars=max_excel_preview_chars,
         max_excel_preview_sheets=max_excel_preview_sheets,
         buffer_wait=buffer_wait,
+        image_llm_delay=image_llm_delay,
         reply_to_user=reply_to_user,
         require_at_in_group=require_at_in_group,
         enable_features_in_group=enable_features_in_group,

--- a/document_core/models/blocks.py
+++ b/document_core/models/blocks.py
@@ -691,6 +691,11 @@ class ImageBlock(BlockBase):
     caption: str = ""
     width_px: int | None = Field(default=None, gt=0)
 
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        return validate_image_asset_ref(value)
+
 
 class GroupBlock(BlockBase):
     type: Literal["group"] = "group"
@@ -768,6 +773,21 @@ def validate_workspace_relative_path(value: str) -> str:
     return candidate
 
 
+def validate_image_asset_ref(value: str) -> str:
+    """Validate that an image path is a managed asset pool reference.
+
+    Requires the images/ prefix, rejects absolute paths and traversal.
+    Actual file existence and index membership are checked at resolve time.
+    """
+    candidate = validate_workspace_relative_path(value)
+    if not candidate.startswith("images/"):
+        raise ValueError(
+            "image path must be a registered asset reference starting with 'images/'. "
+            "Use /img add to register uploaded images first."
+        )
+    return candidate
+
+
 class TitleSlideBlock(BlockBase):
     type: Literal["title_slide"] = "title_slide"
     title: str
@@ -796,7 +816,7 @@ class ImageSlideBlock(BlockBase):
     @field_validator("image_path")
     @classmethod
     def validate_image_path(cls, value: str) -> str:
-        return validate_workspace_relative_path(value)
+        return validate_image_asset_ref(value)
 
 
 DocumentBlock = Annotated[

--- a/document_core/models/document.py
+++ b/document_core/models/document.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 
 from .blocks import (
     DocumentBlock,
@@ -136,6 +136,7 @@ class DocumentMetadata(BaseModel):
 
 class DocumentModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
+    _workspace_dir: str = PrivateAttr(default="")
 
     document_id: str
     session_id: str = ""

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -1641,9 +1641,25 @@ class ImageSlideInput(BaseModel):
     @field_validator("image_path")
     @classmethod
     def validate_image_path(cls, value: str) -> str:
-        from ...document_core.models.blocks import validate_workspace_relative_path
+        from ...document_core.models.blocks import validate_image_asset_ref
 
-        return validate_workspace_relative_path(value)
+        return validate_image_asset_ref(value)
+
+
+class ImageInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    type: Literal["image"] = "image"
+    path: str
+    caption: str = ""
+    width_px: int | None = Field(default=None, gt=0)
+
+    @field_validator("path")
+    @classmethod
+    def validate_path(cls, value: str) -> str:
+        from ...document_core.models.blocks import validate_image_asset_ref
+
+        return validate_image_asset_ref(value)
 
 
 BlockInput = Annotated[
@@ -1661,6 +1677,7 @@ BlockInput = Annotated[
     | TocInput
     | BlockGroupInput
     | BlockColumnsInput
+    | ImageInput
     | TitleSlideInput
     | ContentSlideInput
     | TableSlideInput

--- a/domain/document/contracts.py
+++ b/domain/document/contracts.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import re
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Annotated, Any, Literal
 
@@ -1838,6 +1838,8 @@ def execute_add_slides(
     store: Any,
     document_id: str,
     slides: list,
+    *,
+    validate_blocks: Callable[[list[BlockInput]], None] | None = None,
 ) -> ToolResult:
     """Shared add_slides core logic for agent and MCP entry points.
 
@@ -1859,6 +1861,8 @@ def execute_add_slides(
     normalized = normalize_slide_bullets(slides)
     try:
         request = AddBlocksRequest(document_id=document_id, blocks=normalized)
+        if validate_blocks is not None:
+            validate_blocks(request.blocks)
         document = store.add_blocks(request)
     except Exception as exc:
         return ToolResult(success=False, message=str(exc))

--- a/domain/document/render_backends.py
+++ b/domain/document/render_backends.py
@@ -122,6 +122,13 @@ def build_document_render_payload(document: DocumentModel) -> dict[str, Any]:
     }
 
 
+def _resolve_document_workspace_dir(document: DocumentModel, output_path: Path) -> Path:
+    workspace_dir = str(getattr(document, "_workspace_dir", "") or "").strip()
+    if workspace_dir:
+        return Path(workspace_dir).resolve()
+    return output_path.parent.resolve()
+
+
 def _fixup_block_payload(block_payload: dict[str, Any], block: object) -> None:
     """Recursively ensure ``type`` is present and ``block_id`` is stripped."""
     block_payload.pop("block_id", None)
@@ -182,7 +189,9 @@ class NodeDocumentRenderBackend:
             )
 
         payload = build_document_render_payload(document)
-        payload["workspace_dir"] = str(output_path.parent.resolve())
+        payload["workspace_dir"] = str(
+            _resolve_document_workspace_dir(document, output_path)
+        )
         output_path.parent.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             mode="w",

--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -20,6 +20,7 @@ from ...document_core.models.blocks import (
     GroupBlock,
     HeadingBlock,
     HeroBannerBlock,
+    ImageBlock,
     ImageSlideBlock,
     ListBlock,
     MetricCard,
@@ -78,6 +79,7 @@ from .contracts import (
     ContentSlideInput,
     TableSlideInput,
     ImageSlideInput,
+    ImageInput,
     _coerce_table_input_rows_to_runtime,
     _normalize_output_filename,
 )
@@ -693,10 +695,26 @@ class DocumentSessionStore:
                 rows=[list(row) for row in block.rows],
             )
         if isinstance(block, ImageSlideInput):
+            image_file = self.workspace_dir / block.image_path
+            if not image_file.exists():
+                raise ValueError(
+                    f"图片文件不存在: {block.image_path}。请确认已通过 /img add 注册。"
+                )
             return ImageSlideBlock(
                 title=block.title,
                 image_path=block.image_path,
                 caption=block.caption,
+            )
+        if isinstance(block, ImageInput):
+            image_file = self.workspace_dir / block.path
+            if not image_file.exists():
+                raise ValueError(
+                    f"图片文件不存在: {block.path}。请确认已通过 /img add 注册。"
+                )
+            return ImageBlock(
+                path=block.path,
+                caption=block.caption,
+                width_px=block.width_px,
             )
         raise TypeError(f"Unsupported block input: {type(block)!r}")
 

--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -180,6 +180,7 @@ class DocumentSessionStore:
             self._drop_duplicate_document_title_headings,
             self._move_landscape_intro_paragraphs_before_section_break,
             self._promote_heading_before_table_to_caption,
+            self._drop_adjacent_duplicate_images,
         ]
 
     def _evict_expired_locked(self) -> None:
@@ -453,6 +454,30 @@ class DocumentSessionStore:
             normalized.append(current)
             index += 1
 
+        return normalized
+
+    @staticmethod
+    def _drop_adjacent_duplicate_images(
+        context: BlockNormalizationContext,
+    ) -> list[BlockInput]:
+        # 模型偶尔会把同一张图连着加两次（常因前序 heading 被去重导致 block_count
+        # 没按预期增长，模型误判图没加上而重试）。这里丢弃路径相同且相邻的图片，
+        # 既覆盖单次批量内的重复，也覆盖与上一批末尾图片的跨调用重复。
+        # 仅针对“相邻”，不影响同一张图用在文档不同位置的合法用法。
+        stored_blocks = context.document.blocks
+        last_stored = stored_blocks[-1] if stored_blocks else None
+        previous_image_path = (
+            last_stored.path if isinstance(last_stored, ImageBlock) else None
+        )
+
+        normalized: list[BlockInput] = []
+        for current in context.incoming_blocks:
+            current_path = current.path if isinstance(current, ImageInput) else None
+            if current_path is not None and current_path == previous_image_path:
+                logger.debug("[文件管理] 丢弃相邻重复图片 %s", current_path)
+                continue
+            normalized.append(current)
+            previous_image_path = current_path
         return normalized
 
     def _build_runtime_block(

--- a/domain/document/session_store.py
+++ b/domain/document/session_store.py
@@ -242,6 +242,7 @@ class DocumentSessionStore:
                     document_style=document_style,
                 ),
             )
+            document._workspace_dir = str(self.workspace_dir.resolve())
             self._documents[document_id] = document
             self._prune_locked()
             return document

--- a/main.py
+++ b/main.py
@@ -535,18 +535,23 @@ class FileOperationPlugin(Star):
 
         all_resources = inline_images + pending_resources
 
-        # 把 Comp.Image / Comp.File 解析为本地文件路径 + 原始文件名
-        source_items: list[tuple[Path, str]] = []
+        # 把 Path / Comp.Image / Comp.File 解析为本地文件路径 + 原始文件名，
+        # 同时保留原始 resource，供 CommandService 精准清理 pending cache。
+        source_items: list[tuple[Path, str, object]] = []
         for resource in all_resources:
             try:
-                if isinstance(resource, Comp.Image):
+                if isinstance(resource, Path):
+                    source_items.append((resource, resource.name, resource))
+                elif isinstance(resource, Comp.Image):
                     file_path = await resource.convert_to_file_path()
                     if file_path:
-                        source_items.append((Path(file_path), ""))
+                        source_items.append((Path(file_path), "", resource))
                 elif isinstance(resource, Comp.File):
                     file_path = await resource.get_file()
                     if file_path:
-                        source_items.append((Path(file_path), resource.name or ""))
+                        source_items.append(
+                            (Path(file_path), resource.name or "", resource)
+                        )
             except Exception as exc:
                 resource_name = getattr(resource, "name", None)
                 resource_id = getattr(resource, "id", None)
@@ -564,7 +569,6 @@ class FileOperationPlugin(Star):
             source_items=source_items,
             selection=str(selection),
         )
-        self._runtime.upload_session_service.clear_pending_images(event)
         event.set_result(MessageEventResult().message(result).stop_event())
 
     @img.command("list")

--- a/main.py
+++ b/main.py
@@ -230,23 +230,37 @@ class FileOperationPlugin(Star):
             import asyncio
 
             wait = self._runtime.settings.image_llm_delay
-            pending = self._runtime.upload_session_service.get_pending_image_resources(
-                event
+            pending_for_event = list(
+                getattr(event, "_pending_image_resources", None) or []
             )
-            if pending and wait > 0:
-                logger.debug("[文件管理] 图片消息等待 %.1f 秒，看是否有 /img add", wait)
-                await asyncio.sleep(wait)
-                pending = (
+            if not pending_for_event:
+                pending_for_event = (
                     self._runtime.upload_session_service.get_pending_image_resources(
                         event
                     )
                 )
-                if not pending:
+            if pending_for_event and wait > 0:
+                logger.debug("[文件管理] 图片消息等待 %.1f 秒，看是否有 /img add", wait)
+                await asyncio.sleep(wait)
+                current_pending = (
+                    self._runtime.upload_session_service.get_pending_image_resources(
+                        event
+                    )
+                )
+                event_resource_ids = {id(resource) for resource in pending_for_event}
+                remaining_for_event = [
+                    resource
+                    for resource in current_pending
+                    if id(resource) in event_resource_ids
+                ]
+                if not remaining_for_event:
                     logger.debug("[文件管理] 图片已被 /img add 消费，跳过 LLM 请求")
                     event.stop_event()
                     return
                 logger.debug("[文件管理] 等待超时，图片未被注册，继续 LLM 请求")
-                self._runtime.upload_session_service.clear_pending_images(event)
+                self._runtime.upload_session_service.clear_pending_image_resources(
+                    event, remaining_for_event
+                )
                 setattr(event, "_has_pending_images", False)
 
         await self._runtime.llm_request_policy.apply(event, req)
@@ -533,8 +547,17 @@ class FileOperationPlugin(Star):
                     file_path = await resource.get_file()
                     if file_path:
                         source_items.append((Path(file_path), resource.name or ""))
-            except Exception:
-                pass
+            except Exception as exc:
+                resource_name = getattr(resource, "name", None)
+                resource_id = getattr(resource, "id", None)
+                logger.warning(
+                    "[img] failed to resolve image/file resource "
+                    "(name=%r, id=%r, type=%s): %r",
+                    resource_name,
+                    resource_id,
+                    type(resource).__name__,
+                    exc,
+                )
 
         result = self._runtime.command_service.img_add(
             event,

--- a/main.py
+++ b/main.py
@@ -523,6 +523,13 @@ class FileOperationPlugin(Star):
     @img.command("add")
     async def img_add(self, event: AstrMessageEvent, selection: GreedyStr = ""):
         """注册上传的图片到资源池。"""
+        buffered = await self._runtime.message_buffer.pop_buffer(event)
+        if buffered:
+            for image in buffered.images:
+                self._runtime.upload_session_service.cache_pending_image_resource(
+                    event, image
+                )
+
         inline_images: list = []
         for component in event.message_obj.message:
             if isinstance(component, (Comp.Image, Comp.File)):

--- a/main.py
+++ b/main.py
@@ -452,6 +452,39 @@ class FileOperationPlugin(Star):
             return
         event.stop_event()
 
+    @filter.command_group("img")
+    def img(self):
+        """管理当前会话的图片资源池。"""
+
+    @img.command("add")
+    async def img_add(self, event: AstrMessageEvent, selection: GreedyStr = ""):
+        """注册上传的图片到资源池。"""
+        pending = self._runtime.upload_session_service.get_pending_images(event)
+        result = self._runtime.command_service.img_add(
+            event,
+            source_paths=pending,
+            selection=str(selection),
+        )
+        event.set_result(MessageEventResult().message(result).stop_event())
+
+    @img.command("list")
+    async def img_list(self, event: AstrMessageEvent):
+        """查看当前会话已注册的图片。"""
+        result = self._runtime.command_service.img_list(event)
+        event.set_result(MessageEventResult().message(result).stop_event())
+
+    @img.command("note")
+    async def img_note(self, event: AstrMessageEvent, args: GreedyStr = ""):
+        """修改图片备注。"""
+        result = self._runtime.command_service.img_note(event, str(args))
+        event.set_result(MessageEventResult().message(result).stop_event())
+
+    @img.command("clear")
+    async def img_clear(self, event: AstrMessageEvent, target: str = ""):
+        """清理会话图片。"""
+        result = self._runtime.command_service.img_clear(event, target)
+        event.set_result(MessageEventResult().message(result).stop_event())
+
     @on_plugin_error_filter()
     async def on_plugin_error(
         self,

--- a/main.py
+++ b/main.py
@@ -257,9 +257,8 @@ class FileOperationPlugin(Star):
                     logger.debug("[文件管理] 图片已被 /img add 消费，跳过 LLM 请求")
                     event.stop_event()
                     return
-                logger.debug("[文件管理] 等待超时，图片未被注册，继续 LLM 请求")
-                self._runtime.upload_session_service.clear_pending_image_resources(
-                    event, remaining_for_event
+                logger.debug(
+                    "[文件管理] 等待超时，图片仍保留在待注册资源池，继续 LLM 请求"
                 )
                 setattr(event, "_has_pending_images", False)
 

--- a/main.py
+++ b/main.py
@@ -465,6 +465,7 @@ class FileOperationPlugin(Star):
             source_paths=pending,
             selection=str(selection),
         )
+        self._runtime.upload_session_service.clear_pending_images(event)
         event.set_result(MessageEventResult().message(result).stop_event())
 
     @img.command("list")

--- a/main.py
+++ b/main.py
@@ -522,12 +522,11 @@ class FileOperationPlugin(Star):
     @img.command("add")
     async def img_add(self, event: AstrMessageEvent, selection: GreedyStr = ""):
         """注册上传的图片到资源池。"""
-        buffered = await self._runtime.message_buffer.pop_buffer(event)
-        if buffered:
-            for image in buffered.images:
-                self._runtime.upload_session_service.cache_pending_image_resource(
-                    event, image
-                )
+        buffered_images = await self._runtime.message_buffer.pop_images(event)
+        for image in buffered_images:
+            self._runtime.upload_session_service.cache_pending_image_resource(
+                event, image
+            )
 
         inline_images: list = []
         for component in event.message_obj.message:

--- a/main.py
+++ b/main.py
@@ -513,6 +513,8 @@ class FileOperationPlugin(Star):
             "/img 命令 - 管理图片资源池\n"
             "  /img add [备注] — 注册图片到资源池（先发图片再执行，或附带图片发送）\n"
             "  /img list — 查看当前会话已注册的图片\n"
+            "  /img active — 查看本轮文档/PPT 可直接使用的活动图片\n"
+            "  /img use <序号|引用|all> — 选择本轮文档/PPT 可直接使用的图片\n"
             "  /img note <序号> <备注> — 修改图片备注\n"
             "  /img clear [序号] — 清理指定图片（不指定则清理全部）\n"
             "  /img help — 显示此帮助"
@@ -580,6 +582,18 @@ class FileOperationPlugin(Star):
     async def img_list(self, event: AstrMessageEvent):
         """查看当前会话已注册的图片。"""
         result = self._runtime.command_service.img_list(event)
+        event.set_result(MessageEventResult().message(result).stop_event())
+
+    @img.command("active")
+    async def img_active(self, event: AstrMessageEvent):
+        """查看当前活动图片。"""
+        result = self._runtime.command_service.img_active(event)
+        event.set_result(MessageEventResult().message(result).stop_event())
+
+    @img.command("use")
+    async def img_use(self, event: AstrMessageEvent, selection: GreedyStr = ""):
+        """选择本轮文档/PPT 可直接使用的图片。"""
+        result = self._runtime.command_service.img_use(event, str(selection))
         event.set_result(MessageEventResult().message(result).stop_event())
 
     @img.command("note")

--- a/main.py
+++ b/main.py
@@ -217,13 +217,38 @@ class FileOperationPlugin(Star):
     @filter.event_message_type(filter.EventMessageType.ALL, priority=100)
     async def on_file_message(self, event: AstrMessageEvent):
         """
-        拦截包含文件的消息，使用缓冲器聚合文件和后续文本消息
-        仅处理支持的文件格式（Office、文本、PDF），其他格式直接放行
+        拦截包含文件的消息，使用缓冲器聚合文件、图片和后续文本消息
+        仅处理支持的文件格式（Office、文本、PDF）和图片，其他格式直接放行
         """
         await self._runtime.incoming_message_service.handle_file_message(event)
 
     @filter.on_llm_request()
     async def before_llm_chat(self, event: AstrMessageEvent, req: ProviderRequest):
+        if getattr(event, "_has_pending_images", False) and not getattr(
+            event, "_buffered", False
+        ):
+            import asyncio
+
+            wait = self._runtime.settings.image_llm_delay
+            pending = self._runtime.upload_session_service.get_pending_image_resources(
+                event
+            )
+            if pending and wait > 0:
+                logger.debug("[文件管理] 图片消息等待 %.1f 秒，看是否有 /img add", wait)
+                await asyncio.sleep(wait)
+                pending = (
+                    self._runtime.upload_session_service.get_pending_image_resources(
+                        event
+                    )
+                )
+                if not pending:
+                    logger.debug("[文件管理] 图片已被 /img add 消费，跳过 LLM 请求")
+                    event.stop_event()
+                    return
+                logger.debug("[文件管理] 等待超时，图片未被注册，继续 LLM 请求")
+                self._runtime.upload_session_service.clear_pending_images(event)
+                setattr(event, "_has_pending_images", False)
+
         await self._runtime.llm_request_policy.apply(event, req)
 
     @llm_tool(name="read_file")
@@ -424,6 +449,18 @@ class FileOperationPlugin(Star):
     def doc(self):
         """处理当前会话中的上传文件。"""
 
+    @doc.command("help")
+    async def doc_help(self, event: AstrMessageEvent):
+        """查看 /doc 命令帮助。"""
+        text = (
+            "/doc 命令 - 管理上传文件\n"
+            "  /doc list — 查看当前会话可用的上传文件\n"
+            "  /doc use <文件名或序号> <指令> — 使用指定文件处理请求\n"
+            "  /doc clear [序号] — 清理上传文件（不指定则清理全部）\n"
+            "  /doc help — 显示此帮助"
+        )
+        event.set_result(MessageEventResult().message(text).stop_event())
+
     @doc.command("list")
     async def doc_list(self, event: AstrMessageEvent):
         """查看当前会话可用的上传文件。"""
@@ -456,13 +493,52 @@ class FileOperationPlugin(Star):
     def img(self):
         """管理当前会话的图片资源池。"""
 
+    @img.command("help")
+    async def img_help(self, event: AstrMessageEvent):
+        """查看 /img 命令帮助。"""
+        text = (
+            "/img 命令 - 管理图片资源池\n"
+            "  /img add [备注] — 注册图片到资源池（先发图片再执行，或附带图片发送）\n"
+            "  /img list — 查看当前会话已注册的图片\n"
+            "  /img note <序号> <备注> — 修改图片备注\n"
+            "  /img clear [序号] — 清理指定图片（不指定则清理全部）\n"
+            "  /img help — 显示此帮助"
+        )
+        event.set_result(MessageEventResult().message(text).stop_event())
+
     @img.command("add")
     async def img_add(self, event: AstrMessageEvent, selection: GreedyStr = ""):
         """注册上传的图片到资源池。"""
-        pending = self._runtime.upload_session_service.get_pending_images(event)
+        inline_images: list = []
+        for component in event.message_obj.message:
+            if isinstance(component, (Comp.Image, Comp.File)):
+                inline_images.append(component)
+
+        # 从 pending cache 取出之前发送的图片引用
+        pending_resources = (
+            self._runtime.upload_session_service.get_pending_image_resources(event)
+        )
+
+        all_resources = inline_images + pending_resources
+
+        # 把 Comp.Image / Comp.File 解析为本地文件路径 + 原始文件名
+        source_items: list[tuple[Path, str]] = []
+        for resource in all_resources:
+            try:
+                if isinstance(resource, Comp.Image):
+                    file_path = await resource.convert_to_file_path()
+                    if file_path:
+                        source_items.append((Path(file_path), ""))
+                elif isinstance(resource, Comp.File):
+                    file_path = await resource.get_file()
+                    if file_path:
+                        source_items.append((Path(file_path), resource.name or ""))
+            except Exception:
+                pass
+
         result = self._runtime.command_service.img_add(
             event,
-            source_paths=pending,
+            source_items=source_items,
             selection=str(selection),
         )
         self._runtime.upload_session_service.clear_pending_images(event)
@@ -475,9 +551,11 @@ class FileOperationPlugin(Star):
         event.set_result(MessageEventResult().message(result).stop_event())
 
     @img.command("note")
-    async def img_note(self, event: AstrMessageEvent, args: GreedyStr = ""):
-        """修改图片备注。"""
-        result = self._runtime.command_service.img_note(event, str(args))
+    async def img_note(
+        self, event: AstrMessageEvent, ref: str = "", note: GreedyStr = ""
+    ):
+        """修改图片备注。用法: /img note <序号或引用> <新备注>"""
+        result = self._runtime.command_service.img_note(event, ref, str(note))
         event.set_result(MessageEventResult().message(result).stop_event())
 
     @img.command("clear")

--- a/prompts/static/document_tools.py
+++ b/prompts/static/document_tools.py
@@ -125,7 +125,7 @@ def build_document_tools_detail_notice() -> str:
         "  - `title_slide`：标题页，字段 `title`（必填）、`subtitle`（可选）\n"
         "  - `content_slide`：内容页，字段 `title`（必填）、`bullets`（纯字符串数组，必填）\n"
         "  - `table_slide`：表格页，字段 `title`（可选）、`headers`（必填）、`rows`（必填）\n"
-        "  - `image_slide`：图片页，字段 `title`（可选）、`image_path`（工作区相对路径，必填）、`caption`（可选）\n"
+        "  - `image_slide`：图片页，字段 `title`（可选）、`image_path`（已注册的 `images/...` 引用，必填）、`caption`（可选）\n"
         "- PPT 文档不能使用 add_blocks，Word 文档不能使用 add_slides\n"
         '- 典型流程：create_document(format="ppt", title="季度汇报") → add_slides(slides=[...]) → finalize_document → export_document\n'
     )

--- a/services/command_service.py
+++ b/services/command_service.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from ..constants import DOC_COMMAND_TRIGGER_EVENT_KEY
 from ..constants import ALL_OFFICE_SUFFIXES
 from ..domain.document.render_backends import NodeDocumentRenderBackend
 from ..utils import format_file_size
+
+if TYPE_CHECKING:
+    from .image_asset_service import ImageAssetService
 
 
 class CommandService:
@@ -20,6 +26,7 @@ class CommandService:
         allow_local_excel_script: bool,
         reply_to_user: bool,
         upload_session_service,
+        image_asset_service: ImageAssetService,
         is_group_feature_enabled,
         is_all_users_allowed,
         check_permission,
@@ -36,6 +43,7 @@ class CommandService:
         self._allow_local_excel_script = allow_local_excel_script
         self._reply_to_user = reply_to_user
         self._upload_session_service = upload_session_service
+        self._image_asset_service = image_asset_service
         self._is_group_feature_enabled = is_group_feature_enabled
         self._is_all_users_allowed = is_all_users_allowed
         self._check_permission = check_permission
@@ -305,3 +313,144 @@ class CommandService:
             upload_infos=upload_infos,
             user_instruction=user_instruction,
         )
+
+    # ── /img commands ──
+
+    def img_add(
+        self,
+        event,
+        *,
+        source_paths: list[Path],
+        selection: str = "",
+    ) -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        if not source_paths:
+            return "当前没有待注册的图片。请先在聊天中上传图片，再使用 /img add。"
+
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+
+        parts = selection.strip().split(maxsplit=1) if selection.strip() else []
+        selector = parts[0] if parts else "all"
+        note = parts[1] if len(parts) > 1 else ""
+
+        if selector == "all":
+            targets = list(enumerate(source_paths, 1))
+        else:
+            try:
+                idx = int(selector)
+            except ValueError:
+                note = selection.strip()
+                targets = list(enumerate(source_paths, 1))
+            else:
+                if idx < 1 or idx > len(source_paths):
+                    return f"序号超出范围。当前有 {len(source_paths)} 张待注册图片。"
+                targets = [(idx, source_paths[idx - 1])]
+
+        registered = []
+        errors = []
+        for idx, path in targets:
+            try:
+                info = self._image_asset_service.register_image(
+                    path,
+                    session_key=session_key,
+                    note=note,
+                    original_name=path.name,
+                )
+                registered.append(info)
+            except (ValueError, FileNotFoundError) as exc:
+                errors.append(f"图片 {idx}: {exc}")
+
+        lines = []
+        if registered:
+            lines.append(f"已注册 {len(registered)} 张图片：")
+            for info in registered:
+                size_str = format_file_size(info["size_bytes"])
+                lines.append(
+                    f"  {info['ref']} ({info['width']}x{info['height']}, {size_str})"
+                )
+        if errors:
+            lines.append("注册失败：")
+            lines.extend(f"  {e}" for e in errors)
+        return "\n".join(lines)
+
+    def img_list(self, event) -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+        images = self._image_asset_service.list_images(session_key)
+
+        if not images:
+            return "当前会话没有已注册的图片。使用 /img add 注册上传的图片。"
+
+        lines = [f"📷 当前会话图片（共 {len(images)} 张）："]
+        for i, info in enumerate(images, 1):
+            size_str = format_file_size(info["size_bytes"])
+            note_str = f" — {info['note']}" if info["note"] else ""
+            lines.append(
+                f"  {i}. {info['ref']}\n"
+                f"     原名: {info['original_name']} | "
+                f"{info['width']}x{info['height']} | {size_str}{note_str}"
+            )
+        return "\n".join(lines)
+
+    def img_note(self, event, args: str) -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        parts = args.strip().split(maxsplit=1)
+        if len(parts) < 2:
+            return "用法: /img note <引用或序号> <新备注>"
+
+        ref_or_idx, new_note = parts[0], parts[1]
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+        images = self._image_asset_service.list_images(session_key)
+
+        ref = self._resolve_img_ref(ref_or_idx, images)
+        if ref is None:
+            return f"未找到图片: {ref_or_idx}"
+
+        if self._image_asset_service.update_note(
+            ref, new_note, session_key=session_key
+        ):
+            return f"已更新备注: {ref} — {new_note}"
+        return f"更新失败: {ref}"
+
+    def img_clear(self, event, target: str = "") -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+        target = target.strip()
+
+        if not target or target == "all":
+            count = self._image_asset_service.clear_images(session_key=session_key)
+            return f"已清理 {count} 张图片。" if count else "当前会话没有图片可清理。"
+
+        images = self._image_asset_service.list_images(session_key)
+        ref = self._resolve_img_ref(target, images)
+        if ref is None:
+            return f"未找到图片: {target}"
+
+        count = self._image_asset_service.clear_images(session_key=session_key, ref=ref)
+        return f"已清理: {ref}" if count else f"清理失败: {ref}"
+
+    def _resolve_img_ref(self, ref_or_idx: str, images: list[dict]) -> str | None:
+        if ref_or_idx.startswith("images/"):
+            return ref_or_idx
+        try:
+            idx = int(ref_or_idx)
+            if 1 <= idx <= len(images):
+                return images[idx - 1]["ref"]
+        except ValueError:
+            pass
+        for img in images:
+            if img["ref"].endswith(ref_or_idx):
+                return img["ref"]
+        return None

--- a/services/command_service.py
+++ b/services/command_service.py
@@ -392,12 +392,17 @@ class CommandService:
 
         lines = []
         if registered:
+            self._image_asset_service.set_active_images(
+                [info["ref"] for info in registered],
+                session_key=session_key,
+            )
             lines.append(f"已注册 {len(registered)} 张图片：")
             for info in registered:
                 size_str = format_file_size(info["size_bytes"])
                 lines.append(
                     f"  {info['ref']} ({info['width']}x{info['height']}, {size_str})"
                 )
+            lines.append("这批图片已设为当前活动图片，文档/PPT 工作流会优先使用它们。")
         if errors:
             lines.append("注册失败：")
             lines.extend(f"  {e}" for e in errors)
@@ -414,18 +419,64 @@ class CommandService:
         if not images:
             return "当前会话没有已注册的图片。使用 /img add 注册上传的图片。"
 
+        active_refs = {
+            img["ref"]
+            for img in self._image_asset_service.list_active_images(session_key)
+        }
         lines = [f"📷 当前会话图片（共 {len(images)} 张）："]
         for i, info in enumerate(images, 1):
             size_str = format_file_size(info["size_bytes"])
             note_str = f" — {info['note']}" if info["note"] else ""
+            active_mark = " [当前使用]" if info["ref"] in active_refs else ""
             detail_parts = []
             if info.get("original_name"):
                 detail_parts.append(info["original_name"])
             detail_parts.append(f"{info['width']}x{info['height']}")
             detail_parts.append(size_str)
             lines.append(
-                f"  {i}. {info['ref']}\n     {' | '.join(detail_parts)}{note_str}"
+                f"  {i}. {info['ref']}{active_mark}\n"
+                f"     {' | '.join(detail_parts)}{note_str}"
             )
+        lines.append("")
+        lines.append("使用 /img use <序号|引用|all> 选择本轮文档/PPT 可用图片。")
+        return "\n".join(lines)
+
+    def img_active(self, event) -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+        images = self._image_asset_service.list_active_images(session_key)
+        if not images:
+            return "当前没有活动图片。使用 /img add 注册图片，或 /img use 从已注册图片中选择。"
+        return self._format_active_images(images)
+
+    def img_use(self, event, selection: str = "") -> str:
+        access_error = self._require_access(event)
+        if access_error:
+            return access_error
+
+        session_key = self._upload_session_service.get_attachment_session_key(event)
+        images = self._image_asset_service.list_images(session_key)
+        if not images:
+            return "当前会话没有已注册的图片。使用 /img add 注册上传的图片。"
+
+        selection = selection.strip()
+        if not selection:
+            return "用法: /img use <序号|引用|all>。需要多张图片时用空格分隔，例如 /img use 1 3。"
+
+        refs, error = self._resolve_img_refs(selection, images)
+        if error:
+            return error
+        active_images = self._image_asset_service.set_active_images(
+            refs,
+            session_key=session_key,
+        )
+        if not active_images:
+            return "没有选择任何图片。"
+        lines = [f"已设置 {len(active_images)} 张当前活动图片："]
+        lines.extend(self._format_image_info_lines(active_images))
         return "\n".join(lines)
 
     def img_note(self, event, ref: str, note: str) -> str:
@@ -470,6 +521,43 @@ class CommandService:
 
         count = self._image_asset_service.clear_images(session_key=session_key, ref=ref)
         return f"已清理: {ref}" if count else f"清理失败: {ref}"
+
+    def _format_active_images(self, images: list[dict]) -> str:
+        lines = [f"当前活动图片（共 {len(images)} 张）："]
+        lines.extend(self._format_image_info_lines(images))
+        return "\n".join(lines)
+
+    def _format_image_info_lines(self, images: list[dict]) -> list[str]:
+        lines: list[str] = []
+        for i, info in enumerate(images, 1):
+            size_str = format_file_size(info["size_bytes"])
+            note_str = f" — {info['note']}" if info.get("note") else ""
+            detail_parts = []
+            if info.get("original_name"):
+                detail_parts.append(info["original_name"])
+            detail_parts.append(f"{info['width']}x{info['height']}")
+            detail_parts.append(size_str)
+            lines.append(
+                f"  {i}. {info['ref']}\n     {' | '.join(detail_parts)}{note_str}"
+            )
+        return lines
+
+    def _resolve_img_refs(
+        self,
+        selection: str,
+        images: list[dict],
+    ) -> tuple[list[str], str]:
+        if selection.strip() == "all":
+            return [img["ref"] for img in images], ""
+
+        refs: list[str] = []
+        for token in selection.split():
+            ref = self._resolve_img_ref(token, images)
+            if ref is None:
+                return [], f"未找到图片: {token}"
+            if ref not in refs:
+                refs.append(ref)
+        return refs, ""
 
     def _resolve_img_ref(self, ref_or_idx: str, images: list[dict]) -> str | None:
         if ref_or_idx.startswith("images/"):

--- a/services/command_service.py
+++ b/services/command_service.py
@@ -316,11 +316,38 @@ class CommandService:
 
     # ── /img commands ──
 
+    @staticmethod
+    def resolve_img_add_selection(
+        source_count: int, selection: str = ""
+    ) -> tuple[list[int], str, str]:
+        if source_count <= 0:
+            return (
+                [],
+                "",
+                "当前没有待注册的图片。请在消息中附带图片并发送 /img add，或先上传图片再使用 /img add。",
+            )
+
+        parts = selection.strip().split(maxsplit=1) if selection.strip() else []
+        selector = parts[0] if parts else "all"
+        note = parts[1] if len(parts) > 1 else ""
+
+        if source_count == 1 and selection.strip() and not note:
+            return [0], selection.strip(), ""
+        if selector == "all":
+            return list(range(source_count)), note, ""
+        try:
+            idx = int(selector)
+        except ValueError:
+            return list(range(source_count)), selection.strip(), ""
+        if idx < 1 or idx > source_count:
+            return [], note, f"序号超出范围。当前有 {source_count} 张待注册图片。"
+        return [idx - 1], note, ""
+
     def img_add(
         self,
         event,
         *,
-        source_items: list[tuple[Path, str]],
+        source_items: list[tuple[Path, str] | tuple[Path, str, object]],
         selection: str = "",
     ) -> str:
         access_error = self._require_access(event)
@@ -331,30 +358,23 @@ class CommandService:
             return "当前没有待注册的图片。请在消息中附带图片并发送 /img add，或先上传图片再使用 /img add。"
 
         session_key = self._upload_session_service.get_attachment_session_key(event)
+        normalized_items: list[tuple[Path, str, object]] = []
+        for item in source_items:
+            path = Path(item[0])
+            original_name = str(item[1] or "")
+            resource = item[2] if len(item) >= 3 else path
+            normalized_items.append((path, original_name, resource))
 
-        parts = selection.strip().split(maxsplit=1) if selection.strip() else []
-        selector = parts[0] if parts else "all"
-        note = parts[1] if len(parts) > 1 else ""
-
-        if len(source_items) == 1 and selection.strip() and not note:
-            note = selection.strip()
-            targets = list(enumerate(source_items, 1))
-        elif selector == "all":
-            targets = list(enumerate(source_items, 1))
-        else:
-            try:
-                idx = int(selector)
-            except ValueError:
-                note = selection.strip()
-                targets = list(enumerate(source_items, 1))
-            else:
-                if idx < 1 or idx > len(source_items):
-                    return f"序号超出范围。当前有 {len(source_items)} 张待注册图片。"
-                targets = [(idx, source_items[idx - 1])]
+        target_indices, note, selection_error = self.resolve_img_add_selection(
+            len(normalized_items), selection
+        )
+        if selection_error:
+            return selection_error
+        targets = [(idx + 1, normalized_items[idx]) for idx in target_indices]
 
         registered = []
         errors = []
-        for idx, (path, original_name) in targets:
+        for idx, (path, original_name, _resource) in targets:
             try:
                 info = self._image_asset_service.register_image(
                     path,
@@ -365,6 +385,10 @@ class CommandService:
                 registered.append(info)
             except (ValueError, FileNotFoundError) as exc:
                 errors.append(f"图片 {idx}: {exc}")
+
+        self._upload_session_service.clear_pending_image_resources(
+            event, [resource for _idx, (_path, _name, resource) in targets]
+        )
 
         lines = []
         if registered:

--- a/services/command_service.py
+++ b/services/command_service.py
@@ -320,15 +320,15 @@ class CommandService:
         self,
         event,
         *,
-        source_paths: list[Path],
+        source_items: list[tuple[Path, str]],
         selection: str = "",
     ) -> str:
         access_error = self._require_access(event)
         if access_error:
             return access_error
 
-        if not source_paths:
-            return "当前没有待注册的图片。请先在聊天中上传图片，再使用 /img add。"
+        if not source_items:
+            return "当前没有待注册的图片。请在消息中附带图片并发送 /img add，或先上传图片再使用 /img add。"
 
         session_key = self._upload_session_service.get_attachment_session_key(event)
 
@@ -336,28 +336,31 @@ class CommandService:
         selector = parts[0] if parts else "all"
         note = parts[1] if len(parts) > 1 else ""
 
-        if selector == "all":
-            targets = list(enumerate(source_paths, 1))
+        if len(source_items) == 1 and selection.strip() and not note:
+            note = selection.strip()
+            targets = list(enumerate(source_items, 1))
+        elif selector == "all":
+            targets = list(enumerate(source_items, 1))
         else:
             try:
                 idx = int(selector)
             except ValueError:
                 note = selection.strip()
-                targets = list(enumerate(source_paths, 1))
+                targets = list(enumerate(source_items, 1))
             else:
-                if idx < 1 or idx > len(source_paths):
-                    return f"序号超出范围。当前有 {len(source_paths)} 张待注册图片。"
-                targets = [(idx, source_paths[idx - 1])]
+                if idx < 1 or idx > len(source_items):
+                    return f"序号超出范围。当前有 {len(source_items)} 张待注册图片。"
+                targets = [(idx, source_items[idx - 1])]
 
         registered = []
         errors = []
-        for idx, path in targets:
+        for idx, (path, original_name) in targets:
             try:
                 info = self._image_asset_service.register_image(
                     path,
                     session_key=session_key,
                     note=note,
-                    original_name=path.name,
+                    original_name=original_name,
                 )
                 registered.append(info)
             except (ValueError, FileNotFoundError) as exc:
@@ -391,35 +394,38 @@ class CommandService:
         for i, info in enumerate(images, 1):
             size_str = format_file_size(info["size_bytes"])
             note_str = f" — {info['note']}" if info["note"] else ""
+            detail_parts = []
+            if info.get("original_name"):
+                detail_parts.append(info["original_name"])
+            detail_parts.append(f"{info['width']}x{info['height']}")
+            detail_parts.append(size_str)
             lines.append(
-                f"  {i}. {info['ref']}\n"
-                f"     原名: {info['original_name']} | "
-                f"{info['width']}x{info['height']} | {size_str}{note_str}"
+                f"  {i}. {info['ref']}\n     {' | '.join(detail_parts)}{note_str}"
             )
         return "\n".join(lines)
 
-    def img_note(self, event, args: str) -> str:
+    def img_note(self, event, ref: str, note: str) -> str:
         access_error = self._require_access(event)
         if access_error:
             return access_error
 
-        parts = args.strip().split(maxsplit=1)
-        if len(parts) < 2:
+        ref = ref.strip()
+        note = note.strip()
+        if not ref or not note:
             return "用法: /img note <引用或序号> <新备注>"
 
-        ref_or_idx, new_note = parts[0], parts[1]
         session_key = self._upload_session_service.get_attachment_session_key(event)
         images = self._image_asset_service.list_images(session_key)
 
-        ref = self._resolve_img_ref(ref_or_idx, images)
-        if ref is None:
-            return f"未找到图片: {ref_or_idx}"
+        resolved = self._resolve_img_ref(ref, images)
+        if resolved is None:
+            return f"未找到图片: {ref}"
 
         if self._image_asset_service.update_note(
-            ref, new_note, session_key=session_key
+            resolved, note, session_key=session_key
         ):
-            return f"已更新备注: {ref} — {new_note}"
-        return f"更新失败: {ref}"
+            return f"已更新备注: {resolved} — {note}"
+        return f"更新失败: {resolved}"
 
     def img_clear(self, event, target: str = "") -> str:
         access_error = self._require_access(event)

--- a/services/command_service.py
+++ b/services/command_service.py
@@ -443,14 +443,13 @@ class CommandService:
 
     def _resolve_img_ref(self, ref_or_idx: str, images: list[dict]) -> str | None:
         if ref_or_idx.startswith("images/"):
-            return ref_or_idx
+            return (
+                ref_or_idx if any(img["ref"] == ref_or_idx for img in images) else None
+            )
         try:
             idx = int(ref_or_idx)
             if 1 <= idx <= len(images):
                 return images[idx - 1]["ref"]
         except ValueError:
             pass
-        for img in images:
-            if img["ref"].endswith(ref_or_idx):
-                return img["ref"]
         return None

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -84,24 +84,30 @@ class ImageAssetService:
                 f"不支持的图片格式: {pil_format}。仅接受 PNG、JPEG、WebP。"
             )
 
-        ext_map = {"PNG": ".png", "JPEG": ".jpg", "WEBP": ".webp"}
+        ext_map = {"PNG": ".png", "JPEG": ".jpg", "WEBP": ".png"}
         real_ext = ext_map[pil_format]
+        stored_format = "PNG" if pil_format == "WEBP" else pil_format
 
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d")
         short_id = uuid.uuid4().hex[:8]
         filename = f"img_{timestamp}_{short_id}{real_ext}"
         dest_path = self._images_dir / filename
 
-        shutil.copy2(source_path, dest_path)
+        if pil_format == "WEBP":
+            # docx/pptx 无法嵌入 webp，注册时转存为 png 保证文档生成兼容
+            with Image.open(source_path) as img:
+                img.save(dest_path, format="PNG")
+        else:
+            shutil.copy2(source_path, dest_path)
 
         ref = f"images/{filename}"
         info: ImageAssetInfo = {
             "ref": ref,
-            "original_name": original_name or source_path.name,
+            "original_name": original_name or "",
             "note": note,
             "width": width,
             "height": height,
-            "format": pil_format,
+            "format": stored_format,
             "size_bytes": dest_path.stat().st_size,
             "registered_at": time.time(),
             "session_key": list(session_key),

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+import shutil
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+from astrbot.api import logger
+
+ALLOWED_FORMATS = {"PNG", "JPEG", "WEBP"}
+ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
+SVG_EXTENSIONS = {".svg", ".svgz"}
+
+
+class ImageAssetInfo(TypedDict):
+    ref: str
+    original_name: str
+    note: str
+    width: int
+    height: int
+    format: str
+    size_bytes: int
+    registered_at: float
+    session_key: list[str]
+
+
+class ImageAssetService:
+    def __init__(self, *, plugin_data_path: Path) -> None:
+        self._images_dir = plugin_data_path / "images"
+        self._images_dir.mkdir(parents=True, exist_ok=True)
+        self._index_path = self._images_dir / "index.json"
+        self._index: list[ImageAssetInfo] = self._load_index()
+
+    def _load_index(self) -> list[ImageAssetInfo]:
+        if self._index_path.exists():
+            try:
+                data = json.loads(self._index_path.read_text(encoding="utf-8"))
+                if isinstance(data, list):
+                    return data
+            except (json.JSONDecodeError, OSError):
+                logger.warning("image asset index corrupted, starting fresh")
+        return []
+
+    def _save_index(self) -> None:
+        self._index_path.write_text(
+            json.dumps(self._index, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def register_image(
+        self,
+        source_path: Path,
+        *,
+        session_key: tuple[str, str, str],
+        note: str = "",
+        original_name: str = "",
+    ) -> ImageAssetInfo:
+        source_path = Path(source_path)
+        if not source_path.exists():
+            raise FileNotFoundError(f"源文件不存在: {source_path}")
+
+        suffix = source_path.suffix.lower()
+        if suffix in SVG_EXTENSIONS:
+            raise ValueError(
+                "不支持 SVG 格式。请提供 PNG、JPEG 或 WebP 格式的位图文件。"
+            )
+
+        from PIL import Image
+
+        try:
+            with Image.open(source_path) as img:
+                img.verify()
+            with Image.open(source_path) as img:
+                pil_format = img.format
+                width, height = img.size
+        except Exception as exc:
+            raise ValueError(f"无法识别为有效图片: {exc}") from exc
+
+        if pil_format not in ALLOWED_FORMATS:
+            raise ValueError(
+                f"不支持的图片格式: {pil_format}。仅接受 PNG、JPEG、WebP。"
+            )
+
+        ext_map = {"PNG": ".png", "JPEG": ".jpg", "WEBP": ".webp"}
+        real_ext = ext_map[pil_format]
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d")
+        short_id = uuid.uuid4().hex[:8]
+        filename = f"img_{timestamp}_{short_id}{real_ext}"
+        dest_path = self._images_dir / filename
+
+        shutil.copy2(source_path, dest_path)
+
+        ref = f"images/{filename}"
+        info: ImageAssetInfo = {
+            "ref": ref,
+            "original_name": original_name or source_path.name,
+            "note": note,
+            "width": width,
+            "height": height,
+            "format": pil_format,
+            "size_bytes": dest_path.stat().st_size,
+            "registered_at": time.time(),
+            "session_key": list(session_key),
+        }
+        self._index.append(info)
+        self._save_index()
+        return info
+
+    def list_images(self, session_key: tuple[str, str, str]) -> list[ImageAssetInfo]:
+        sk = list(session_key)
+        return [item for item in self._index if item["session_key"] == sk]
+
+    def update_note(
+        self,
+        ref: str,
+        note: str,
+        *,
+        session_key: tuple[str, str, str],
+    ) -> bool:
+        sk = list(session_key)
+        for item in self._index:
+            if item["ref"] == ref and item["session_key"] == sk:
+                item["note"] = note
+                self._save_index()
+                return True
+        return False
+
+    def clear_images(
+        self,
+        *,
+        session_key: tuple[str, str, str],
+        ref: str | None = None,
+    ) -> int:
+        sk = list(session_key)
+        to_remove: list[ImageAssetInfo] = []
+        kept: list[ImageAssetInfo] = []
+
+        for item in self._index:
+            if item["session_key"] != sk:
+                kept.append(item)
+                continue
+            if ref is None or item["ref"] == ref:
+                to_remove.append(item)
+            else:
+                kept.append(item)
+
+        for item in to_remove:
+            file_path = self._images_dir.parent / item["ref"]
+            if file_path.exists():
+                try:
+                    file_path.unlink()
+                except OSError:
+                    logger.warning(f"failed to delete image file: {file_path}")
+
+        self._index = kept
+        self._save_index()
+        return len(to_remove)
+
+    def resolve_ref(
+        self,
+        ref: str,
+        *,
+        session_key: tuple[str, str, str],
+    ) -> Path:
+        if not ref.startswith("images/"):
+            raise ValueError(f"无效的图片引用: {ref}。引用必须以 images/ 开头。")
+        if ".." in ref.replace("\\", "/").split("/"):
+            raise ValueError("图片引用不允许包含目录遍历 (..)")
+
+        sk = list(session_key)
+        found = any(
+            item["ref"] == ref and item["session_key"] == sk for item in self._index
+        )
+        if not found:
+            raise ValueError(
+                f"图片引用 {ref} 不在当前会话的资源池中。请先使用 /img add 注册图片。"
+            )
+
+        file_path = self._images_dir.parent / ref
+        if not file_path.exists():
+            raise FileNotFoundError(
+                f"图片文件不存在: {ref}。可能已被清理，请重新上传。"
+            )
+        return file_path.resolve()
+
+    def ref_exists(
+        self,
+        ref: str,
+        *,
+        session_key: tuple[str, str, str],
+    ) -> bool:
+        try:
+            self.resolve_ref(ref, session_key=session_key)
+            return True
+        except (ValueError, FileNotFoundError):
+            return False

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -11,7 +11,6 @@ from typing import TypedDict
 from astrbot.api import logger
 
 ALLOWED_FORMATS = {"PNG", "JPEG", "WEBP"}
-ALLOWED_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp"}
 SVG_EXTENSIONS = {".svg", ".svgz"}
 
 

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -34,6 +34,9 @@ class ImageAssetService:
         self._images_dir.mkdir(parents=True, exist_ok=True)
         self._index_path = self._images_dir / "index.json"
         self._index: list[ImageAssetInfo] = self._load_index()
+        self._by_session_ref: dict[tuple[str, str, str], dict[str, ImageAssetInfo]] = (
+            self._build_lookup(self._index)
+        )
 
     def _load_index(self) -> list[ImageAssetInfo]:
         if self._index_path.exists():
@@ -54,6 +57,24 @@ class ImageAssetService:
         except OSError as exc:
             logger.warning("failed to persist image asset index: %s", exc)
 
+    @staticmethod
+    def _normalize_session_key(
+        session_key: tuple[str, str, str] | list[str],
+    ) -> tuple[str, str, str]:
+        platform_id, sender_id, origin = (list(session_key) + ["", "", ""])[:3]
+        return (str(platform_id), str(sender_id), str(origin))
+
+    @classmethod
+    def _build_lookup(
+        cls,
+        items: list[ImageAssetInfo],
+    ) -> dict[tuple[str, str, str], dict[str, ImageAssetInfo]]:
+        lookup: dict[tuple[str, str, str], dict[str, ImageAssetInfo]] = {}
+        for item in items:
+            session_key = cls._normalize_session_key(item["session_key"])
+            lookup.setdefault(session_key, {})[item["ref"]] = item
+        return lookup
+
     def register_image(
         self,
         source_path: Path,
@@ -62,6 +83,7 @@ class ImageAssetService:
         note: str = "",
         original_name: str = "",
     ) -> ImageAssetInfo:
+        session_key = self._normalize_session_key(session_key)
         source_path = Path(source_path)
         if not source_path.exists():
             raise FileNotFoundError(f"源文件不存在: {source_path}")
@@ -117,12 +139,13 @@ class ImageAssetService:
             "session_key": list(session_key),
         }
         self._index.append(info)
+        self._by_session_ref.setdefault(session_key, {})[ref] = info
         self._save_index()
         return info
 
     def list_images(self, session_key: tuple[str, str, str]) -> list[ImageAssetInfo]:
-        sk = list(session_key)
-        return [item for item in self._index if item["session_key"] == sk]
+        session_key = self._normalize_session_key(session_key)
+        return list(self._by_session_ref.get(session_key, {}).values())
 
     def update_note(
         self,
@@ -131,13 +154,13 @@ class ImageAssetService:
         *,
         session_key: tuple[str, str, str],
     ) -> bool:
-        sk = list(session_key)
-        for item in self._index:
-            if item["ref"] == ref and item["session_key"] == sk:
-                item["note"] = note
-                self._save_index()
-                return True
-        return False
+        session_key = self._normalize_session_key(session_key)
+        item = self._by_session_ref.get(session_key, {}).get(ref)
+        if item is None:
+            return False
+        item["note"] = note
+        self._save_index()
+        return True
 
     def clear_images(
         self,
@@ -145,18 +168,15 @@ class ImageAssetService:
         session_key: tuple[str, str, str],
         ref: str | None = None,
     ) -> int:
-        sk = list(session_key)
-        to_remove: list[ImageAssetInfo] = []
-        kept: list[ImageAssetInfo] = []
-
-        for item in self._index:
-            if item["session_key"] != sk:
-                kept.append(item)
-                continue
-            if ref is None or item["ref"] == ref:
-                to_remove.append(item)
-            else:
-                kept.append(item)
+        session_key = self._normalize_session_key(session_key)
+        session_items = self._by_session_ref.get(session_key, {})
+        if ref is None:
+            to_remove = list(session_items.values())
+        else:
+            item = session_items.get(ref)
+            to_remove = [item] if item is not None else []
+        if not to_remove:
+            return 0
 
         for item in to_remove:
             file_path = self._images_dir.parent / item["ref"]
@@ -166,7 +186,21 @@ class ImageAssetService:
                 except OSError:
                     logger.warning(f"failed to delete image file: {file_path}")
 
-        self._index = kept
+        removed_refs = {item["ref"] for item in to_remove}
+        self._index = [
+            item
+            for item in self._index
+            if not (
+                self._normalize_session_key(item["session_key"]) == session_key
+                and item["ref"] in removed_refs
+            )
+        ]
+        if ref is None:
+            self._by_session_ref.pop(session_key, None)
+        else:
+            session_items.pop(ref, None)
+            if not session_items:
+                self._by_session_ref.pop(session_key, None)
         self._save_index()
         return len(to_remove)
 
@@ -176,16 +210,13 @@ class ImageAssetService:
         *,
         session_key: tuple[str, str, str],
     ) -> Path:
+        session_key = self._normalize_session_key(session_key)
         try:
             ref = validate_image_asset_ref(ref)
         except ValueError as exc:
             raise ValueError(f"无效的图片引用: {ref}。{exc}") from exc
 
-        sk = list(session_key)
-        found = any(
-            item["ref"] == ref and item["session_key"] == sk for item in self._index
-        )
-        if not found:
+        if ref not in self._by_session_ref.get(session_key, {}):
             raise ValueError(
                 f"图片引用 {ref} 不在当前会话的资源池中。请先使用 /img add 注册图片。"
             )

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -45,10 +45,13 @@ class ImageAssetService:
         return []
 
     def _save_index(self) -> None:
-        self._index_path.write_text(
-            json.dumps(self._index, ensure_ascii=False, indent=2),
-            encoding="utf-8",
-        )
+        tmp_path = self._index_path.with_suffix(self._index_path.suffix + ".tmp")
+        data = json.dumps(self._index, ensure_ascii=False, indent=2)
+        try:
+            tmp_path.write_text(data, encoding="utf-8")
+            tmp_path.replace(self._index_path)
+        except OSError as exc:
+            logger.warning("failed to persist image asset index: %s", exc)
 
     def register_image(
         self,

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -28,14 +28,23 @@ class ImageAssetInfo(TypedDict):
     session_key: list[str]
 
 
+class ImageAssetActiveSet(TypedDict):
+    session_key: list[str]
+    refs: list[str]
+
+
 class ImageAssetService:
     def __init__(self, *, plugin_data_path: Path) -> None:
         self._images_dir = plugin_data_path / "images"
         self._images_dir.mkdir(parents=True, exist_ok=True)
         self._index_path = self._images_dir / "index.json"
+        self._active_path = self._images_dir / "active.json"
         self._index: list[ImageAssetInfo] = self._load_index()
         self._by_session_ref: dict[tuple[str, str, str], dict[str, ImageAssetInfo]] = (
             self._build_lookup(self._index)
+        )
+        self._active_refs_by_session: dict[tuple[str, str, str], list[str]] = (
+            self._load_active_refs()
         )
 
     def _load_index(self) -> list[ImageAssetInfo]:
@@ -56,6 +65,46 @@ class ImageAssetService:
             tmp_path.replace(self._index_path)
         except OSError as exc:
             logger.warning("failed to persist image asset index: %s", exc)
+
+    def _load_active_refs(self) -> dict[tuple[str, str, str], list[str]]:
+        if not self._active_path.exists():
+            return {}
+        try:
+            data = json.loads(self._active_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            logger.warning("image asset active set corrupted, starting fresh")
+            return {}
+        if not isinstance(data, list):
+            return {}
+
+        active_refs: dict[tuple[str, str, str], list[str]] = {}
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            raw_refs = item.get("refs")
+            if not isinstance(raw_refs, list):
+                continue
+            session_key = self._normalize_session_key(item.get("session_key", []))
+            refs = [str(ref) for ref in raw_refs if isinstance(ref, str)]
+            if refs:
+                active_refs[session_key] = refs
+        return active_refs
+
+    def _save_active_refs(self) -> None:
+        tmp_path = self._active_path.with_suffix(self._active_path.suffix + ".tmp")
+        data: list[ImageAssetActiveSet] = [
+            {"session_key": list(session_key), "refs": refs}
+            for session_key, refs in self._active_refs_by_session.items()
+            if refs
+        ]
+        try:
+            tmp_path.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            tmp_path.replace(self._active_path)
+        except OSError as exc:
+            logger.warning("failed to persist image asset active set: %s", exc)
 
     @staticmethod
     def _normalize_session_key(
@@ -147,6 +196,46 @@ class ImageAssetService:
         session_key = self._normalize_session_key(session_key)
         return list(self._by_session_ref.get(session_key, {}).values())
 
+    def list_active_images(
+        self,
+        session_key: tuple[str, str, str],
+    ) -> list[ImageAssetInfo]:
+        session_key = self._normalize_session_key(session_key)
+        session_items = self._by_session_ref.get(session_key, {})
+        active_refs = self._active_refs_by_session.get(session_key, [])
+        active_images = [
+            session_items[ref] for ref in active_refs if ref in session_items
+        ]
+        if len(active_images) != len(active_refs):
+            if active_images:
+                self._active_refs_by_session[session_key] = [
+                    item["ref"] for item in active_images
+                ]
+            else:
+                self._active_refs_by_session.pop(session_key, None)
+            self._save_active_refs()
+        return active_images
+
+    def set_active_images(
+        self,
+        refs: list[str],
+        *,
+        session_key: tuple[str, str, str],
+    ) -> list[ImageAssetInfo]:
+        session_key = self._normalize_session_key(session_key)
+        session_items = self._by_session_ref.get(session_key, {})
+        active_refs: list[str] = []
+        for ref in refs:
+            if ref not in session_items or ref in active_refs:
+                continue
+            active_refs.append(ref)
+        if active_refs:
+            self._active_refs_by_session[session_key] = active_refs
+        else:
+            self._active_refs_by_session.pop(session_key, None)
+        self._save_active_refs()
+        return [session_items[ref] for ref in active_refs]
+
     def update_note(
         self,
         ref: str,
@@ -201,7 +290,20 @@ class ImageAssetService:
             session_items.pop(ref, None)
             if not session_items:
                 self._by_session_ref.pop(session_key, None)
+
+        active_refs = self._active_refs_by_session.get(session_key)
+        if active_refs is not None:
+            remaining_active_refs = [
+                active_ref
+                for active_ref in active_refs
+                if active_ref not in removed_refs
+            ]
+            if remaining_active_refs:
+                self._active_refs_by_session[session_key] = remaining_active_refs
+            else:
+                self._active_refs_by_session.pop(session_key, None)
         self._save_index()
+        self._save_active_refs()
         return len(to_remove)
 
     def resolve_ref(

--- a/services/image_asset_service.py
+++ b/services/image_asset_service.py
@@ -10,6 +10,8 @@ from typing import TypedDict
 
 from astrbot.api import logger
 
+from ..document_core.models.blocks import validate_image_asset_ref
+
 ALLOWED_FORMATS = {"PNG", "JPEG", "WEBP"}
 SVG_EXTENSIONS = {".svg", ".svgz"}
 
@@ -174,10 +176,10 @@ class ImageAssetService:
         *,
         session_key: tuple[str, str, str],
     ) -> Path:
-        if not ref.startswith("images/"):
-            raise ValueError(f"无效的图片引用: {ref}。引用必须以 images/ 开头。")
-        if ".." in ref.replace("\\", "/").split("/"):
-            raise ValueError("图片引用不允许包含目录遍历 (..)")
+        try:
+            ref = validate_image_asset_ref(ref)
+        except ValueError as exc:
+            raise ValueError(f"无效的图片引用: {ref}。{exc}") from exc
 
         sk = list(session_key)
         found = any(

--- a/services/image_file_utils.py
+++ b/services/image_file_utils.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+from typing import Any
 from urllib.parse import unquote, urlparse
+
+import astrbot.api.message_components as Comp
 
 IMAGE_FILE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
 IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/webp"})
@@ -23,3 +26,17 @@ def is_supported_image_mime_type(mime_type: str) -> bool:
         str(mime_type or "").split(";", maxsplit=1)[0].strip().lower()
         in IMAGE_MIME_TYPES
     )
+
+
+def is_image_file_component(component: Any) -> bool:
+    if not isinstance(component, Comp.File):
+        return False
+    for attr_name in ("name", "file", "file_", "url"):
+        value = getattr(component, attr_name, "") or ""
+        if value and is_supported_image_reference(str(value)):
+            return True
+    for attr_name in ("mime_type", "mimetype", "mime", "content_type"):
+        value = getattr(component, attr_name, "") or ""
+        if value and is_supported_image_mime_type(str(value)):
+            return True
+    return False

--- a/services/image_file_utils.py
+++ b/services/image_file_utils.py
@@ -1,7 +1,25 @@
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 IMAGE_FILE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+IMAGE_MIME_TYPES = frozenset({"image/png", "image/jpeg", "image/webp"})
 
 
 def is_supported_image_filename(filename: str) -> bool:
     return Path(filename).suffix.lower() in IMAGE_FILE_SUFFIXES
+
+
+def is_supported_image_reference(value: str) -> bool:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return False
+    parsed = urlparse(candidate)
+    path_value = parsed.path if parsed.scheme and parsed.path else candidate
+    return is_supported_image_filename(unquote(path_value))
+
+
+def is_supported_image_mime_type(mime_type: str) -> bool:
+    return (
+        str(mime_type or "").split(";", maxsplit=1)[0].strip().lower()
+        in IMAGE_MIME_TYPES
+    )

--- a/services/image_file_utils.py
+++ b/services/image_file_utils.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+IMAGE_FILE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+
+
+def is_supported_image_filename(filename: str) -> bool:
+    return Path(filename).suffix.lower() in IMAGE_FILE_SUFFIXES

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -81,10 +81,13 @@ class IncomingMessageService:
 
         if not has_supported_file:
             if self._is_image_message(event):
+                pending_resources = []
                 for component in event.message_obj.message:
                     if isinstance(component, (Comp.Image, Comp.File)):
                         self._cache_pending_image_resource(event, component)
+                        pending_resources.append(component)
                 setattr(event, "_has_pending_images", True)
+                setattr(event, "_pending_image_resources", pending_resources)
                 logger.debug("[文件管理] 图片已缓存为待注册资源，消息正常流向 LLM")
                 return
             if self._message_buffer.is_buffering(event):

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -4,8 +4,7 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
-
-_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+from .image_file_utils import is_supported_image_filename
 
 
 class IncomingMessageService:
@@ -45,8 +44,7 @@ class IncomingMessageService:
                 continue
             if isinstance(component, Comp.File):
                 name = component.name or ""
-                suffix = Path(name).suffix.lower() if name else ""
-                if suffix in _IMAGE_SUFFIXES:
+                if name and is_supported_image_filename(name):
                     has_image = True
                     continue
                 return False

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -4,10 +4,7 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
-from .image_file_utils import (
-    is_supported_image_mime_type,
-    is_supported_image_reference,
-)
+from .image_file_utils import is_image_file_component
 
 
 class IncomingMessageService:
@@ -46,7 +43,7 @@ class IncomingMessageService:
                 has_image = True
                 continue
             if isinstance(component, Comp.File):
-                if self._is_image_file_component(component):
+                if is_image_file_component(component):
                     has_image = True
                     continue
                 return False
@@ -55,18 +52,6 @@ class IncomingMessageService:
                 if text.startswith("/"):
                     return False
         return has_image
-
-    @staticmethod
-    def _is_image_file_component(component: Comp.File) -> bool:
-        for attr_name in ("name", "file", "file_", "url"):
-            value = getattr(component, attr_name, "") or ""
-            if value and is_supported_image_reference(str(value)):
-                return True
-        for attr_name in ("mime_type", "mimetype", "mime", "content_type"):
-            value = getattr(component, attr_name, "") or ""
-            if value and is_supported_image_mime_type(str(value)):
-                return True
-        return False
 
     async def handle_file_message(self, event) -> None:
         if getattr(event, "_buffered", False):

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -5,6 +5,8 @@ from astrbot.api import logger
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
 
+_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+
 
 class IncomingMessageService:
     def __init__(
@@ -13,10 +15,12 @@ class IncomingMessageService:
         message_buffer,
         remember_recent_text,
         is_group_feature_enabled,
+        cache_pending_image_resource,
     ) -> None:
         self._message_buffer = message_buffer
         self._remember_recent_text = remember_recent_text
         self._is_group_feature_enabled = is_group_feature_enabled
+        self._cache_pending_image_resource = cache_pending_image_resource
 
     def _has_follow_up_text(self, event) -> bool:
         has_plain_text = False
@@ -31,6 +35,26 @@ class IncomingMessageService:
                     return False
                 has_plain_text = True
         return has_plain_text
+
+    def _is_image_message(self, event) -> bool:
+        """检查消息是否只包含图片（Comp.Image 或图片后缀的 Comp.File），无命令文本"""
+        has_image = False
+        for component in event.message_obj.message:
+            if isinstance(component, Comp.Image):
+                has_image = True
+                continue
+            if isinstance(component, Comp.File):
+                name = component.name or ""
+                suffix = Path(name).suffix.lower() if name else ""
+                if suffix in _IMAGE_SUFFIXES:
+                    has_image = True
+                    continue
+                return False
+            if isinstance(component, Comp.Plain):
+                text = component.text.strip()
+                if text.startswith("/"):
+                    return False
+        return has_image
 
     async def handle_file_message(self, event) -> None:
         if getattr(event, "_buffered", False):
@@ -56,6 +80,13 @@ class IncomingMessageService:
                     break
 
         if not has_supported_file:
+            if self._is_image_message(event):
+                for component in event.message_obj.message:
+                    if isinstance(component, (Comp.Image, Comp.File)):
+                        self._cache_pending_image_resource(event, component)
+                setattr(event, "_has_pending_images", True)
+                logger.debug("[文件管理] 图片已缓存为待注册资源，消息正常流向 LLM")
+                return
             if self._message_buffer.is_buffering(event):
                 if not self._has_follow_up_text(event):
                     return

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -58,7 +58,7 @@ class IncomingMessageService:
 
     @staticmethod
     def _is_image_file_component(component: Comp.File) -> bool:
-        for attr_name in ("name", "file_", "url"):
+        for attr_name in ("name", "file", "file_", "url"):
             value = getattr(component, attr_name, "") or ""
             if value and is_supported_image_reference(str(value)):
                 return True

--- a/services/incoming_message_service.py
+++ b/services/incoming_message_service.py
@@ -4,7 +4,10 @@ import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
-from .image_file_utils import is_supported_image_filename
+from .image_file_utils import (
+    is_supported_image_mime_type,
+    is_supported_image_reference,
+)
 
 
 class IncomingMessageService:
@@ -43,8 +46,7 @@ class IncomingMessageService:
                 has_image = True
                 continue
             if isinstance(component, Comp.File):
-                name = component.name or ""
-                if name and is_supported_image_filename(name):
+                if self._is_image_file_component(component):
                     has_image = True
                     continue
                 return False
@@ -53,6 +55,18 @@ class IncomingMessageService:
                 if text.startswith("/"):
                     return False
         return has_image
+
+    @staticmethod
+    def _is_image_file_component(component: Comp.File) -> bool:
+        for attr_name in ("name", "file_", "url"):
+            value = getattr(component, attr_name, "") or ""
+            if value and is_supported_image_reference(str(value)):
+                return True
+        for attr_name in ("mime_type", "mimetype", "mime", "content_type"):
+            value = getattr(component, attr_name, "") or ""
+            if value and is_supported_image_mime_type(str(value)):
+                return True
+        return False
 
     async def handle_file_message(self, event) -> None:
         if getattr(event, "_buffered", False):

--- a/services/message_buffer.py
+++ b/services/message_buffer.py
@@ -186,14 +186,21 @@ class MessageBuffer:
         key = self._get_buffer_key(event)
         return key in self._buffers
 
-    async def pop_buffer(self, event: AstrMessageEvent) -> BufferedMessage | None:
-        """取出当前用户的缓冲并取消定时器，用于命令显式消费缓冲内容"""
+    async def pop_images(self, event: AstrMessageEvent) -> list[Comp.Image]:
+        """取出当前用户缓冲中的图片，保留文件/文本继续等待聚合完成。"""
         key = self._get_buffer_key(event)
         async with self._lock:
-            buf = self._buffers.pop(key, None)
-            if buf and buf.timer_task and not buf.timer_task.done():
+            buf = self._buffers.get(key)
+            if buf is None or not buf.images:
+                return []
+            images = list(buf.images)
+            buf.images.clear()
+            if buf.files or buf.texts:
+                return images
+            self._buffers.pop(key, None)
+            if buf.timer_task and not buf.timer_task.done():
                 buf.timer_task.cancel()
-            return buf
+            return images
 
     async def cancel_buffer(self, event: AstrMessageEvent):
         """取消指定用户的缓冲"""

--- a/services/message_buffer.py
+++ b/services/message_buffer.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 import astrbot.api.message_components as Comp
 from astrbot.api import logger
 
+from .image_file_utils import is_image_file_component
+
 if TYPE_CHECKING:
     from astrbot.api.event import AstrMessageEvent
 
@@ -186,15 +188,24 @@ class MessageBuffer:
         key = self._get_buffer_key(event)
         return key in self._buffers
 
-    async def pop_images(self, event: AstrMessageEvent) -> list[Comp.Image]:
-        """取出当前用户缓冲中的图片，保留文件/文本继续等待聚合完成。"""
+    async def pop_images(self, event: AstrMessageEvent) -> list[Comp.Image | Comp.File]:
+        """取出当前用户缓冲中的图片，保留非图片文件/文本继续等待聚合完成。"""
         key = self._get_buffer_key(event)
         async with self._lock:
             buf = self._buffers.get(key)
-            if buf is None or not buf.images:
+            if buf is None:
                 return []
             images = list(buf.images)
+            image_files = [file for file in buf.files if is_image_file_component(file)]
+            if not images and not image_files:
+                return []
             buf.images.clear()
+            if image_files:
+                image_file_ids = {id(file) for file in image_files}
+                buf.files = [
+                    file for file in buf.files if id(file) not in image_file_ids
+                ]
+                images.extend(image_files)
             if buf.files or buf.texts:
                 return images
             self._buffers.pop(key, None)

--- a/services/message_buffer.py
+++ b/services/message_buffer.py
@@ -21,6 +21,7 @@ class BufferedMessage:
 
     event: AstrMessageEvent  # 原始事件（用于发送响应等）
     files: list[Comp.File] = field(default_factory=list)  # 文件列表
+    images: list[Comp.Image] = field(default_factory=list)  # 图片列表
     texts: list[str] = field(default_factory=list)  # 文本内容列表
     timer_task: asyncio.Task | None = None  # 定时器任务
 
@@ -60,38 +61,50 @@ class MessageBuffer:
 
     def _extract_components(
         self, event: AstrMessageEvent
-    ) -> tuple[list[Comp.File], list[str]]:
-        """从消息中提取文件和文本组件"""
+    ) -> tuple[list[Comp.File], list[Comp.Image], list[str]]:
+        """从消息中提取文件、图片和文本组件"""
         files = []
+        images = []
         texts = []
 
         for component in event.message_obj.message:
             if isinstance(component, Comp.File):
                 files.append(component)
+            elif isinstance(component, Comp.Image):
+                images.append(component)
             elif isinstance(component, Comp.Plain):
                 text = component.text.strip()
                 if text:
                     texts.append(text)
             # 忽略 At、Reply 等其他组件
 
-        return files, texts
+        return files, images, texts
 
-    async def add_message(self, event: AstrMessageEvent) -> bool:
+    async def add_message(
+        self,
+        event: AstrMessageEvent,
+        *,
+        wait_seconds: float | None = None,
+    ) -> bool:
         """
         添加消息到缓冲区
 
         Args:
             event: 消息事件
+            wait_seconds: 可选的覆盖等待时间，用于不同类型消息（例如图片）使用不同的缓冲窗口
 
         Returns:
             True: 消息已被缓冲，调用方应停止事件传播
             False: 消息不需要缓冲（缓冲器已禁用）
         """
+        effective_wait = (
+            self._wait_seconds if wait_seconds is None else float(wait_seconds)
+        )
         # 如果等待时间为 0，则禁用缓冲
-        if self._wait_seconds <= 0:
+        if effective_wait <= 0:
             return False
 
-        files, texts = self._extract_components(event)
+        files, images, texts = self._extract_components(event)
         key = self._get_buffer_key(event)
 
         async with self._lock:
@@ -99,10 +112,11 @@ class MessageBuffer:
             if key in self._buffers:
                 buf = self._buffers[key]
                 buf.files.extend(files)
+                buf.images.extend(images)
                 buf.texts.extend(texts)
                 logger.debug(
                     f"[消息缓冲] 追加消息到缓冲区: {key}, "
-                    f"文件数: {len(files)}, 文本数: {len(texts)}"
+                    f"文件数: {len(files)}, 图片数: {len(images)}, 文本数: {len(texts)}"
                 )
                 return True
 
@@ -110,13 +124,14 @@ class MessageBuffer:
             buf = BufferedMessage(
                 event=event,
                 files=files,
+                images=images,
                 texts=texts,
             )
 
-            logger.info(f"[消息缓冲] 开始缓冲: {key}, 等待 {self._wait_seconds} 秒")
+            logger.info(f"[消息缓冲] 开始缓冲: {key}, 等待 {effective_wait} 秒")
 
             buf.timer_task = asyncio.create_task(
-                self._wait_and_process(key, self._wait_seconds)
+                self._wait_and_process(key, effective_wait)
             )
             self._buffers[key] = buf
             return True
@@ -135,12 +150,13 @@ class MessageBuffer:
 
             buf = self._buffers.pop(key)
 
-        # 只有文件时才调用回调
-        if buf.files and self._on_complete_callback:
+        # 有文件或图片时才调用回调
+        if (buf.files or buf.images) and self._on_complete_callback:
             try:
                 logger.info(
                     f"[消息缓冲] 缓冲完成，"
-                    f"文件数: {len(buf.files)}, 缓冲文本数: {len(buf.texts)}"
+                    f"文件数: {len(buf.files)}, 图片数: {len(buf.images)}, "
+                    f"缓冲文本数: {len(buf.texts)}"
                 )
                 await self._on_complete_callback(buf)
             except Exception as e:
@@ -150,6 +166,15 @@ class MessageBuffer:
         """检查指定用户是否正在缓冲状态"""
         key = self._get_buffer_key(event)
         return key in self._buffers
+
+    async def pop_buffer(self, event: AstrMessageEvent) -> BufferedMessage | None:
+        """取出当前用户的缓冲并取消定时器，用于命令显式消费缓冲内容"""
+        key = self._get_buffer_key(event)
+        async with self._lock:
+            buf = self._buffers.pop(key, None)
+            if buf and buf.timer_task and not buf.timer_task.done():
+                buf.timer_task.cancel()
+            return buf
 
     async def cancel_buffer(self, event: AstrMessageEvent):
         """取消指定用户的缓冲"""

--- a/services/message_buffer.py
+++ b/services/message_buffer.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,7 @@ class BufferedMessage:
     images: list[Comp.Image] = field(default_factory=list)  # 图片列表
     texts: list[str] = field(default_factory=list)  # 文本内容列表
     timer_task: asyncio.Task | None = None  # 定时器任务
+    wait_seconds: float = 0.0  # 当前缓冲计时窗口
 
 
 class MessageBuffer:
@@ -118,6 +120,22 @@ class MessageBuffer:
                     f"[消息缓冲] 追加消息到缓冲区: {key}, "
                     f"文件数: {len(files)}, 图片数: {len(images)}, 文本数: {len(texts)}"
                 )
+                if (
+                    wait_seconds is not None
+                    and effective_wait != buf.wait_seconds
+                    and buf.timer_task
+                    and not buf.timer_task.done()
+                ):
+                    buf.timer_task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await buf.timer_task
+                    buf.wait_seconds = effective_wait
+                    buf.timer_task = asyncio.create_task(
+                        self._wait_and_process(key, effective_wait)
+                    )
+                    logger.debug(
+                        f"[消息缓冲] 已调整缓冲等待时间: {key}, 等待 {effective_wait} 秒"
+                    )
                 return True
 
             # 没有缓冲，开始新的缓冲
@@ -126,6 +144,7 @@ class MessageBuffer:
                 files=files,
                 images=images,
                 texts=texts,
+                wait_seconds=effective_wait,
             )
 
             logger.info(f"[消息缓冲] 开始缓冲: {key}, 等待 {effective_wait} 秒")

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -39,6 +39,8 @@ SECTION_SCENE_UPLOADED_CONTEXT = "scene_uploaded_context"
 SECTION_SCENE_IMAGE_ASSETS = "scene_image_assets"
 SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP = "dynamic_document_follow_up"
 SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP = "dynamic_workbook_follow_up"
+MAX_IMAGE_ASSET_PROMPT_ITEMS = 12
+MAX_IMAGE_ASSET_NOTE_CHARS = 80
 
 
 @dataclass(frozen=True, slots=True)
@@ -303,12 +305,21 @@ class PromptContextService:
     ) -> PromptSection | None:
         if not images:
             return None
+        omitted_count = max(0, len(images) - MAX_IMAGE_ASSET_PROMPT_ITEMS)
+        visible_images = images[-MAX_IMAGE_ASSET_PROMPT_ITEMS:]
         lines = [
             "\n[System Notice] 当前会话已注册图片资源",
             "以下图片可在 add_blocks(image) 或 add_slides(image_slide) 中使用：",
         ]
-        for i, img in enumerate(images, 1):
-            note_str = f" — {img['note']}" if img.get("note") else ""
+        if omitted_count:
+            lines.append(
+                f"仅列出最近 {len(visible_images)} 张，另有 {omitted_count} 张较早图片未列出；需要时让用户用 /img list 查看。"
+            )
+        for i, img in enumerate(visible_images, 1):
+            note = str(img.get("note") or "")
+            if len(note) > MAX_IMAGE_ASSET_NOTE_CHARS:
+                note = note[: MAX_IMAGE_ASSET_NOTE_CHARS - 1] + "…"
+            note_str = f" — {note}" if note else ""
             lines.append(
                 f"  {i}. `{img['ref']}` "
                 f"({img['width']}x{img['height']}, {img['format']}){note_str}"

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -36,6 +36,7 @@ SECTION_STATIC_EXCEL_SCRIPT_UNAVAILABLE = "static_excel_script_unavailable"
 SECTION_STATIC_WORKBOOK_TOOLS = "static_workbook_tools"
 SECTION_STATIC_WORKBOOK_TOOLS_DETAIL = "static_workbook_tools_detail"
 SECTION_SCENE_UPLOADED_CONTEXT = "scene_uploaded_context"
+SECTION_SCENE_IMAGE_ASSETS = "scene_image_assets"
 SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP = "dynamic_document_follow_up"
 SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP = "dynamic_workbook_follow_up"
 
@@ -293,4 +294,34 @@ class PromptContextService:
         return build_buffered_upload_prompt(
             upload_infos=upload_infos,
             user_instruction=user_instruction,
+        )
+
+    def build_image_assets_section(
+        self,
+        *,
+        images: list[dict],
+    ) -> PromptSection | None:
+        if not images:
+            return None
+        lines = [
+            "\n[System Notice] 当前会话已注册图片资源",
+            "以下图片可在 add_blocks(image) 或 add_slides(image_slide) 中使用：",
+        ]
+        for i, img in enumerate(images, 1):
+            note_str = f" — {img['note']}" if img.get("note") else ""
+            lines.append(
+                f"  {i}. `{img['ref']}` "
+                f"({img['width']}x{img['height']}, {img['format']}){note_str}"
+            )
+        lines.append("")
+        lines.append("规则：")
+        lines.append(
+            "- image block 的 path / image_slide 的 image_path 只能使用上述 `images/...` 引用"
+        )
+        lines.append("- 不确定用哪张图时，询问用户")
+        lines.append("- 不要编造不存在的图片路径")
+        return PromptSection(
+            name=SECTION_SCENE_IMAGE_ASSETS,
+            content="\n".join(lines),
+            target="prompt_suffix",
         )

--- a/services/prompt_context_service.py
+++ b/services/prompt_context_service.py
@@ -308,12 +308,12 @@ class PromptContextService:
         omitted_count = max(0, len(images) - MAX_IMAGE_ASSET_PROMPT_ITEMS)
         visible_images = images[-MAX_IMAGE_ASSET_PROMPT_ITEMS:]
         lines = [
-            "\n[System Notice] 当前会话已注册图片资源",
-            "以下图片可在 add_blocks(image) 或 add_slides(image_slide) 中使用：",
+            "\n[System Notice] 当前活动图片资源",
+            "以下是本轮文档/PPT 工作流允许直接使用的图片：",
         ]
         if omitted_count:
             lines.append(
-                f"仅列出最近 {len(visible_images)} 张，另有 {omitted_count} 张较早图片未列出；需要时让用户用 /img list 查看。"
+                f"仅列出最近 {len(visible_images)} 张，另有 {omitted_count} 张活动图片未列出；需要时让用户用 /img active 查看。"
             )
         for i, img in enumerate(visible_images, 1):
             note = str(img.get("note") or "")
@@ -329,7 +329,8 @@ class PromptContextService:
         lines.append(
             "- image block 的 path / image_slide 的 image_path 只能使用上述 `images/...` 引用"
         )
-        lines.append("- 不确定用哪张图时，询问用户")
+        lines.append("- 需要其他历史图片时，询问用户先用 /img use 选择")
+        lines.append("- 不确定用哪张活动图片时，询问用户")
         lines.append("- 不要编造不存在的图片路径")
         return PromptSection(
             name=SECTION_SCENE_IMAGE_ASSETS,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -132,6 +132,7 @@ class RequestHookService:
         | None = None,
         lookup_workbook_summary: Callable[[str], dict[str, object] | None]
         | None = None,
+        get_session_images: Callable[[AstrMessageEvent], list[dict]] | None = None,
     ) -> None:
         self._astrbot_context = astrbot_context
         self._auto_block_execution_tools = auto_block_execution_tools
@@ -142,6 +143,7 @@ class RequestHookService:
         self._consume_session_notice_once = consume_session_notice_once
         self._lookup_document_summary = lookup_document_summary
         self._lookup_workbook_summary = lookup_workbook_summary
+        self._get_session_images = get_session_images
         self.prompt_context_service = prompt_context_service or PromptContextService(
             allow_external_input_files=allow_external_input_files
         )
@@ -199,6 +201,7 @@ class RequestHookService:
             context,
             request_text=request_text,
         )
+        self._append_image_assets_context(context)
         self._append_excel_tool_guides(
             context,
             request_text=request_text,
@@ -299,6 +302,16 @@ class RequestHookService:
                 context,
                 self.prompt_context_service.build_document_tool_detail_section(),
             )
+
+    def _append_image_assets_context(self, context: NoticeBuildContext) -> None:
+        if not self._get_session_images:
+            return
+        images = self._get_session_images(context.event)
+        if not images:
+            return
+        section = self.prompt_context_service.build_image_assets_section(images=images)
+        if section:
+            self._append_notice_section(context, section)
 
     def _append_excel_tool_guides(
         self,

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -673,8 +673,8 @@ class RequestHookService:
                         is_supported = True
 
                 if not is_supported:
-                    logger.info(
-                        "[文件管理] 文件 %s 格式不支持 (%s)，跳过处理",
+                    logger.debug(
+                        "[文件管理] 文件 %s 非文本格式 (%s)，跳过内容提取",
                         original_name,
                         file_suffix,
                     )

--- a/services/request_hook_service.py
+++ b/services/request_hook_service.py
@@ -195,6 +195,7 @@ class RequestHookService:
             request_text=request_text,
             exposed_tool_names=exposed_tool_names,
         ):
+            self._append_image_assets_context(context)
             return context
 
         self._append_document_tool_guides(

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -38,6 +38,7 @@ from .file_delivery_service import FileDeliveryService
 from .file_read_service import FileReadService
 from .file_tool_service import FileToolService
 from .generated_file_delivery_service import GeneratedFileDeliveryService
+from .image_asset_service import ImageAssetService
 from .incoming_message_service import IncomingMessageService
 from .llm_request_policy import LLMRequestPolicy
 from .office_generate_service import OfficeGenerateService
@@ -154,6 +155,7 @@ def build_plugin_runtime(
         office_libs=office_libs,
         access_policy_service=access_policy_service,
     )
+    image_asset_service = ImageAssetService(plugin_data_path=plugin_data_path)
     command_service = CommandService(
         workspace_service=workspace_service,
         pdf_converter=pdf_converter,
@@ -165,6 +167,7 @@ def build_plugin_runtime(
         allow_local_excel_script=settings.allow_local_excel_script,
         reply_to_user=settings.reply_to_user,
         upload_session_service=upload_session_service,
+        image_asset_service=image_asset_service,
         is_group_feature_enabled=access_policy_service.is_group_feature_enabled,
         is_all_users_allowed=access_policy_service.is_all_users_allowed,
         check_permission=access_policy_service.check_permission,
@@ -210,6 +213,7 @@ def build_plugin_runtime(
         file_tool_service=file_processing_services.file_tool_service,
         command_service=command_service,
         error_hook_service=error_hook_service,
+        image_asset_service=image_asset_service,
         message_buffer=message_buffer,
         incoming_message_service=incoming_message_service,
     )

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -125,17 +125,26 @@ def build_plugin_runtime(
         reply_to_user=settings.reply_to_user,
         exported_message=MSG_DOCUMENT_EXPORTED,
     )
+    image_asset_service = ImageAssetService(plugin_data_path=plugin_data_path)
+
+    def validate_document_image_ref(tool_context, ref: str) -> None:
+        event = getattr(getattr(tool_context, "context", None), "event", None)
+        if event is None:
+            return
+        session_key = upload_session_service.get_attachment_session_key(event)
+        image_asset_service.resolve_ref(ref, session_key=session_key)
+
     document_toolset = build_document_toolset(
         workspace_dir=plugin_data_path,
         after_export=handle_exported_document_tool,
         render_backend_config=document_render_backend_config,
         default_document_style=default_document_style,
+        image_ref_validator=validate_document_image_ref,
     )
     workbook_toolset = _build_workbook_toolset(
         workspace_dir=plugin_data_path,
         after_export=handle_exported_document_tool,
     )
-    image_asset_service = ImageAssetService(plugin_data_path=plugin_data_path)
     request_pipeline_services = _build_request_pipeline_services(
         astrbot_context=context,
         settings=settings,

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -135,11 +135,13 @@ def build_plugin_runtime(
         workspace_dir=plugin_data_path,
         after_export=handle_exported_document_tool,
     )
+    image_asset_service = ImageAssetService(plugin_data_path=plugin_data_path)
     request_pipeline_services = _build_request_pipeline_services(
         astrbot_context=context,
         settings=settings,
         upload_session_service=upload_session_service,
         access_policy_service=access_policy_service,
+        image_asset_service=image_asset_service,
         document_toolset=document_toolset,
         workbook_toolset=workbook_toolset,
         extract_upload_source=extract_upload_source,
@@ -155,7 +157,6 @@ def build_plugin_runtime(
         office_libs=office_libs,
         access_policy_service=access_policy_service,
     )
-    image_asset_service = ImageAssetService(plugin_data_path=plugin_data_path)
     command_service = CommandService(
         workspace_service=workspace_service,
         pdf_converter=pdf_converter,
@@ -250,6 +251,7 @@ def _build_request_pipeline_services(
     settings: PluginSettings,
     upload_session_service: UploadSessionService,
     access_policy_service: AccessPolicyService,
+    image_asset_service: ImageAssetService,
     document_toolset,
     workbook_toolset,
     extract_upload_source,
@@ -271,6 +273,9 @@ def _build_request_pipeline_services(
         prompt_context_service=prompt_context_service,
         lookup_document_summary=_build_document_summary_lookup(document_toolset),
         lookup_workbook_summary=_build_workbook_summary_lookup(workbook_toolset),
+        get_session_images=lambda event: image_asset_service.list_images(
+            upload_session_service.get_attachment_session_key(event)
+        ),
     )
     llm_request_policy = LLMRequestPolicy(
         document_toolset=document_toolset,

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -185,6 +185,7 @@ def build_plugin_runtime(
         message_buffer=message_buffer,
         remember_recent_text=upload_session_service.remember_recent_text,
         is_group_feature_enabled=access_policy_service.is_group_feature_enabled,
+        cache_pending_image_resource=upload_session_service.cache_pending_image_resource,
     )
 
     return PluginRuntimeBundle(

--- a/services/runtime_builder.py
+++ b/services/runtime_builder.py
@@ -133,6 +133,15 @@ def build_plugin_runtime(
             return
         session_key = upload_session_service.get_attachment_session_key(event)
         image_asset_service.resolve_ref(ref, session_key=session_key)
+        active_refs = {
+            image["ref"]
+            for image in image_asset_service.list_active_images(session_key)
+        }
+        if active_refs and ref not in active_refs:
+            raise ValueError(
+                f"图片引用 {ref} 不在当前活动图片中。"
+                "请先使用 /img use 选择要用于本轮文档/PPT 的图片。"
+            )
 
     document_toolset = build_document_toolset(
         workspace_dir=plugin_data_path,
@@ -283,7 +292,7 @@ def _build_request_pipeline_services(
         prompt_context_service=prompt_context_service,
         lookup_document_summary=_build_document_summary_lookup(document_toolset),
         lookup_workbook_summary=_build_workbook_summary_lookup(workbook_toolset),
-        get_session_images=lambda event: image_asset_service.list_images(
+        get_session_images=lambda event: image_asset_service.list_active_images(
             upload_session_service.get_attachment_session_key(event)
         ),
     )

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -11,7 +11,7 @@ from astrbot.core.utils.active_event_registry import active_event_registry
 from astrbot.core.platform.message_type import MessageType
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
-from .image_file_utils import is_supported_image_filename
+from .image_file_utils import is_supported_image_reference
 from .message_buffer import BufferedMessage
 from .upload_prompt_service import UploadInfo, UploadPromptService
 
@@ -495,7 +495,9 @@ class UploadSessionService:
                         ) = self._resolve_upload_type(original_name)
                     if src_path and src_path.exists():
                         actual_name = original_name or name
-                        if self.is_image_file(actual_name):
+                        if self.is_image_file(actual_name) or self.is_image_file(
+                            str(src_path)
+                        ):
                             self.cache_pending_image(event, src_path)
                             continue
                         info["source_path"] = str(src_path.resolve())
@@ -606,4 +608,4 @@ class UploadSessionService:
             self._pending_images_by_session.pop(session_key, None)
 
     def is_image_file(self, filename: str) -> bool:
-        return is_supported_image_filename(filename)
+        return is_supported_image_reference(filename)

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -56,7 +56,7 @@ class UploadSessionService:
         ] = {}
         self._session_uploads_last_cleanup_ts = 0.0
         self._pending_images_by_session: dict[
-            tuple[str, str, str], list[tuple[Path, float]]
+            tuple[str, str, str], list[tuple[object, float]]
         ] = {}
 
     def get_attachment_session_key(
@@ -523,6 +523,9 @@ class UploadSessionService:
             logger.warning("[消息缓冲] 事件重入次数过多，停止处理")
             return
 
+        if not files:
+            return
+
         upload_infos = await self._ensure_upload_infos(event, files)
 
         logger.info(
@@ -553,19 +556,30 @@ class UploadSessionService:
     _IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
 
     def cache_pending_image(self, event: AstrMessageEvent, source_path: Path) -> None:
+        self.cache_pending_image_resource(event, source_path)
+
+    def cache_pending_image_resource(
+        self, event: AstrMessageEvent, resource: object
+    ) -> None:
+        """Cache a Path or Comp.Image component for later registration via /img add."""
         session_key = self.get_attachment_session_key(event)
         entries = self._pending_images_by_session.setdefault(session_key, [])
-        entries.append((source_path, time.time()))
+        entries.append((resource, time.time()))
 
-    def get_pending_images(self, event: AstrMessageEvent) -> list[Path]:
+    def get_pending_image_resources(self, event: AstrMessageEvent) -> list[object]:
         session_key = self.get_attachment_session_key(event)
         now = time.time()
         entries = self._pending_images_by_session.get(session_key, [])
         valid = [
-            (p, ts) for p, ts in entries if now - ts < self._upload_session_ttl_seconds
+            (r, ts) for r, ts in entries if now - ts < self._upload_session_ttl_seconds
         ]
         self._pending_images_by_session[session_key] = valid
-        return [p for p, _ in valid]
+        return [r for r, _ in valid]
+
+    def get_pending_images(self, event: AstrMessageEvent) -> list[Path]:
+        return [
+            r for r in self.get_pending_image_resources(event) if isinstance(r, Path)
+        ]
 
     def clear_pending_images(self, event: AstrMessageEvent) -> None:
         session_key = self.get_attachment_session_key(event)

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -518,6 +518,7 @@ class UploadSessionService:
     async def on_buffer_complete(self, buf: BufferedMessage) -> None:
         event = buf.event
         files = buf.files
+        images = buf.images
         texts = buf.texts
 
         buffered_text_count = len(texts)
@@ -527,14 +528,18 @@ class UploadSessionService:
             logger.warning("[消息缓冲] 事件重入次数过多，停止处理")
             return
 
+        for image in images:
+            self.cache_pending_image_resource(event, image)
+
         if not files:
             return
 
         upload_infos = await self._ensure_upload_infos(event, files)
 
         logger.info(
-            "[消息缓冲] 缓冲完成，文件数: %s, 缓冲文本数: %s",
+            "[消息缓冲] 缓冲完成，文件数: %s, 图片数: %s, 缓冲文本数: %s",
             len(files),
+            len(images),
             buffered_text_count,
         )
 

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -55,6 +55,9 @@ class UploadSessionService:
             tuple[str, str, str], tuple[set[str], float]
         ] = {}
         self._session_uploads_last_cleanup_ts = 0.0
+        self._pending_images_by_session: dict[
+            tuple[str, str, str], list[tuple[Path, float]]
+        ] = {}
 
     def get_attachment_session_key(
         self, event: AstrMessageEvent
@@ -540,3 +543,29 @@ class UploadSessionService:
             file_components=files,
             reentry_count=reentry_count,
         )
+
+    # ── Pending image cache for /img add ──
+
+    _IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
+
+    def cache_pending_image(self, event: AstrMessageEvent, source_path: Path) -> None:
+        session_key = self.get_attachment_session_key(event)
+        entries = self._pending_images_by_session.setdefault(session_key, [])
+        entries.append((source_path, time.time()))
+
+    def get_pending_images(self, event: AstrMessageEvent) -> list[Path]:
+        session_key = self.get_attachment_session_key(event)
+        now = time.time()
+        entries = self._pending_images_by_session.get(session_key, [])
+        valid = [
+            (p, ts) for p, ts in entries if now - ts < self._upload_session_ttl_seconds
+        ]
+        self._pending_images_by_session[session_key] = valid
+        return [p for p, _ in valid]
+
+    def clear_pending_images(self, event: AstrMessageEvent) -> None:
+        session_key = self.get_attachment_session_key(event)
+        self._pending_images_by_session.pop(session_key, None)
+
+    def is_image_file(self, filename: str) -> bool:
+        return Path(filename).suffix.lower() in self._IMAGE_SUFFIXES

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -11,6 +11,7 @@ from astrbot.core.utils.active_event_registry import active_event_registry
 from astrbot.core.platform.message_type import MessageType
 
 from ..constants import ALL_OFFICE_SUFFIXES, PDF_SUFFIX, TEXT_SUFFIXES
+from .image_file_utils import is_supported_image_filename
 from .message_buffer import BufferedMessage
 from .upload_prompt_service import UploadInfo, UploadPromptService
 
@@ -554,8 +555,6 @@ class UploadSessionService:
 
     # ── Pending image cache for /img add ──
 
-    _IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
-
     def cache_pending_image(self, event: AstrMessageEvent, source_path: Path) -> None:
         self.cache_pending_image_resource(event, source_path)
 
@@ -607,4 +606,4 @@ class UploadSessionService:
             self._pending_images_by_session.pop(session_key, None)
 
     def is_image_file(self, filename: str) -> bool:
-        return Path(filename).suffix.lower() in self._IMAGE_SUFFIXES
+        return is_supported_image_filename(filename)

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -1,5 +1,6 @@
 import copy
 import time
+from collections.abc import Iterable
 from pathlib import Path
 
 import astrbot.api.message_components as Comp
@@ -584,6 +585,26 @@ class UploadSessionService:
     def clear_pending_images(self, event: AstrMessageEvent) -> None:
         session_key = self.get_attachment_session_key(event)
         self._pending_images_by_session.pop(session_key, None)
+
+    def clear_pending_image_resources(
+        self, event: AstrMessageEvent, resources: Iterable[object]
+    ) -> None:
+        session_key = self.get_attachment_session_key(event)
+        resource_ids = {id(resource) for resource in resources}
+        if not resource_ids:
+            return
+        entries = self._pending_images_by_session.get(session_key)
+        if not entries:
+            return
+        kept = [
+            (resource, ts)
+            for resource, ts in entries
+            if id(resource) not in resource_ids
+        ]
+        if kept:
+            self._pending_images_by_session[session_key] = kept
+        else:
+            self._pending_images_by_session.pop(session_key, None)
 
     def is_image_file(self, filename: str) -> bool:
         return Path(filename).suffix.lower() in self._IMAGE_SUFFIXES

--- a/services/upload_session_service.py
+++ b/services/upload_session_service.py
@@ -492,6 +492,10 @@ class UploadSessionService:
                             info["is_supported"],
                         ) = self._resolve_upload_type(original_name)
                     if src_path and src_path.exists():
+                        actual_name = original_name or name
+                        if self.is_image_file(actual_name):
+                            self.cache_pending_image(event, src_path)
+                            continue
                         info["source_path"] = str(src_path.resolve())
                         if info["is_supported"]:
                             stored_path = self._store_uploaded_file(

--- a/tests/test_image_asset_service.py
+++ b/tests/test_image_asset_service.py
@@ -154,11 +154,11 @@ class TestImageAssetServiceResolveRef:
         assert resolved.exists()
 
     def test_resolve_rejects_non_images_prefix(self, image_service):
-        with pytest.raises(ValueError, match="引用必须以 images/ 开头"):
+        with pytest.raises(ValueError, match="images/"):
             image_service.resolve_ref("other/file.png", session_key=SESSION_A)
 
     def test_resolve_rejects_traversal(self, image_service):
-        with pytest.raises(ValueError, match="目录遍历"):
+        with pytest.raises(ValueError, match="traversal|目录遍历"):
             image_service.resolve_ref("images/../etc/passwd", session_key=SESSION_A)
 
     def test_resolve_rejects_unregistered_ref(self, image_service):

--- a/tests/test_image_asset_service.py
+++ b/tests/test_image_asset_service.py
@@ -41,7 +41,10 @@ SESSION_B = ("platform1", "user2", "origin2")
 class TestImageAssetServiceRegistration:
     def test_register_png(self, image_service, sample_png):
         info = image_service.register_image(
-            sample_png, session_key=SESSION_A, note="test image"
+            sample_png,
+            session_key=SESSION_A,
+            note="test image",
+            original_name="sample.png",
         )
         assert info["ref"].startswith("images/img_")
         assert info["ref"].endswith(".png")
@@ -58,6 +61,23 @@ class TestImageAssetServiceRegistration:
         assert info["format"] == "JPEG"
         assert info["width"] == 200
         assert info["height"] == 100
+
+    def test_register_webp_converts_to_png(self, image_service, tmp_path):
+        from PIL import Image
+
+        img = Image.new("RGB", (120, 60), color="green")
+        webp_file = tmp_path / "sample.webp"
+        img.save(webp_file, format="WEBP")
+
+        info = image_service.register_image(webp_file, session_key=SESSION_A)
+        assert info["ref"].endswith(".png")
+        assert info["format"] == "PNG"
+        assert info["width"] == 120
+        assert info["height"] == 60
+
+        stored = image_service.resolve_ref(info["ref"], session_key=SESSION_A)
+        with Image.open(stored) as reopened:
+            assert reopened.format == "PNG"
 
     def test_register_corrects_extension(self, image_service, tmp_path):
         from PIL import Image

--- a/tests/test_image_asset_service.py
+++ b/tests/test_image_asset_service.py
@@ -222,6 +222,38 @@ class TestImageAssetServiceNoteAndClear:
         image_service.clear_images(session_key=SESSION_A)
         assert not file_path.exists()
 
+    def test_set_active_images_limits_workflow_refs(self, image_service, sample_png):
+        old_info = image_service.register_image(sample_png, session_key=SESSION_A)
+        new_info = image_service.register_image(sample_png, session_key=SESSION_A)
+
+        active = image_service.set_active_images(
+            [new_info["ref"]],
+            session_key=SESSION_A,
+        )
+
+        assert [info["ref"] for info in active] == [new_info["ref"]]
+        assert [info["ref"] for info in image_service.list_images(SESSION_A)] == [
+            old_info["ref"],
+            new_info["ref"],
+        ]
+        assert [
+            info["ref"] for info in image_service.list_active_images(SESSION_A)
+        ] == [new_info["ref"]]
+
+    def test_clear_removes_refs_from_active_set(self, image_service, sample_png):
+        old_info = image_service.register_image(sample_png, session_key=SESSION_A)
+        new_info = image_service.register_image(sample_png, session_key=SESSION_A)
+        image_service.set_active_images(
+            [old_info["ref"], new_info["ref"]],
+            session_key=SESSION_A,
+        )
+
+        image_service.clear_images(session_key=SESSION_A, ref=old_info["ref"])
+
+        assert [
+            info["ref"] for info in image_service.list_active_images(SESSION_A)
+        ] == [new_info["ref"]]
+
 
 class TestImageAssetServicePersistence:
     def test_index_survives_reload(self, tmp_path, sample_png):
@@ -235,6 +267,17 @@ class TestImageAssetServicePersistence:
         assert len(images) == 1
         assert images[0]["ref"] == info["ref"]
         assert images[0]["note"] == "persist"
+
+    def test_active_set_survives_reload(self, tmp_path, sample_png):
+        service1 = ImageAssetService(plugin_data_path=tmp_path)
+        info = service1.register_image(sample_png, session_key=SESSION_A)
+        service1.set_active_images([info["ref"]], session_key=SESSION_A)
+
+        service2 = ImageAssetService(plugin_data_path=tmp_path)
+
+        active_images = service2.list_active_images(SESSION_A)
+        assert len(active_images) == 1
+        assert active_images[0]["ref"] == info["ref"]
 
 
 class TestImageBlockValidation:

--- a/tests/test_image_asset_service.py
+++ b/tests/test_image_asset_service.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from astrbot_plugin_office_assistant.services.image_asset_service import (
+    ImageAssetService,
+)
+
+
+@pytest.fixture()
+def image_service(tmp_path: Path) -> ImageAssetService:
+    return ImageAssetService(plugin_data_path=tmp_path)
+
+
+@pytest.fixture()
+def sample_png(tmp_path: Path) -> Path:
+    from PIL import Image
+
+    img = Image.new("RGB", (100, 50), color="red")
+    path = tmp_path / "sample.png"
+    img.save(path, format="PNG")
+    return path
+
+
+@pytest.fixture()
+def sample_jpeg(tmp_path: Path) -> Path:
+    from PIL import Image
+
+    img = Image.new("RGB", (200, 100), color="blue")
+    path = tmp_path / "sample.jpg"
+    img.save(path, format="JPEG")
+    return path
+
+
+SESSION_A = ("platform1", "user1", "origin1")
+SESSION_B = ("platform1", "user2", "origin2")
+
+
+class TestImageAssetServiceRegistration:
+    def test_register_png(self, image_service, sample_png):
+        info = image_service.register_image(
+            sample_png, session_key=SESSION_A, note="test image"
+        )
+        assert info["ref"].startswith("images/img_")
+        assert info["ref"].endswith(".png")
+        assert info["width"] == 100
+        assert info["height"] == 50
+        assert info["format"] == "PNG"
+        assert info["note"] == "test image"
+        assert info["original_name"] == "sample.png"
+        assert info["session_key"] == list(SESSION_A)
+
+    def test_register_jpeg(self, image_service, sample_jpeg):
+        info = image_service.register_image(sample_jpeg, session_key=SESSION_A)
+        assert info["ref"].endswith(".jpg")
+        assert info["format"] == "JPEG"
+        assert info["width"] == 200
+        assert info["height"] == 100
+
+    def test_register_corrects_extension(self, image_service, tmp_path):
+        from PIL import Image
+
+        img = Image.new("RGB", (10, 10))
+        wrong_ext = tmp_path / "actually_png.bmp"
+        img.save(wrong_ext, format="PNG")
+
+        info = image_service.register_image(wrong_ext, session_key=SESSION_A)
+        assert info["ref"].endswith(".png")
+        assert info["format"] == "PNG"
+
+    def test_register_rejects_svg(self, image_service, tmp_path):
+        svg_file = tmp_path / "diagram.svg"
+        svg_file.write_text("<svg></svg>")
+
+        with pytest.raises(ValueError, match="不支持 SVG"):
+            image_service.register_image(svg_file, session_key=SESSION_A)
+
+    def test_register_rejects_svgz(self, image_service, tmp_path):
+        svgz_file = tmp_path / "diagram.svgz"
+        svgz_file.write_bytes(b"\x1f\x8b")
+
+        with pytest.raises(ValueError, match="不支持 SVG"):
+            image_service.register_image(svgz_file, session_key=SESSION_A)
+
+    def test_register_rejects_invalid_image(self, image_service, tmp_path):
+        bad_file = tmp_path / "not_an_image.png"
+        bad_file.write_text("this is not an image")
+
+        with pytest.raises(ValueError, match="无法识别为有效图片"):
+            image_service.register_image(bad_file, session_key=SESSION_A)
+
+    def test_register_rejects_missing_file(self, image_service, tmp_path):
+        missing = tmp_path / "does_not_exist.png"
+
+        with pytest.raises(FileNotFoundError, match="源文件不存在"):
+            image_service.register_image(missing, session_key=SESSION_A)
+
+
+class TestImageAssetServiceSessionIsolation:
+    def test_list_only_shows_own_session(self, image_service, sample_png):
+        image_service.register_image(sample_png, session_key=SESSION_A, note="A")
+        image_service.register_image(sample_png, session_key=SESSION_B, note="B")
+
+        images_a = image_service.list_images(SESSION_A)
+        images_b = image_service.list_images(SESSION_B)
+
+        assert len(images_a) == 1
+        assert images_a[0]["note"] == "A"
+        assert len(images_b) == 1
+        assert images_b[0]["note"] == "B"
+
+    def test_clear_only_affects_own_session(self, image_service, sample_png):
+        image_service.register_image(sample_png, session_key=SESSION_A)
+        image_service.register_image(sample_png, session_key=SESSION_B)
+
+        cleared = image_service.clear_images(session_key=SESSION_A)
+        assert cleared == 1
+        assert len(image_service.list_images(SESSION_A)) == 0
+        assert len(image_service.list_images(SESSION_B)) == 1
+
+    def test_resolve_rejects_other_session_ref(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+
+        with pytest.raises(ValueError, match="不在当前会话的资源池中"):
+            image_service.resolve_ref(info["ref"], session_key=SESSION_B)
+
+
+class TestImageAssetServiceResolveRef:
+    def test_resolve_valid_ref(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+        resolved = image_service.resolve_ref(info["ref"], session_key=SESSION_A)
+        assert resolved.exists()
+
+    def test_resolve_rejects_non_images_prefix(self, image_service):
+        with pytest.raises(ValueError, match="引用必须以 images/ 开头"):
+            image_service.resolve_ref("other/file.png", session_key=SESSION_A)
+
+    def test_resolve_rejects_traversal(self, image_service):
+        with pytest.raises(ValueError, match="目录遍历"):
+            image_service.resolve_ref("images/../etc/passwd", session_key=SESSION_A)
+
+    def test_resolve_rejects_unregistered_ref(self, image_service):
+        with pytest.raises(ValueError, match="不在当前会话的资源池中"):
+            image_service.resolve_ref("images/fake.png", session_key=SESSION_A)
+
+    def test_resolve_rejects_deleted_file(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+        file_path = image_service._images_dir.parent / info["ref"]
+        file_path.unlink()
+
+        with pytest.raises(FileNotFoundError, match="图片文件不存在"):
+            image_service.resolve_ref(info["ref"], session_key=SESSION_A)
+
+    def test_ref_exists_returns_true_for_valid(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+        assert image_service.ref_exists(info["ref"], session_key=SESSION_A) is True
+
+    def test_ref_exists_returns_false_for_invalid(self, image_service):
+        assert (
+            image_service.ref_exists("images/nope.png", session_key=SESSION_A) is False
+        )
+
+
+class TestImageAssetServiceNoteAndClear:
+    def test_update_note(self, image_service, sample_png):
+        info = image_service.register_image(
+            sample_png, session_key=SESSION_A, note="old"
+        )
+        assert image_service.update_note(info["ref"], "new", session_key=SESSION_A)
+        images = image_service.list_images(SESSION_A)
+        assert images[0]["note"] == "new"
+
+    def test_update_note_wrong_session(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+        assert not image_service.update_note(info["ref"], "hack", session_key=SESSION_B)
+
+    def test_clear_specific_ref(self, image_service, sample_png, sample_jpeg):
+        info1 = image_service.register_image(sample_png, session_key=SESSION_A)
+        image_service.register_image(sample_jpeg, session_key=SESSION_A)
+
+        cleared = image_service.clear_images(session_key=SESSION_A, ref=info1["ref"])
+        assert cleared == 1
+        remaining = image_service.list_images(SESSION_A)
+        assert len(remaining) == 1
+        assert remaining[0]["format"] == "JPEG"
+
+    def test_clear_all(self, image_service, sample_png, sample_jpeg):
+        image_service.register_image(sample_png, session_key=SESSION_A)
+        image_service.register_image(sample_jpeg, session_key=SESSION_A)
+
+        cleared = image_service.clear_images(session_key=SESSION_A)
+        assert cleared == 2
+        assert len(image_service.list_images(SESSION_A)) == 0
+
+    def test_clear_deletes_file(self, image_service, sample_png):
+        info = image_service.register_image(sample_png, session_key=SESSION_A)
+        file_path = image_service._images_dir.parent / info["ref"]
+        assert file_path.exists()
+
+        image_service.clear_images(session_key=SESSION_A)
+        assert not file_path.exists()
+
+
+class TestImageAssetServicePersistence:
+    def test_index_survives_reload(self, tmp_path, sample_png):
+        service1 = ImageAssetService(plugin_data_path=tmp_path)
+        info = service1.register_image(
+            sample_png, session_key=SESSION_A, note="persist"
+        )
+
+        service2 = ImageAssetService(plugin_data_path=tmp_path)
+        images = service2.list_images(SESSION_A)
+        assert len(images) == 1
+        assert images[0]["ref"] == info["ref"]
+        assert images[0]["note"] == "persist"
+
+
+class TestImageBlockValidation:
+    def test_image_block_rejects_non_asset_path(self):
+        from astrbot_plugin_office_assistant.document_core.models.blocks import (
+            ImageBlock,
+        )
+
+        with pytest.raises(Exception, match="images/"):
+            ImageBlock(path="some/other/path.png")
+
+    def test_image_block_accepts_asset_ref(self):
+        from astrbot_plugin_office_assistant.document_core.models.blocks import (
+            ImageBlock,
+        )
+
+        block = ImageBlock(path="images/img_20260521_abc12345.png")
+        assert block.path == "images/img_20260521_abc12345.png"
+
+    def test_image_slide_block_rejects_non_asset_path(self):
+        from astrbot_plugin_office_assistant.document_core.models.blocks import (
+            ImageSlideBlock,
+        )
+
+        with pytest.raises(Exception, match="images/"):
+            ImageSlideBlock(image_path="photo.jpg", title="test")
+
+    def test_image_slide_block_accepts_asset_ref(self):
+        from astrbot_plugin_office_assistant.document_core.models.blocks import (
+            ImageSlideBlock,
+        )
+
+        block = ImageSlideBlock(
+            image_path="images/img_20260521_def67890.jpg", title="test"
+        )
+        assert block.image_path == "images/img_20260521_def67890.jpg"

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -306,6 +306,38 @@ async def test_img_add_consumes_buffered_images_before_timeout():
 
 
 @pytest.mark.asyncio
+async def test_img_add_preserves_buffered_files_when_consuming_buffered_images():
+    async with _managed_plugin() as managed:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        runtime = managed.plugin._runtime
+        image_path = runtime.plugin_data_path / "buffered-image.png"
+        _write_png(image_path, width=10, height=10)
+        image = Comp.Image.fromFileSystem(str(image_path))
+        upload = Comp.File(name="report.docx", file="report.docx")
+        buffered = BufferedMessage(
+            event=event,
+            files=[upload],
+            images=[image],
+            texts=["整理一下"],
+        )
+        buffer_key = runtime.message_buffer._get_buffer_key(event)
+        runtime.message_buffer._buffers[buffer_key] = buffered
+
+        await managed.plugin.img_add(event, "配图")
+
+        remaining = runtime.message_buffer._buffers[buffer_key]
+        session_key = runtime.upload_session_service.get_attachment_session_key(event)
+        images = runtime.image_asset_service.list_images(session_key)
+        assert len(images) == 1
+        assert images[0]["note"] == "配图"
+        assert remaining.files == [upload]
+        assert remaining.images == []
+        assert remaining.texts == ["整理一下"]
+
+
+@pytest.mark.asyncio
 async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
     async with _managed_plugin() as managed:
         event = _build_event(

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -39,6 +39,7 @@ from astrbot.core.message.message_event_result import MessageEventResult
 from astrbot.core.platform.message_type import MessageType
 from astrbot.core.provider.entities import ProviderRequest
 from conftest import build_notice_once_callback as _build_notice_once_callback
+from tests._docx_test_helpers import _write_png
 
 _REQUEST_FUNC_TOOL_UNSET = object()
 
@@ -250,6 +251,31 @@ async def test_before_llm_chat_timeout_preserves_newer_pending_images():
         assert upload_session_service.get_pending_image_resources(event) == [
             newer_resource
         ]
+
+
+@pytest.mark.asyncio
+async def test_img_add_registers_selected_path_pending_and_preserves_rest():
+    async with _managed_plugin() as managed:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        runtime = managed.plugin._runtime
+        first_image = runtime.plugin_data_path / "pending-first.png"
+        second_image = runtime.plugin_data_path / "pending-second.png"
+        _write_png(first_image, width=10, height=10)
+        _write_png(second_image, width=10, height=10)
+        runtime.upload_session_service.cache_pending_image(event, first_image)
+        runtime.upload_session_service.cache_pending_image(event, second_image)
+
+        await managed.plugin.img_add(event, "1 封面图")
+
+        session_key = runtime.upload_session_service.get_attachment_session_key(event)
+        images = runtime.image_asset_service.list_images(session_key)
+        pending = runtime.upload_session_service.get_pending_image_resources(event)
+        assert len(images) == 1
+        assert images[0]["note"] == "封面图"
+        assert images[0]["original_name"] == "pending-first.png"
+        assert pending == [second_image]
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -196,7 +196,7 @@ async def test_before_llm_chat_injects_document_tools_per_request():
 
 
 @pytest.mark.asyncio
-async def test_before_llm_chat_clears_pending_images_after_delay_timeout():
+async def test_before_llm_chat_keeps_pending_images_after_delay_timeout():
     config = _build_config()
     config["file_settings"]["image_llm_delay_seconds"] = 0.01
     async with _managed_plugin(config=config) as managed:
@@ -218,7 +218,9 @@ async def test_before_llm_chat_clears_pending_images_after_delay_timeout():
         await managed.plugin.before_llm_chat(event, req)
 
         assert event._has_pending_images is False
-        assert upload_session_service.get_pending_image_resources(event) == []
+        assert upload_session_service.get_pending_image_resources(event) == [
+            Path("image.png")
+        ]
 
 
 @pytest.mark.asyncio
@@ -249,7 +251,8 @@ async def test_before_llm_chat_timeout_preserves_newer_pending_images():
 
         assert event._has_pending_images is False
         assert upload_session_service.get_pending_image_resources(event) == [
-            newer_resource
+            old_resource,
+            newer_resource,
         ]
 
 

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -279,6 +279,30 @@ async def test_img_add_registers_selected_path_pending_and_preserves_rest():
 
 
 @pytest.mark.asyncio
+async def test_img_add_consumes_buffered_images_before_timeout():
+    async with _managed_plugin() as managed:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        runtime = managed.plugin._runtime
+        image_path = runtime.plugin_data_path / "buffered-image.png"
+        _write_png(image_path, width=10, height=10)
+        image = Comp.Image.fromFileSystem(str(image_path))
+        buffered = BufferedMessage(event=event, images=[image], texts=[])
+        runtime.message_buffer._buffers[
+            runtime.message_buffer._get_buffer_key(event)
+        ] = buffered
+
+        await managed.plugin.img_add(event, "缓冲图")
+
+        session_key = runtime.upload_session_service.get_attachment_session_key(event)
+        images = runtime.image_asset_service.list_images(session_key)
+        assert len(images) == 1
+        assert images[0]["note"] == "缓冲图"
+        assert runtime.upload_session_service.get_pending_image_resources(event) == []
+
+
+@pytest.mark.asyncio
 async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
     async with _managed_plugin() as managed:
         event = _build_event(

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -221,6 +221,38 @@ async def test_before_llm_chat_clears_pending_images_after_delay_timeout():
 
 
 @pytest.mark.asyncio
+async def test_before_llm_chat_timeout_preserves_newer_pending_images():
+    config = _build_config()
+    config["file_settings"]["image_llm_delay_seconds"] = 0.01
+    async with _managed_plugin(config=config) as managed:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        old_resource = Path("old.png")
+        newer_resource = Path("newer.png")
+        event._has_pending_images = True
+        event._buffered = False
+        event._pending_image_resources = [old_resource]
+        req = _build_provider_request(
+            "看看这张图",
+            tool_names=["existing_tool"],
+        )
+        upload_session_service = managed.plugin._runtime.upload_session_service
+        session_key = upload_session_service.get_attachment_session_key(event)
+        upload_session_service._pending_images_by_session[session_key] = [
+            (old_resource, time.time()),
+            (newer_resource, time.time()),
+        ]
+
+        await managed.plugin.before_llm_chat(event, req)
+
+        assert event._has_pending_images is False
+        assert upload_session_service.get_pending_image_resources(event) == [
+            newer_resource
+        ]
+
+
+@pytest.mark.asyncio
 async def test_before_llm_chat_keeps_document_id_follow_up_prompt_lightweight():
     async with _managed_plugin() as managed:
         event = _build_event(

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -1,5 +1,6 @@
 import contextlib
 import json
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -191,6 +192,32 @@ async def test_before_llm_chat_injects_document_tools_per_request():
         assert "NEVER 调用网络搜索" in req.prompt
         assert "文件工具使用指南" not in req.system_prompt
         assert req.prompt.startswith("请生成一份 Word 报告，并导出给我。")
+
+
+@pytest.mark.asyncio
+async def test_before_llm_chat_clears_pending_images_after_delay_timeout():
+    config = _build_config()
+    config["file_settings"]["image_llm_delay_seconds"] = 0.01
+    async with _managed_plugin(config=config) as managed:
+        event = _build_event(
+            message_type=MessageType.FRIEND_MESSAGE, sender_id="user-1"
+        )
+        event._has_pending_images = True
+        event._buffered = False
+        req = _build_provider_request(
+            "看看这张图",
+            tool_names=["existing_tool"],
+        )
+        upload_session_service = managed.plugin._runtime.upload_session_service
+        session_key = upload_session_service.get_attachment_session_key(event)
+        upload_session_service._pending_images_by_session[session_key] = [
+            (Path("image.png"), time.time())
+        ]
+
+        await managed.plugin.before_llm_chat(event, req)
+
+        assert event._has_pending_images is False
+        assert upload_session_service.get_pending_image_resources(event) == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_document_tools.py
+++ b/tests/test_office_assistant_document_tools.py
@@ -157,6 +157,99 @@ async def test_add_blocks_failure_message_keeps_model_on_same_tool(
 
 
 @pytest.mark.asyncio
+async def test_add_blocks_tool_validates_image_refs_before_store(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-image-ref-validator"
+    )
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    _write_png(images_dir / "other-session.png", width=10, height=10)
+    seen_refs: list[str] = []
+
+    def reject_ref(_context, ref: str) -> None:
+        seen_refs.append(ref)
+        raise ValueError("图片引用不属于当前会话")
+
+    toolset = build_document_toolset(
+        workspace_dir=workspace_dir,
+        image_ref_validator=reject_ref,
+    )
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            title="Image Ref Validation",
+        )
+    )
+    failed = json.loads(
+        await tool_by_name["add_blocks"].call(
+            None,
+            document_id=created["document"]["document_id"],
+            blocks=[
+                {
+                    "type": "image",
+                    "path": "images/other-session.png",
+                }
+            ],
+        )
+    )
+
+    assert failed["success"] is False
+    assert "图片引用不属于当前会话" in failed["message"]
+    assert seen_refs == ["images/other-session.png"]
+
+
+@pytest.mark.asyncio
+async def test_add_slides_tool_validates_image_refs_before_store(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root, "pytest-agent-tools-slide-image-ref-validator"
+    )
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    _write_png(images_dir / "other-session.png", width=10, height=10)
+    seen_refs: list[str] = []
+
+    def reject_ref(_context, ref: str) -> None:
+        seen_refs.append(ref)
+        raise ValueError("图片引用不属于当前会话")
+
+    toolset = build_document_toolset(
+        workspace_dir=workspace_dir,
+        image_ref_validator=reject_ref,
+    )
+    tool_by_name = {tool.name: tool for tool in toolset.tools}
+
+    created = json.loads(
+        await tool_by_name["create_document"].call(
+            None,
+            title="Slide Image Ref Validation",
+            format="ppt",
+        )
+    )
+    failed = json.loads(
+        await tool_by_name["add_slides"].call(
+            None,
+            document_id=created["document"]["document_id"],
+            slides=[
+                {
+                    "type": "image_slide",
+                    "image_path": "images/other-session.png",
+                }
+            ],
+        )
+    )
+
+    assert failed["success"] is False
+    assert "图片引用不属于当前会话" in failed["message"]
+    assert seen_refs == ["images/other-session.png"]
+
+
+@pytest.mark.asyncio
 async def test_add_blocks_returns_hint_when_dispatcher_degrades_to_empty_kwargs(
     workspace_root: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -271,6 +271,129 @@ def test_node_render_backend_renders_sections_and_table_styles(workspace_root: P
     assert "PAGE" not in loaded_doc.sections[1].footer._element.xml
 
 
+def test_node_word_renderer_embeds_image_block_and_caption(workspace_root: Path):
+    docx = pytest.importorskip("docx")
+
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-render-backend-word-image",
+    )
+    renderer_entry = _node_renderer_entry()
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    image_path = images_dir / "wide.png"
+    _write_png(image_path, width=640, height=320)
+
+    output_path = workspace_dir / "word-image.docx"
+    payload_path = workspace_dir / "word-image.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "format": "word",
+                "render_mode": "structured",
+                "document_id": "node-word-image",
+                "workspace_dir": str(workspace_dir),
+                "metadata": _business_report_metadata(title="Word 图片测试"),
+                "blocks": [
+                    {
+                        "type": "image",
+                        "path": "images/wide.png",
+                        "caption": "图片说明",
+                        "width_px": 320,
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    loaded_doc = docx.Document(output_path)
+    assert any(paragraph.text == "图片说明" for paragraph in loaded_doc.paragraphs)
+    ns = {
+        "wp": "http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing"
+    }
+    with zipfile.ZipFile(output_path) as zf:
+        names = zf.namelist()
+        document_xml = zf.read("word/document.xml").decode("utf-8")
+    assert any(name.startswith("word/media/") for name in names)
+    assert "图片说明" in document_xml
+    root = ET.fromstring(document_xml)
+    extent = root.find(".//wp:inline/wp:extent", ns)
+    assert extent is not None
+    rendered_ratio = int(extent.attrib["cx"]) / int(extent.attrib["cy"])
+    assert rendered_ratio == pytest.approx(2.0, rel=0.001)
+
+
+@pytest.mark.parametrize(
+    "block,expected_code",
+    [
+        ({"type": "image", "path": ""}, "SCHEMA_VALIDATION_FAILED"),
+        ({"type": "image", "path": "outside.png"}, "SCHEMA_VALIDATION_FAILED"),
+        ({"type": "image", "path": "images/../outside.png"}, "INVALID_IMAGE_PATH"),
+        ({"type": "image", "path": "images/missing.png"}, "MISSING_IMAGE_FILE"),
+        ({"type": "image", "path": "images/bad.png"}, "UNSUPPORTED_IMAGE_TYPE"),
+    ],
+    ids=[
+        "missing_path",
+        "invalid_prefix",
+        "traversal_path",
+        "missing_file",
+        "unsupported_image_data",
+    ],
+)
+def test_node_word_renderer_rejects_invalid_image_blocks(
+    workspace_root: Path, block: dict, expected_code: str
+):
+    workspace_dir = _make_workspace(workspace_root, "pytest-node-word-image-errors")
+    renderer_entry = _node_renderer_entry()
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    (images_dir / "bad.png").write_bytes(b"not an image")
+
+    output_path = workspace_dir / "word-image-error.docx"
+    payload_path = workspace_dir / "word-image-error.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "format": "word",
+                "render_mode": "structured",
+                "document_id": "node-word-image-error",
+                "workspace_dir": str(workspace_dir),
+                "metadata": _business_report_metadata(title="Word 图片错误测试"),
+                "blocks": [block],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode != 0
+    error_payload = json.loads(completed.stderr)
+    assert error_payload["code"] == expected_code
+
+
 def test_node_renderer_produces_valid_pptx(workspace_root: Path):
     workspace_dir = _make_workspace(
         workspace_root,

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -79,7 +79,48 @@ def test_node_render_backend_serializes_payload_and_invokes_cli(workspace_root: 
     assert payloads[0]["version"] == "v1"
     assert payloads[0]["render_mode"] == "structured"
     assert payloads[0]["document_id"] == document.document_id
+    assert payloads[0]["workspace_dir"] == str(workspace_dir.resolve())
     assert payloads[0]["blocks"][0]["type"] == "paragraph"
+
+
+def test_node_render_backend_uses_document_workspace_for_output_subdir(
+    workspace_root: Path,
+):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-render-backend-output-dir",
+    )
+    entry_path = workspace_dir / "dist" / "cli.js"
+    entry_path.parent.mkdir(parents=True, exist_ok=True)
+    entry_path.write_text("// fake cli", encoding="utf-8")
+
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    document = store.create_document(
+        CreateDocumentRequest(
+            title="Node Backend",
+            output_name="node-backend.docx",
+        )
+    )
+    document.add_block(ParagraphBlock(text="Node payload paragraph"))
+    output_path = workspace_dir / "reports" / "node-output.docx"
+    payloads: list[dict[str, object]] = []
+
+    def _fake_run(command, cwd, check, capture_output, text, encoding):
+        payload_path = Path(command[2])
+        moved_payload_path = payload_path.with_suffix(".moved.json")
+        payload_path.rename(moved_payload_path)
+        payloads.append(json.loads(moved_payload_path.read_text(encoding="utf-8")))
+        output_path.write_bytes(b"node-docx")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch(
+        "astrbot_plugin_office_assistant.domain.document.render_backends.subprocess.run",
+        side_effect=_fake_run,
+    ):
+        NodeDocumentRenderBackend(entry_path=entry_path).render(document, output_path)
+
+    assert payloads[0]["workspace_dir"] == str(workspace_dir.resolve())
+    assert payloads[0]["workspace_dir"] != str(output_path.parent.resolve())
 
 
 def test_node_render_backend_extracts_message_from_json_error(workspace_root: Path):

--- a/tests/test_office_assistant_node_renderer.py
+++ b/tests/test_office_assistant_node_renderer.py
@@ -321,6 +321,66 @@ def test_node_renderer_produces_valid_pptx(workspace_root: Path):
         assert any("ppt/presentation.xml" in n for n in names)
 
 
+def test_node_ppt_renderer_preserves_image_slide_aspect_ratio(workspace_root: Path):
+    workspace_dir = _make_workspace(
+        workspace_root,
+        "pytest-node-render-backend-ppt-image-ratio",
+    )
+    renderer_entry = _node_renderer_entry()
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    image_path = images_dir / "wide.png"
+    _write_png(image_path, width=1280, height=799)
+
+    output_path = workspace_dir / "image-ratio.pptx"
+    payload_path = workspace_dir / "image-ratio.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "render_mode": "structured",
+                "document_id": "node-structured-ppt-image-ratio",
+                "format": "ppt",
+                "workspace_dir": str(workspace_dir),
+                "metadata": _business_report_metadata(title="PPT 图片比例测试"),
+                "blocks": [
+                    {
+                        "type": "image_slide",
+                        "title": "图片页",
+                        "image_path": "images/wide.png",
+                        "caption": "保持原图比例",
+                    },
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    completed = subprocess.run(
+        ["node", str(renderer_entry), str(payload_path), str(output_path)],
+        cwd=str(renderer_entry.parents[1]),
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    ns = {
+        "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+        "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    }
+    with zipfile.ZipFile(output_path) as zf:
+        slide = ET.fromstring(zf.read("ppt/slides/slide1.xml"))
+    pic = slide.find(".//p:pic", ns)
+    assert pic is not None
+    ext = pic.find(".//a:xfrm/a:ext", ns)
+    assert ext is not None
+    rendered_ratio = int(ext.attrib["cx"]) / int(ext.attrib["cy"])
+    assert rendered_ratio == pytest.approx(1280 / 799, rel=0.001)
+
+
 @pytest.mark.parametrize(
     "blocks,expected_code",
     [

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -6235,6 +6235,8 @@ async def test_incoming_message_service_caches_image_file_as_pending():
     await service.handle_file_message(event)
 
     cache_pending.assert_called_once_with(event, file_comp)
+    assert event._has_pending_images is True
+    assert event._pending_image_resources == [file_comp]
     remember_recent_text.assert_not_called()
     message_buffer.is_buffering.assert_not_called()
     event.stop_event.assert_not_called()

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -372,6 +372,7 @@ def _build_command_service(
         allow_local_excel_script=allow_local_excel_script,
         reply_to_user=reply_to_user,
         upload_session_service=upload_session_service or MagicMock(),
+        image_asset_service=MagicMock(),
         is_group_feature_enabled=is_group_feature_enabled or (lambda _event: True),
         is_all_users_allowed=lambda: allow_all_users,
         check_permission=check_permission or (lambda _event: True),

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -1190,6 +1190,75 @@ def test_build_plugin_runtime_returns_temp_workspace_and_services():
                 pass
 
 
+@pytest.mark.asyncio
+async def test_document_toolset_rejects_non_active_image_refs():
+    context = MagicMock()
+    context.get_config.return_value = {
+        "admins_id": ["admin-1"],
+        "file_settings": {"auto_delete_files": False},
+        "permission_settings": {"allow_all_users": True},
+    }
+    runtime = build_plugin_runtime(
+        context=context,
+        config=context.get_config.return_value,
+        plugin_name="astrbot_plugin_office_assistant",
+        handle_exported_document_tool=AsyncMock(),
+        extract_upload_source=AsyncMock(),
+        store_uploaded_file=MagicMock(),
+    )
+
+    try:
+        event = _build_event(sender_id="user-a")
+        session_key = runtime.upload_session_service.get_attachment_session_key(event)
+        old_image = runtime.plugin_data_path / "old.png"
+        new_image = runtime.plugin_data_path / "new.png"
+        _write_valid_png(old_image, color="red")
+        _write_valid_png(new_image, color="blue")
+        old_info = runtime.image_asset_service.register_image(
+            old_image,
+            session_key=session_key,
+            note="旧图",
+            original_name="old.png",
+        )
+        new_info = runtime.image_asset_service.register_image(
+            new_image,
+            session_key=session_key,
+            note="测试",
+            original_name="new.png",
+        )
+        runtime.image_asset_service.set_active_images(
+            [new_info["ref"]],
+            session_key=session_key,
+        )
+
+        tool_by_name = {tool.name: tool for tool in runtime.document_toolset.tools}
+        created = json.loads(
+            await tool_by_name["create_document"].call(
+                SimpleNamespace(context=SimpleNamespace(event=event)),
+                title="Active Image Guard",
+            )
+        )
+        failed = json.loads(
+            await tool_by_name["add_blocks"].call(
+                SimpleNamespace(context=SimpleNamespace(event=event)),
+                document_id=created["document"]["document_id"],
+                blocks=[{"type": "image", "path": old_info["ref"]}],
+            )
+        )
+
+        assert failed["success"] is False
+        assert "不在当前活动图片中" in failed["message"]
+    finally:
+        runtime.executor.shutdown(wait=False)
+        runtime.office_gen.cleanup()
+        runtime.pdf_converter.cleanup()
+        if runtime.temp_dir is not None:
+            try:
+                runtime.temp_dir.cleanup()
+            except PermissionError:
+                pass
+
+
 def test_build_plugin_runtime_ignores_legacy_word_render_settings():
     context = MagicMock()
     context.get_config.return_value = {"admins_id": ["admin-1"]}
@@ -4500,12 +4569,33 @@ def test_prompt_context_service_limits_image_assets_section():
 
     assert section is not None
     assert section.name == SECTION_SCENE_IMAGE_ASSETS
-    assert "另有 2 张较早图片未列出" in section.content
+    assert "另有 2 张活动图片未列出" in section.content
     assert "`images/img_00.png`" not in section.content
     assert "`images/img_01.png`" not in section.content
     assert "`images/img_02.png`" in section.content
     assert long_note not in section.content
     assert "…" in section.content
+
+
+def test_prompt_context_service_marks_image_assets_as_active_scope():
+    service = PromptContextService(allow_external_input_files=False)
+
+    section = service.build_image_assets_section(
+        images=[
+            {
+                "ref": "images/img_active.png",
+                "width": 100,
+                "height": 50,
+                "format": "PNG",
+                "note": "测试",
+            }
+        ]
+    )
+
+    assert section is not None
+    assert "当前活动图片资源" in section.content
+    assert "允许直接使用" in section.content
+    assert "/img use" in section.content
 
 
 def test_upload_prompt_service_builds_instructional_notice_for_readable_files():
@@ -5310,6 +5400,10 @@ def test_command_service_img_add_treats_single_numeric_argument_as_note():
         assert len(images) == 1
         assert images[0]["note"] == "2"
         assert images[0]["original_name"] == "sample.png"
+        active_images = image_asset_service.list_active_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        assert [info["ref"] for info in active_images] == [images[0]["ref"]]
 
 
 def test_command_service_img_add_keeps_numeric_selector_for_multiple_images():
@@ -5345,6 +5439,81 @@ def test_command_service_img_add_keeps_numeric_selector_for_multiple_images():
         assert len(images) == 1
         assert images[0]["note"] == ""
         assert images[0]["original_name"] == "second.png"
+        active_images = image_asset_service.list_active_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        assert [info["ref"] for info in active_images] == [images[0]["ref"]]
+
+
+def test_command_service_img_use_selects_multiple_active_images():
+    upload_session_service = _build_upload_session_service()
+
+    with _managed_workspace_service(name="command-img-use") as managed:
+        image_asset_service = ImageAssetService(plugin_data_path=managed.workspace_dir)
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
+            upload_session_service=upload_session_service,
+            image_asset_service=image_asset_service,
+        )
+        first_image = managed.workspace_dir / "first.png"
+        second_image = managed.workspace_dir / "second.png"
+        third_image = managed.workspace_dir / "third.png"
+        _write_valid_png(first_image, color="red")
+        _write_valid_png(second_image, color="blue")
+        _write_valid_png(third_image, color="green")
+
+        event = _build_event(sender_id="user-a")
+        service.img_add(
+            event,
+            source_items=[
+                (first_image, "first.png"),
+                (second_image, "second.png"),
+                (third_image, "third.png"),
+            ],
+            selection="all 截图",
+        )
+
+        result = service.img_use(event, "1 3")
+
+        images = image_asset_service.list_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        active_images = image_asset_service.list_active_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        assert "已设置 2 张当前活动图片" in result
+        assert [info["ref"] for info in active_images] == [
+            images[0]["ref"],
+            images[2]["ref"],
+        ]
+
+
+def test_command_service_img_active_reports_current_active_images():
+    upload_session_service = _build_upload_session_service()
+
+    with _managed_workspace_service(name="command-img-active") as managed:
+        image_asset_service = ImageAssetService(plugin_data_path=managed.workspace_dir)
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
+            upload_session_service=upload_session_service,
+            image_asset_service=image_asset_service,
+        )
+        image_path = managed.workspace_dir / "sample.png"
+        _write_valid_png(image_path)
+
+        event = _build_event(sender_id="user-a")
+        service.img_add(
+            event,
+            source_items=[(image_path, "sample.png")],
+            selection="测试",
+        )
+
+        result = service.img_active(event)
+
+        assert "当前活动图片（共 1 张）" in result
+        assert "测试" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -4913,6 +4913,37 @@ async def test_upload_session_service_caches_file_only_buffered_upload_in_group_
 
 
 @pytest.mark.asyncio
+async def test_upload_session_service_caches_buffered_images_alongside_files():
+    context = MagicMock()
+    event_queue = AsyncMock()
+    context.get_event_queue.return_value = event_queue
+    source_path = Path(__file__).resolve()
+    service = UploadSessionService(
+        context=context,
+        recent_text_ttl_seconds=30,
+        upload_session_ttl_seconds=300,
+        recent_text_max_entries=32,
+        recent_text_cleanup_interval_seconds=10,
+        upload_session_cleanup_interval_seconds=30,
+        extract_upload_source=AsyncMock(return_value=(source_path, "report.docx")),
+        store_uploaded_file=MagicMock(return_value=Path("report_1.docx")),
+        allow_external_input_files=True,
+    )
+    event = _build_event(message_type=MessageType.GROUP_MESSAGE)
+    upload = Comp.File(name="report.docx", file="report.docx")
+    image = Comp.Image(file="avatar.png")
+    buf = BufferedMessage(event=event, files=[upload], images=[image], texts=[])
+
+    await service.on_buffer_complete(buf)
+
+    event_queue.put.assert_not_awaited()
+    assert service.get_pending_image_resources(event) == [image]
+    upload_infos = service.list_session_upload_infos(event)
+    assert len(upload_infos) == 1
+    assert upload_infos[0]["original_name"] == "report.docx"
+
+
+@pytest.mark.asyncio
 async def test_upload_session_service_uses_recent_text_for_file_only_buffered_upload():
     context = MagicMock()
     event_queue = AsyncMock()
@@ -6322,6 +6353,36 @@ async def test_incoming_message_service_caches_image_file_by_path_when_name_miss
     event = _build_event()
     event.stop_event = MagicMock()
     file_comp = Comp.File(name="", file="C:/tmp/avatar.png")
+    event.message_obj.message = [file_comp]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_called_once_with(event, file_comp)
+    assert event._has_pending_images is True
+    message_buffer.is_buffering.assert_not_called()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_incoming_message_service_caches_image_file_by_file_property():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = True
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    file_comp = MagicMock(spec=Comp.File)
+    file_comp.name = ""
+    file_comp.file = "C:/tmp/avatar.png"
+    file_comp.file_ = ""
+    file_comp.url = ""
     event.message_obj.message = [file_comp]
 
     await service.handle_file_message(event)

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -31,6 +31,7 @@ from astrbot_plugin_office_assistant.domain.document.session_store import (
 )
 from astrbot_plugin_office_assistant.services.office_generator import OfficeGenerator
 from astrbot_plugin_office_assistant.internal_hooks import NoticeBuildContext
+from astrbot_plugin_office_assistant.services.message_buffer import MessageBuffer
 from astrbot_plugin_office_assistant.services.message_buffer import BufferedMessage
 from astrbot_plugin_office_assistant.services import (
     AccessPolicyService,
@@ -2480,6 +2481,42 @@ async def test_request_hook_service_injects_document_follow_up_notice_for_draft(
     assert "继续调用 `add_blocks`" in context.notices[0]
     assert context.system_notices == []
     assert context.system_section_names == []
+
+
+@pytest.mark.asyncio
+async def test_request_hook_service_includes_image_assets_for_document_follow_up():
+    service = _build_request_hook_service(
+        lookup_document_summary=lambda document_id: {
+            "document_id": document_id,
+            "status": "draft",
+            "block_count": 3,
+        },
+        get_session_images=lambda _event: [
+            {
+                "ref": "images/img_20260531_ab12cd34.png",
+                "width": 320,
+                "height": 180,
+                "format": "PNG",
+                "note": "封面图",
+            }
+        ],
+    )
+    context = _build_notice_context(
+        _build_provider_request(
+            '把这张图加到 document_id="doc-1" 里',
+            tool_names=["add_blocks"],
+        ),
+    )
+
+    context = await service.append_document_tool_guide_notice(context)
+
+    assert context.section_names == [
+        SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
+        SECTION_SCENE_IMAGE_ASSETS,
+    ]
+    assert "当前 `document_id=doc-1` 仍是 draft" in context.notices[0]
+    assert "`images/img_20260531_ab12cd34.png`" in context.notices[1]
+    assert "封面图" in context.notices[1]
 
 
 @pytest.mark.asyncio
@@ -6270,6 +6307,59 @@ async def test_incoming_message_service_caches_image_file_as_pending():
 
 
 @pytest.mark.asyncio
+async def test_incoming_message_service_caches_image_file_by_path_when_name_missing():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = True
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    file_comp = Comp.File(name="", file="C:/tmp/avatar.png")
+    event.message_obj.message = [file_comp]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_called_once_with(event, file_comp)
+    assert event._has_pending_images is True
+    message_buffer.is_buffering.assert_not_called()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_incoming_message_service_caches_image_file_by_mime_when_name_generic():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = True
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    file_comp = Comp.File(name="file", file="file")
+    object.__setattr__(file_comp, "mime_type", "image/png")
+    event.message_obj.message = [file_comp]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_called_once_with(event, file_comp)
+    assert event._has_pending_images is True
+    message_buffer.is_buffering.assert_not_called()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_incoming_message_service_caches_image_component_as_pending():
     message_buffer = MagicMock()
     message_buffer.add_message = AsyncMock(return_value=True)
@@ -6420,6 +6510,29 @@ async def test_incoming_message_service_remembers_plain_text_when_no_buffer_acti
     message_buffer.is_buffering.assert_called_once_with(event)
     message_buffer.add_message.assert_not_awaited()
     event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_message_buffer_restarts_timer_when_wait_override_changes():
+    buffer = MessageBuffer(wait_seconds=30)
+    event = _build_event()
+    event.message_obj.message = [Comp.File(name="report.docx", file="report.docx")]
+
+    assert await buffer.add_message(event, wait_seconds=30)
+    key = buffer._get_buffer_key(event)
+    first_task = buffer._buffers[key].timer_task
+    assert first_task is not None
+
+    follow_up = _build_event()
+    follow_up.message_obj.message = [Comp.Plain("补充说明")]
+    assert await buffer.add_message(follow_up, wait_seconds=5)
+
+    updated = buffer._buffers[key]
+    assert updated.wait_seconds == 5
+    assert updated.timer_task is not first_task
+    assert first_task.done()
+
+    await buffer.cancel_buffer(event)
 
 
 @pytest.mark.asyncio

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -65,6 +65,7 @@ from astrbot_plugin_office_assistant.services.image_asset_service import (
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
     SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
+    SECTION_SCENE_IMAGE_ASSETS,
     SECTION_SCENE_UPLOADED_CONTEXT,
     SECTION_STATIC_DOCUMENT_TOOLS,
     SECTION_STATIC_DOCUMENT_TOOLS_DETAIL,
@@ -4442,6 +4443,32 @@ def test_prompt_context_service_build_section_trace_tolerates_length_mismatch():
     assert f"[len={SECTION_STATIC_DOCUMENT_TOOLS}:11]" in trace
     assert "[groups=static:11]" in trace
     assert "[total=11]" in trace
+
+
+def test_prompt_context_service_limits_image_assets_section():
+    service = PromptContextService(allow_external_input_files=False)
+    long_note = "这是一段很长的图片备注" * 12
+    images = [
+        {
+            "ref": f"images/img_{idx:02d}.png",
+            "width": 10,
+            "height": 10,
+            "format": "PNG",
+            "note": long_note,
+        }
+        for idx in range(14)
+    ]
+
+    section = service.build_image_assets_section(images=images)
+
+    assert section is not None
+    assert section.name == SECTION_SCENE_IMAGE_ASSETS
+    assert "另有 2 张较早图片未列出" in section.content
+    assert "`images/img_00.png`" not in section.content
+    assert "`images/img_01.png`" not in section.content
+    assert "`images/img_02.png`" in section.content
+    assert long_note not in section.content
+    assert "…" in section.content
 
 
 def test_upload_prompt_service_builds_instructional_notice_for_readable_files():

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -6787,6 +6787,27 @@ async def test_message_buffer_pop_images_preserves_files_and_texts():
 
 
 @pytest.mark.asyncio
+async def test_message_buffer_pop_images_extracts_image_file_components():
+    buffer = MessageBuffer(wait_seconds=30)
+    event = _build_event()
+    upload = Comp.File(name="report.docx", file="report.docx")
+    image_file = Comp.File(name="avatar.jpg", file="avatar.jpg")
+    event.message_obj.message = [upload, image_file, Comp.Plain("整理一下")]
+
+    assert await buffer.add_message(event, wait_seconds=30)
+
+    images = await buffer.pop_images(event)
+    key = buffer._get_buffer_key(event)
+    remaining = buffer._buffers[key]
+    assert images == [image_file]
+    assert remaining.files == [upload]
+    assert remaining.images == []
+    assert remaining.texts == ["整理一下"]
+
+    await buffer.cancel_buffer(event)
+
+
+@pytest.mark.asyncio
 async def test_message_buffer_pop_images_removes_image_only_buffer():
     buffer = MessageBuffer(wait_seconds=30)
     event = _build_event()

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -6597,6 +6597,42 @@ async def test_message_buffer_restarts_timer_when_wait_override_changes():
 
 
 @pytest.mark.asyncio
+async def test_message_buffer_pop_images_preserves_files_and_texts():
+    buffer = MessageBuffer(wait_seconds=30)
+    event = _build_event()
+    upload = Comp.File(name="report.docx", file="report.docx")
+    image = Comp.Image(file="avatar.png")
+    event.message_obj.message = [upload, image, Comp.Plain("整理一下")]
+
+    assert await buffer.add_message(event, wait_seconds=30)
+
+    images = await buffer.pop_images(event)
+    key = buffer._get_buffer_key(event)
+    remaining = buffer._buffers[key]
+    assert images == [image]
+    assert remaining.files == [upload]
+    assert remaining.images == []
+    assert remaining.texts == ["整理一下"]
+
+    await buffer.cancel_buffer(event)
+
+
+@pytest.mark.asyncio
+async def test_message_buffer_pop_images_removes_image_only_buffer():
+    buffer = MessageBuffer(wait_seconds=30)
+    event = _build_event()
+    image = Comp.Image(file="avatar.png")
+    event.message_obj.message = [image]
+
+    assert await buffer.add_message(event, wait_seconds=30)
+
+    images = await buffer.pop_images(event)
+    key = buffer._get_buffer_key(event)
+    assert images == [image]
+    assert key not in buffer._buffers
+
+
+@pytest.mark.asyncio
 async def test_error_hook_service_uses_event_session_when_target_not_configured():
     context = MagicMock()
     context.send_message = AsyncMock(return_value=True)

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -6270,6 +6270,87 @@ async def test_incoming_message_service_caches_image_file_as_pending():
 
 
 @pytest.mark.asyncio
+async def test_incoming_message_service_caches_image_component_as_pending():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = True
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    image_comp = Comp.Image(file="avatar.png")
+    event.message_obj.message = [image_comp]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_called_once_with(event, image_comp)
+    assert event._has_pending_images is True
+    assert event._pending_image_resources == [image_comp]
+    remember_recent_text.assert_not_called()
+    message_buffer.is_buffering.assert_not_called()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_incoming_message_service_does_not_cache_image_with_command_text():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = False
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    image_comp = Comp.Image(file="avatar.png")
+    event.message_obj.message = [image_comp, Comp.Plain("/img list")]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_not_called()
+    remember_recent_text.assert_called_once_with(event)
+    message_buffer.is_buffering.assert_called_once_with(event)
+    message_buffer.add_message.assert_not_awaited()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_incoming_message_service_does_not_cache_unsupported_image_file():
+    message_buffer = MagicMock()
+    message_buffer.add_message = AsyncMock(return_value=True)
+    message_buffer.is_buffering.return_value = False
+    remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
+    service = IncomingMessageService(
+        message_buffer=message_buffer,
+        remember_recent_text=remember_recent_text,
+        is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
+    )
+    event = _build_event()
+    event.stop_event = MagicMock()
+    event.message_obj.message = [Comp.File(name="avatar.gif", file="avatar.gif")]
+
+    await service.handle_file_message(event)
+
+    cache_pending.assert_not_called()
+    remember_recent_text.assert_called_once_with(event)
+    message_buffer.is_buffering.assert_called_once_with(event)
+    message_buffer.add_message.assert_not_awaited()
+    event.stop_event.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_incoming_message_service_buffers_follow_up_plain_text_while_file_waits():
     message_buffer = MagicMock()
     message_buffer.add_message = AsyncMock(return_value=True)

--- a/tests/test_office_assistant_services.py
+++ b/tests/test_office_assistant_services.py
@@ -59,6 +59,9 @@ from astrbot_plugin_office_assistant.services.runtime_builder import (
 from astrbot_plugin_office_assistant.services.excel_intent_router import (
     ExcelIntentRouter,
 )
+from astrbot_plugin_office_assistant.services.image_asset_service import (
+    ImageAssetService,
+)
 from astrbot_plugin_office_assistant.services.prompt_context_service import (
     SECTION_DYNAMIC_DOCUMENT_FOLLOW_UP,
     SECTION_DYNAMIC_WORKBOOK_FOLLOW_UP,
@@ -349,6 +352,7 @@ def _build_command_service(
     auto_block_execution_tools: bool = True,
     allow_local_excel_script: bool = False,
     reply_to_user: bool = True,
+    image_asset_service=None,
     is_group_feature_enabled=None,
     check_permission=None,
     group_feature_disabled_error=None,
@@ -372,7 +376,7 @@ def _build_command_service(
         allow_local_excel_script=allow_local_excel_script,
         reply_to_user=reply_to_user,
         upload_session_service=upload_session_service or MagicMock(),
-        image_asset_service=MagicMock(),
+        image_asset_service=image_asset_service or MagicMock(),
         is_group_feature_enabled=is_group_feature_enabled or (lambda _event: True),
         is_all_users_allowed=lambda: allow_all_users,
         check_permission=check_permission or (lambda _event: True),
@@ -654,6 +658,13 @@ def _write_png(path: Path) -> None:
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aF9kAAAAASUVORK5CYII="
     )
     path.write_bytes(png_bytes)
+
+
+def _write_valid_png(path: Path, *, color: str = "red") -> None:
+    from PIL import Image
+
+    img = Image.new("RGB", (10, 10), color=color)
+    img.save(path, format="PNG")
 
 
 def _import_docx():
@@ -5176,6 +5187,71 @@ async def test_command_service_doc_use_supports_multiple_file_ids():
         assert "根据这些文件整理成正式汇报" in queued_event.message_str
 
 
+def test_command_service_img_add_treats_single_numeric_argument_as_note():
+    upload_session_service = _build_upload_session_service()
+
+    with _managed_workspace_service(name="command-img-single-note") as managed:
+        image_asset_service = ImageAssetService(plugin_data_path=managed.workspace_dir)
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
+            upload_session_service=upload_session_service,
+            image_asset_service=image_asset_service,
+        )
+        image_path = managed.workspace_dir / "sample.png"
+        _write_valid_png(image_path)
+
+        event = _build_event(sender_id="user-a")
+        result = service.img_add(
+            event,
+            source_items=[(image_path, "sample.png")],
+            selection="2",
+        )
+
+        images = image_asset_service.list_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        assert "已注册 1 张图片" in result
+        assert len(images) == 1
+        assert images[0]["note"] == "2"
+        assert images[0]["original_name"] == "sample.png"
+
+
+def test_command_service_img_add_keeps_numeric_selector_for_multiple_images():
+    upload_session_service = _build_upload_session_service()
+
+    with _managed_workspace_service(name="command-img-multi-select") as managed:
+        image_asset_service = ImageAssetService(plugin_data_path=managed.workspace_dir)
+        service = _build_command_service(
+            workspace_service=managed.workspace_service,
+            plugin_data_path=managed.workspace_dir,
+            upload_session_service=upload_session_service,
+            image_asset_service=image_asset_service,
+        )
+        first_image = managed.workspace_dir / "first.png"
+        second_image = managed.workspace_dir / "second.png"
+        _write_valid_png(first_image, color="red")
+        _write_valid_png(second_image, color="blue")
+
+        event = _build_event(sender_id="user-a")
+        result = service.img_add(
+            event,
+            source_items=[
+                (first_image, "first.png"),
+                (second_image, "second.png"),
+            ],
+            selection="2",
+        )
+
+        images = image_asset_service.list_images(
+            upload_session_service.get_attachment_session_key(event)
+        )
+        assert "已注册 1 张图片" in result
+        assert len(images) == 1
+        assert images[0]["note"] == ""
+        assert images[0]["original_name"] == "second.png"
+
+
 @pytest.mark.asyncio
 async def test_upload_session_service_requeue_uses_configured_wake_prefix():
     context = MagicMock()
@@ -6125,6 +6201,7 @@ async def test_incoming_message_service_buffers_supported_file_and_stops_event()
         message_buffer=message_buffer,
         remember_recent_text=remember_recent_text,
         is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=MagicMock(),
     )
     event = _build_event()
     event.stop_event = MagicMock()
@@ -6138,25 +6215,28 @@ async def test_incoming_message_service_buffers_supported_file_and_stops_event()
 
 
 @pytest.mark.asyncio
-async def test_incoming_message_service_ignores_non_file_messages_during_buffer():
+async def test_incoming_message_service_caches_image_file_as_pending():
     message_buffer = MagicMock()
     message_buffer.add_message = AsyncMock(return_value=True)
     message_buffer.is_buffering.return_value = True
     remember_recent_text = MagicMock()
+    cache_pending = MagicMock()
     service = IncomingMessageService(
         message_buffer=message_buffer,
         remember_recent_text=remember_recent_text,
         is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=cache_pending,
     )
     event = _build_event()
     event.stop_event = MagicMock()
-    event.message_obj.message = [Comp.File(name="avatar.png", file="avatar.png")]
+    file_comp = Comp.File(name="avatar.png", file="avatar.png")
+    event.message_obj.message = [file_comp]
 
     await service.handle_file_message(event)
 
+    cache_pending.assert_called_once_with(event, file_comp)
     remember_recent_text.assert_not_called()
-    message_buffer.is_buffering.assert_called_once_with(event)
-    message_buffer.add_message.assert_not_awaited()
+    message_buffer.is_buffering.assert_not_called()
     event.stop_event.assert_not_called()
 
 
@@ -6170,6 +6250,7 @@ async def test_incoming_message_service_buffers_follow_up_plain_text_while_file_
         message_buffer=message_buffer,
         remember_recent_text=remember_recent_text,
         is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=MagicMock(),
     )
     event = _build_event()
     event.stop_event = MagicMock()
@@ -6193,6 +6274,7 @@ async def test_incoming_message_service_ignores_command_like_text_while_file_wai
         message_buffer=message_buffer,
         remember_recent_text=remember_recent_text,
         is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=MagicMock(),
     )
     event = _build_event()
     event.stop_event = MagicMock()
@@ -6216,6 +6298,7 @@ async def test_incoming_message_service_remembers_plain_text_when_no_buffer_acti
         message_buffer=message_buffer,
         remember_recent_text=remember_recent_text,
         is_group_feature_enabled=lambda _event: True,
+        cache_pending_image_resource=MagicMock(),
     )
     event = _build_event()
     event.stop_event = MagicMock()

--- a/tests/test_office_assistant_session_store.py
+++ b/tests/test_office_assistant_session_store.py
@@ -14,6 +14,7 @@ from astrbot_plugin_office_assistant.document_core.models.blocks import (
     BusinessReviewCoverData,
     GroupBlock,
     HeroBannerBlock,
+    ImageBlock,
     PageTemplateBlock,
     ParagraphBlock,
 )
@@ -30,6 +31,7 @@ from astrbot_plugin_office_assistant.domain.document.contracts import (
     CreateDocumentRequest,
     ExportDocumentRequest,
     FinalizeDocumentRequest,
+    ImageInput,
     SectionListInput,
     SectionParagraphInput,
     SectionTableInput,
@@ -732,3 +734,71 @@ def test_document_session_store_builds_prompt_summary_with_unknown_block_type():
     summary = DocumentSessionStore._build_prompt_summary_locked(document)
 
     assert summary["latest_block_types"] == ["unknown"]
+
+
+def _register_workspace_image(workspace_dir: Path, name: str) -> str:
+    images_dir = workspace_dir / "images"
+    images_dir.mkdir(parents=True, exist_ok=True)
+    _write_png(images_dir / name, width=10, height=10)
+    return f"images/{name}"
+
+
+def test_add_blocks_drops_adjacent_duplicate_image_across_calls(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-dup-image-across-calls")
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    ref = _register_workspace_image(workspace_dir, "img_dup.png")
+    document = store.create_document(CreateDocumentRequest(title="测试图片展示"))
+
+    store.add_blocks(
+        AddBlocksRequest(
+            document_id=document.document_id,
+            blocks=[BlockHeadingInput(text="标题"), ImageInput(path=ref)],
+        )
+    )
+    store.add_blocks(
+        AddBlocksRequest(
+            document_id=document.document_id,
+            blocks=[ImageInput(path=ref)],
+        )
+    )
+
+    image_blocks = [b for b in document.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 1
+
+
+def test_add_blocks_drops_adjacent_duplicate_image_within_batch(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-dup-image-within-batch")
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    ref = _register_workspace_image(workspace_dir, "img_dup.png")
+    document = store.create_document(CreateDocumentRequest(title="批内重复"))
+
+    store.add_blocks(
+        AddBlocksRequest(
+            document_id=document.document_id,
+            blocks=[ImageInput(path=ref), ImageInput(path=ref)],
+        )
+    )
+
+    image_blocks = [b for b in document.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 1
+
+
+def test_add_blocks_keeps_same_image_when_not_adjacent(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-dup-image-not-adjacent")
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    ref = _register_workspace_image(workspace_dir, "img_reuse.png")
+    document = store.create_document(CreateDocumentRequest(title="非相邻复用"))
+
+    store.add_blocks(
+        AddBlocksRequest(
+            document_id=document.document_id,
+            blocks=[
+                ImageInput(path=ref),
+                BlockHeadingInput(text="中间章节"),
+                ImageInput(path=ref),
+            ],
+        )
+    )
+
+    image_blocks = [b for b in document.blocks if isinstance(b, ImageBlock)]
+    assert len(image_blocks) == 2

--- a/tests/test_office_assistant_session_store.py
+++ b/tests/test_office_assistant_session_store.py
@@ -32,6 +32,7 @@ from astrbot_plugin_office_assistant.domain.document.contracts import (
     ExportDocumentRequest,
     FinalizeDocumentRequest,
     ImageInput,
+    ImageSlideInput,
     SectionListInput,
     SectionParagraphInput,
     SectionTableInput,
@@ -741,6 +742,44 @@ def _register_workspace_image(workspace_dir: Path, name: str) -> str:
     images_dir.mkdir(parents=True, exist_ok=True)
     _write_png(images_dir / name, width=10, height=10)
     return f"images/{name}"
+
+
+def test_add_blocks_raises_for_missing_image_path(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-missing-image-path")
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    document = store.create_document(CreateDocumentRequest(title="Missing image path"))
+
+    with pytest.raises(ValueError, match="图片文件不存在"):
+        store.add_blocks(
+            AddBlocksRequest(
+                document_id=document.document_id,
+                blocks=[
+                    BlockHeadingInput(text="Heading"),
+                    ImageInput(path="images/nonexistent.png"),
+                ],
+            )
+        )
+
+
+def test_add_blocks_raises_for_missing_image_slide_path(workspace_root: Path):
+    workspace_dir = _make_workspace(workspace_root, "pytest-missing-image-slide-path")
+    store = DocumentSessionStore(workspace_dir=workspace_dir)
+    document = store.create_document(
+        CreateDocumentRequest(title="Missing slide image", format="ppt")
+    )
+
+    with pytest.raises(ValueError, match="图片文件不存在"):
+        store.add_blocks(
+            AddBlocksRequest(
+                document_id=document.document_id,
+                blocks=[
+                    ImageSlideInput(
+                        image_path="images/nonexistent-slide.png",
+                        title="Slide 1",
+                    )
+                ],
+            )
+        )
 
 
 def test_add_blocks_drops_adjacent_duplicate_image_across_calls(workspace_root: Path):

--- a/tests/test_office_assistant_session_store.py
+++ b/tests/test_office_assistant_session_store.py
@@ -761,6 +761,17 @@ def test_add_blocks_raises_for_missing_image_path(workspace_root: Path):
         )
 
 
+def test_image_input_rejects_non_asset_path():
+    with pytest.raises(Exception, match="images/"):
+        ImageInput(path="outside/image.png")
+
+
+def test_image_input_accepts_asset_ref():
+    image = ImageInput(path="images/img_20260531_ab12cd34.png")
+
+    assert image.path == "images/img_20260531_ab12cd34.png"
+
+
 def test_add_blocks_raises_for_missing_image_slide_path(workspace_root: Path):
     workspace_dir = _make_workspace(workspace_root, "pytest-missing-image-slide-path")
     store = DocumentSessionStore(workspace_dir=workspace_dir)

--- a/tests/test_office_assistant_workbook_tools.py
+++ b/tests/test_office_assistant_workbook_tools.py
@@ -416,7 +416,11 @@ async def test_write_rows_tool_passes_options_to_store(workspace_root: Path):
             workbook_id=workbook.workbook_id,
             sheet="Data",
             rows=[["h1", "h2"], ["v1", "v2"]],
-            options={"freeze_panes": "A2", "column_widths": {"A": 20}, "autofilter": True},
+            options={
+                "freeze_panes": "A2",
+                "column_widths": {"A": 20},
+                "autofilter": True,
+            },
         )
     )
 

--- a/tools/astrbot_adapter.py
+++ b/tools/astrbot_adapter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -58,6 +58,7 @@ def build_document_toolset_from_registry(
     after_export_hooks: list[AfterExportHook] | None = None,
     render_backend_config: DocumentRenderBackendConfig | None = None,
     default_document_style: dict[str, object] | None = None,
+    image_ref_validator: Callable[[object, str], None] | None = None,
 ) -> DocumentToolSet:
     store = build_document_store(
         workspace_dir=workspace_dir,
@@ -75,6 +76,10 @@ def build_document_toolset_from_registry(
         )
         for spec in get_document_tool_specs()
     ]
+    if image_ref_validator is not None:
+        for tool in tools:
+            if hasattr(tool, "image_ref_validator"):
+                tool.image_ref_validator = image_ref_validator
     return DocumentToolSet(tools, document_store=store)
 
 

--- a/word_renderer_js/package-lock.json
+++ b/word_renderer_js/package-lock.json
@@ -11,6 +11,7 @@
         "ajv": "^8.17.1",
         "docx": "^9.5.1",
         "docxtemplater": "^3.67.1",
+        "image-size": "^2.0.2",
         "pizzip": "^3.2.0",
         "pptxgenjs": "^4.0.0"
       },
@@ -142,13 +143,10 @@
       "license": "ISC"
     },
     "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
       "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
       "bin": {
         "image-size": "bin/image-size.js"
       },
@@ -256,6 +254,21 @@
         "https": "^1.0.0",
         "image-size": "^1.2.1",
         "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/process-nextick-args": {

--- a/word_renderer_js/package.json
+++ b/word_renderer_js/package.json
@@ -10,6 +10,7 @@
     "ajv": "^8.17.1",
     "docx": "^9.5.1",
     "docxtemplater": "^3.67.1",
+    "image-size": "^2.0.2",
     "pizzip": "^3.2.0",
     "pptxgenjs": "^4.0.0"
   },

--- a/word_renderer_js/src/renderers/ppt/blocks.ts
+++ b/word_renderer_js/src/renderers/ppt/blocks.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { imageSize } from "image-size";
 import pptxgen from "pptxgenjs";
 
 import { JsonObject } from "../../core/payload";
@@ -268,13 +269,13 @@ function renderImageSlide(
   }
 
   const imageH = caption ? 3.5 : 4.0;
+  const imageBox = fitImageInBox(imagePath, 1.0, imageY, 8.0, imageH);
   slide.addImage({
     path: imagePath,
-    x: 1.0,
-    y: imageY,
-    w: 8.0,
-    h: imageH,
-    sizing: { type: "contain", w: 8.0, h: imageH },
+    x: imageBox.x,
+    y: imageBox.y,
+    w: imageBox.w,
+    h: imageBox.h,
   });
 
   if (caption) {
@@ -290,4 +291,27 @@ function renderImageSlide(
       italic: true,
     });
   }
+}
+
+function fitImageInBox(
+  imagePath: string,
+  boxX: number,
+  boxY: number,
+  boxW: number,
+  boxH: number,
+): { x: number; y: number; w: number; h: number } {
+  const imageData = fs.readFileSync(imagePath);
+  const dimensions = imageSize(imageData);
+  const naturalW = dimensions.width || 1;
+  const naturalH = dimensions.height || 1;
+  const scale = Math.min(boxW / naturalW, boxH / naturalH);
+  const w = naturalW * scale;
+  const h = naturalH * scale;
+
+  return {
+    x: boxX + (boxW - w) / 2,
+    y: boxY + (boxH - h) / 2,
+    w,
+    h,
+  };
 }

--- a/word_renderer_js/src/renderers/structured/image.ts
+++ b/word_renderer_js/src/renderers/structured/image.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { AlignmentType, ImageRun, Paragraph, TextRun } from "docx";
+import { imageSize } from "image-size";
 
 import { RenderCliError } from "../../core/errors";
 import { Block, FileChild, ThemeConfig } from "./types";
@@ -48,9 +49,20 @@ export function renderImageBlock(
   const imageData = fs.readFileSync(resolvedPath);
 
   const maxWidthPx = 580;
-  const displayWidth = widthPx && widthPx > 0
-    ? Math.min(widthPx, maxWidthPx)
-    : maxWidthPx;
+  let displayWidth: number;
+  let displayHeight: number;
+
+  const dimensions = imageSize(imageData);
+  const naturalWidth = dimensions.width || 580;
+  const naturalHeight = dimensions.height || 580;
+
+  if (widthPx && widthPx > 0) {
+    displayWidth = Math.min(widthPx, maxWidthPx);
+  } else {
+    displayWidth = Math.min(naturalWidth, maxWidthPx);
+  }
+  const scale = displayWidth / naturalWidth;
+  displayHeight = Math.round(naturalHeight * scale);
 
   const elements: FileChild[] = [];
 
@@ -62,7 +74,7 @@ export function renderImageBlock(
           data: imageData,
           transformation: {
             width: displayWidth,
-            height: displayWidth,
+            height: displayHeight,
           },
           altText: {
             title: caption || path.basename(imagePath),

--- a/word_renderer_js/src/renderers/structured/image.ts
+++ b/word_renderer_js/src/renderers/structured/image.ts
@@ -56,6 +56,21 @@ export function renderImageBlock(
   const naturalWidth = dimensions.width || 580;
   const naturalHeight = dimensions.height || 580;
 
+  type DocxImageType = "png" | "jpg" | "gif" | "bmp";
+  const typeMap: Record<string, DocxImageType> = {
+    png: "png",
+    jpg: "jpg",
+    gif: "gif",
+    bmp: "bmp",
+  };
+  const docxType = dimensions.type ? typeMap[dimensions.type] : undefined;
+  if (!docxType) {
+    throw new RenderCliError(
+      "UNSUPPORTED_IMAGE_TYPE",
+      `Unsupported image type for embedding: ${dimensions.type ?? "unknown"} (${imagePath}). Supported: png, jpg, gif, bmp.`,
+    );
+  }
+
   if (widthPx && widthPx > 0) {
     displayWidth = Math.min(widthPx, maxWidthPx);
   } else {
@@ -71,6 +86,7 @@ export function renderImageBlock(
       alignment: AlignmentType.CENTER,
       children: [
         new ImageRun({
+          type: docxType,
           data: imageData,
           transformation: {
             width: displayWidth,
@@ -81,7 +97,7 @@ export function renderImageBlock(
             description: caption || imagePath,
             name: path.basename(imagePath),
           },
-        } as ConstructorParameters<typeof ImageRun>[0]),
+        }),
       ],
     }),
   );

--- a/word_renderer_js/src/renderers/structured/image.ts
+++ b/word_renderer_js/src/renderers/structured/image.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { AlignmentType, ImageRun, Paragraph, TextRun } from "docx";
+
+import { RenderCliError } from "../../core/errors";
+import { Block, FileChild, ThemeConfig } from "./types";
+
+export function renderImageBlock(
+  block: Block,
+  theme: ThemeConfig,
+  workspaceDir: string,
+): FileChild[] {
+  const imagePath = (block.path as string) || "";
+  const caption = (block.caption as string) || "";
+  const widthPx = (block.width_px as number) || 0;
+
+  if (!imagePath) {
+    throw new RenderCliError(
+      "MISSING_IMAGE_PATH",
+      "image block requires a non-empty path",
+    );
+  }
+
+  if (!imagePath.startsWith("images/")) {
+    throw new RenderCliError(
+      "INVALID_IMAGE_PATH",
+      `image block path must start with "images/", got: ${imagePath}`,
+    );
+  }
+
+  const segments = imagePath.replace(/\\/g, "/").split("/");
+  if (segments.includes("..")) {
+    throw new RenderCliError(
+      "INVALID_IMAGE_PATH",
+      `image block path must not contain directory traversal (..): ${imagePath}`,
+    );
+  }
+
+  const resolvedPath = path.resolve(workspaceDir, imagePath);
+  if (!fs.existsSync(resolvedPath)) {
+    throw new RenderCliError(
+      "MISSING_IMAGE_FILE",
+      `Image file does not exist: ${resolvedPath}`,
+    );
+  }
+
+  const imageData = fs.readFileSync(resolvedPath);
+
+  const maxWidthPx = 580;
+  const displayWidth = widthPx && widthPx > 0
+    ? Math.min(widthPx, maxWidthPx)
+    : maxWidthPx;
+
+  const elements: FileChild[] = [];
+
+  elements.push(
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      children: [
+        new ImageRun({
+          data: imageData,
+          transformation: {
+            width: displayWidth,
+            height: displayWidth,
+          },
+          altText: {
+            title: caption || path.basename(imagePath),
+            description: caption || imagePath,
+            name: path.basename(imagePath),
+          },
+        } as ConstructorParameters<typeof ImageRun>[0]),
+      ],
+    }),
+  );
+
+  if (caption) {
+    elements.push(
+      new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { before: 80 },
+        children: [
+          new TextRun({
+            text: caption,
+            italics: true,
+            size: theme.bodySize - 2,
+            font: theme.fontName,
+          }),
+        ],
+      }),
+    );
+  }
+
+  return elements;
+}

--- a/word_renderer_js/src/renderers/structured/image.ts
+++ b/word_renderer_js/src/renderers/structured/image.ts
@@ -52,7 +52,16 @@ export function renderImageBlock(
   let displayWidth: number;
   let displayHeight: number;
 
-  const dimensions = imageSize(imageData);
+  let dimensions: ReturnType<typeof imageSize>;
+  try {
+    dimensions = imageSize(imageData);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new RenderCliError(
+      "UNSUPPORTED_IMAGE_TYPE",
+      `Unsupported image data for embedding: ${imagePath}. ${reason}`,
+    );
+  }
   const naturalWidth = dimensions.width || 580;
   const naturalHeight = dimensions.height || 580;
 

--- a/word_renderer_js/src/renderers/structured/image.ts
+++ b/word_renderer_js/src/renderers/structured/image.ts
@@ -52,16 +52,7 @@ export function renderImageBlock(
   let displayWidth: number;
   let displayHeight: number;
 
-  let dimensions: ReturnType<typeof imageSize>;
-  try {
-    dimensions = imageSize(imageData);
-  } catch (error) {
-    const reason = error instanceof Error ? error.message : String(error);
-    throw new RenderCliError(
-      "UNSUPPORTED_IMAGE_TYPE",
-      `Unsupported image data for embedding: ${imagePath}. ${reason}`,
-    );
-  }
+  const dimensions = readImageDimensions(imageData, imagePath);
   const naturalWidth = dimensions.width || 580;
   const naturalHeight = dimensions.height || 580;
 
@@ -129,4 +120,16 @@ export function renderImageBlock(
   }
 
   return elements;
+}
+
+function readImageDimensions(imageData: Uint8Array, imagePath: string) {
+  try {
+    return imageSize(imageData);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new RenderCliError(
+      "UNSUPPORTED_IMAGE_TYPE",
+      `Unsupported image data for embedding: ${imagePath}. ${reason}`,
+    );
+  }
 }

--- a/word_renderer_js/src/renderers/structured/index.ts
+++ b/word_renderer_js/src/renderers/structured/index.ts
@@ -21,6 +21,7 @@ import {
 } from "./blocks";
 import { renderAccentBox, renderMetricCards } from "./cards";
 import { renderHeroBannerBlock } from "./hero-banner";
+import { renderImageBlock } from "./image";
 import {
   EXTERNAL_WORD_STYLES_XML,
   ORDERED_NUMBERING_REFERENCE,
@@ -74,6 +75,8 @@ export async function renderStructuredDocument(
   const metadata = asObject(payload.metadata);
   const theme = resolveTheme(metadata);
   const structuredBlocks = payload.blocks.map((block) => block as Block);
+  const workspaceDir =
+    ((payload as Record<string, unknown>).workspace_dir as string) || "";
   const defaultHeaderFooter = asObject(metadata.header_footer);
   const defaultMargins = resolveDefaultSectionMargins(structuredBlocks);
   const sections: SectionState[] = [
@@ -99,6 +102,7 @@ export async function renderStructuredDocument(
     theme,
     sections,
     defaultHeaderFooter,
+    workspaceDir,
   );
 
   const doc = new Document({
@@ -160,6 +164,7 @@ function appendBlocksToSections(
   theme: ThemeConfig,
   sections: SectionState[],
   currentHeaderFooter: HeaderFooterConfig,
+  workspaceDir: string,
   hasTrailingContent = false,
   topLevelDeferredChildren?: FileChild[],
 ): HeaderFooterConfig {
@@ -191,6 +196,7 @@ function appendBlocksToSections(
         theme,
         sections,
         activeHeaderFooter,
+        workspaceDir,
         hasFollowingBlocks,
         deferredTrailingChildren,
       );
@@ -217,6 +223,7 @@ function appendBlocksToSections(
           theme,
           sections,
           activeHeaderFooter,
+          workspaceDir,
           hasFollowingBlocks || columnIndex < columns.length - 1,
           deferredTrailingChildren,
         );
@@ -231,7 +238,7 @@ function appendBlocksToSections(
         "Section state is empty",
       );
     }
-    section.children.push(...renderBlock(block, metadata, theme));
+    section.children.push(...renderBlock(block, metadata, theme, workspaceDir));
     const interBlockSpacingAfterPt = resolveInterBlockSpacingAfterPt(block, metadata);
     if (interBlockSpacingAfterPt > 0) {
       section.children.push(createSpacingParagraph({ afterPt: interBlockSpacingAfterPt }));
@@ -425,6 +432,7 @@ function renderBlock(
   block: Block,
   metadata: JsonObject,
   theme: ThemeConfig,
+  workspaceDir: string,
 ): FileChild[] {
   switch (block.type) {
     case "page_template":
@@ -449,6 +457,8 @@ function renderBlock(
       return [renderMetricCards(block, metadata, theme)];
     case "summary_card":
       return renderSummaryCard(block, metadata, theme);
+    case "image":
+      return renderImageBlock(block, theme, workspaceDir);
     default:
       throw new RenderCliError(
         "UNSUPPORTED_BLOCK",

--- a/word_renderer_js/src/schema/document_payload.schema.json
+++ b/word_renderer_js/src/schema/document_payload.schema.json
@@ -667,6 +667,34 @@
             "if": {
               "properties": {
                 "type": {
+                  "const": "image"
+                }
+              }
+            },
+            "then": {
+              "required": [
+                "path"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "^images/"
+                },
+                "caption": {
+                  "type": "string"
+                },
+                "width_px": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "type": {
                   "const": "title_slide"
                 }
               }


### PR DESCRIPTION
## Summary

Closes #72.

本 PR 引入会话级图片资源池，让 Word/PPT 文档工作流可以安全、稳定地引用用户上传图片，并补齐 Word/PPT 图片渲染链路。图片选择从“让模型在历史图片里猜”改为“当前活动图片集”机制，降低误用旧图的概率。

## Changes

- 新增图片资源池服务：
  - 支持注册、列出、修改备注、清理图片资源
  - 资源引用统一为 `images/...`
  - 拒绝绝对路径、目录穿越和未注册图片
  - WebP 注册时转存为 PNG，保证 Office 输出兼容
  - 维护当前会话的活动图片集，用于限定文档/PPT 工作流可直接使用的图片

- 新增 `/img` 命令组：
  - `/img add [备注]`
  - `/img list`
  - `/img active`
  - `/img use <引用或序号|all>`
  - `/img note <引用或序号> <备注>`
  - `/img clear [引用或序号|all]`
  - `/img add` 注册成功后会自动把本次注册图片设为当前活动图片
  - `/img use` 支持选择单张或多张图片作为当前活动集
  - 备注用于说明图片用途，活动集用于约束模型实际可选图片

- 接入上传链路：
  - 图片上传后先进入待注册缓存
  - 在配置时间内收到 `/img add` 则注册到资源池
  - 等待超时只放行当前 LLM 请求，不清理待注册图片；图片仍可在上传会话 TTL 内通过 `/img add` 注册
  - 单图场景下 `/img add 2` 会按备注 `2` 处理，多图场景仍保留数字选择语义
  - 混合上传文件和图片时，图片注册不会丢失仍在缓冲中的文件

- 接入文档工作流：
  - Prompt 中只注入当前活动图片，而不是全部历史注册图片
  - Word `image` block 和 PPT `image_slide` 只能使用资源池引用
  - 当存在活动图片集时，`add_blocks` / `add_slides` 会拒绝非活动图片引用，防止模型误用旧图片
  - 文档 session store 增加图片路径校验

- 补齐渲染器：
  - Word Node renderer 支持 image block 嵌入图片
  - PPT image_slide 支持资源池图片
  - 修复 PPT 图片被固定框拉伸的问题，改为按原图比例缩放并居中

- 配置与文档：
  - 新增 `image_llm_delay_seconds`
  - README 补充图片等待 `/img add` 的配置说明

## Validation

- `ruff format .`
- `ruff check .`
- `npm run build`
- `pytest` 相关图片资源池、上传缓存、Word/PPT 图片渲染、命令和提示词测试通过
- 已完成 E2E 测试并确认通过

## Notes

- SVG 仍不支持注册，错误提示会明确要求使用 PNG/JPEG/WebP。
- 图片资源池是会话级持久资源；如需避免历史图片干扰，可使用 `/img use` 切换活动图片，或 `/img clear` 清理旧图片。
- 已生成的旧 PPT 文件不会自动修复图片比例，需要重新导出。
## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

引入一个与文档工作流、具备图像感知的消息处理以及渲染管线集成的受管图像资源池，用于在 Word 和 PPT 生成中安全地注册、校验和使用会话作用域的图像。

新功能：
- 添加图像资源服务，支持按会话对上传图像进行注册、列出、记录备注和清理，通过受管的 `images/...` 路径进行引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc` 的帮助文本以支持管理与文档相关的资源。
- 使文档工具和会话存储能够接受并校验专用的图像块和幻灯片图像，这些图像只能引用受管图像资源，并支持对相邻重复图像进行去重。
- 扩展提示上下文和请求钩子，将当前会话的图像资源暴露给 LLM，以便其在文档工作流中选择有效图像。

增强：
- 更新 Word 渲染器以支持图像块的路径校验、嵌入、标题渲染和正确尺寸控制，并更新 PPT 渲染器以在图像幻灯片中保持图像纵横比。
- 优化上传和入站消息处理，将图像资源单独缓冲和缓存，略微延迟发送给 LLM 的请求以便执行 `/img add` 注册，并将非文本图像内容路由到图像资源池。
- 收紧跨契约、核心模型和渲染器的图像引用校验和路径处理，防止路径遍历、绝对路径或跨会话泄露。
- 将新的图像资源服务和引用校验接入运行时、文档工具和请求管线，使图像使用范围限定在当前会话，并存储在插件数据下。

构建：
- 新增对 `image-size` 的 JS 依赖，并扩展 Node 渲染器 schema，以支持引用工作区图像的结构化图像块。

文档：
- 更新 README 和静态提示文档，说明图像资源的使用方式、`/img` 工作流，以及新的 `image_llm_delay_seconds` 配置选项。

测试：
- 为图像资源服务、`/img` 命令行为、图像缓存和超时、Word/PPT 图像渲染、文档存储中的图像处理，以及工具和提示中的图像引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

**新特性：**
- 添加图像资源服务，用于注册、列出、注释、校验和清理会话范围内的图像资源，这些资源以 `images/...` 的形式被引用。
- 暴露新的 `/img` 命令组（add/list/note/clear/help），并扩展 `/doc`，在帮助文本中加入管理文档相关资源的说明。
- 允许文档工具和会话存储接受专用的 image blocks 和 `image_slide` 输入，这些输入必须使用受管的图像资源引用，并通过校验钩子强制检查会话所有权。
- 将当前会话的图像资源暴露到 LLM 提示上下文和请求钩子中，使模型在文档工作流中可以选择有效的图像。

**缺陷修复：**
- 修复 PPT `image_slide` 渲染，使图像保持其自然宽高比，而不是被拉伸以适应固定框架。

**增强改进：**
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题说明和大小控制的 image blocks；同时更新 PPT 渲染器，利用实际图像尺寸在图像幻灯片中保留宽高比。
- 收紧文档契约和运行时对图像路径的校验，拒绝绝对路径/路径遍历以及未注册引用，并在文档会话中去重相邻重复图像。
- 增强上传和入站消息处理，以检测图像文件/组件，将其缓存为 `/img add` 的待处理资源，并在短时间内延迟 LLM 请求，以便图像注册完成。
- 扩展消息缓冲，以支持图像并允许为每个缓冲区设置等待时间覆盖，同时改进请求钩子，在文档后续提示旁加入图像资源部分。
- 将新的图像资源服务和校验器接入运行时、请求管线和文档工具集，使图像存储在插件数据下，并被限制在当前会话内。
- 添加可配置的 `image_llm_delay_seconds` 设置，用于控制 LLM 请求在等待潜在 `/img add` 命令时的时长。

**构建：**
- 添加 `image-size` JavaScript 依赖，并扩展 Node 渲染器模式与实现，以支持具备尺寸感知布局的工作区 image blocks。

**文档：**
- 更新 README 和静态文档工具提示，描述图像资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置。

**测试：**
- 为图像资源服务添加大量测试，包括格式处理、会话隔离、持久化以及路径校验。
- 添加 `/img` 命令行为、待处理图像缓存与超时机制，以及在命令层与插件层中的图像选择语义测试。
- 扩展对请求钩子、提示上下文、文档工具、会话存储、消息缓冲、入站消息服务和渲染器的测试，以覆盖图像资源、校验和渲染行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个受管的图片资源池，并将其与文档工作流、消息处理和渲染集成，使 Word/PPT 生成可以安全地引用会话范围内的图片。

新特性：
- 添加一个图片资源服务，用于注册、列出、注释、校验以及清理通过 `managed images/...` 路径引用的会话范围图片。
- 暴露新的 `/img` 命令（add/list/note/clear/help），并扩展 `/doc` 帮助文本以管理与文档相关的资源，将其接入上传会话和命令处理流程。
- 允许文档工具、契约（contracts）和会话存储接受已验证的 image blocks 和 `image_slide` 输入，这些输入必须使用受管图片资源引用，并支持相邻重复图片去重以及按会话的验证钩子。
- 将当前会话的图片资源暴露到 LLM 提示（prompt）上下文和请求钩子中，使模型在文档工作流中可以选择有效图片。

Bug 修复：
- 修复 PPT `image_slide` 渲染，使图片保持其原始纵横比，而不是被拉伸以适配固定框架。

增强：
- 更新 Word 结构化渲染器，以嵌入带路径校验、标题和尺寸控制的 image blocks，并更新 PPT 渲染器以使用实际图片尺寸实现保持纵横比的布局。
- 收紧跨文档契约、核心模型和渲染器的图片路径校验，以拒绝绝对路径、路径遍历和未注册引用，并确保图片使用被限定在当前会话范围内。
- 增强上传和入站消息处理，以检测图片上传，将图片与文件分开缓冲/缓存，针对潜在的 `/img add` 注册短暂延迟 LLM 请求，并将非文本图片内容路由到图片资源池。
- 将图片资源服务和引用校验集成到运行时接线（runtime wiring）、文档工具和请求管道中，使图片存储在插件数据下，并受每个会话的约束。

构建：
- 添加 `image-size` JS 依赖，并扩展 Node 渲染器的 schema/实现，以支持引用工作区图片的结构化 image blocks。

文档：
- 更新 README 和静态提示文档，描述图片资源工作流、`/img` 命令以及新的 `image_llm_delay_seconds` 配置项。

测试：
- 为图片资源服务、`/img` 命令行为、图片缓冲与超时、Word/PPT 图片渲染、文档存储中的图片处理以及提示/工具的图片引用校验添加全面的单元和集成测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a managed image asset pool integrated with document workflows, message handling, and rendering so Word/PPT generation can safely reference session-scoped images.

New Features:
- Add an image asset service to register, list, annotate, validate, and clear session-scoped images referenced via managed images/... paths.
- Expose new /img commands (add/list/note/clear/help) and extend /doc help text to manage document-related resources, wiring them into upload sessions and command handling.
- Allow document tools, contracts, and session store to accept validated image blocks and image_slide inputs that must use managed image asset refs, with adjacent duplicate image de-duplication and per-session validation hooks.
- Surface current session image assets into LLM prompt context and request hooks so the model can choose valid images in document workflows.

Bug Fixes:
- Fix PPT image_slide rendering so images keep their natural aspect ratio instead of being stretched to fit a fixed frame.

Enhancements:
- Update Word structured renderer to embed image blocks with path validation, captions, and size control, and update the PPT renderer to use actual image dimensions for aspect-ratio-preserving layout.
- Tighten image path validation across document contracts, core models, and renderers to reject absolute paths, traversal, and unregistered refs, and ensure image usage is scoped to the current session.
- Enhance upload and incoming message handling to detect image uploads, buffer/cache them separately from files, delay LLM requests briefly for potential /img add registration, and route non-text image content into the image pool.
- Integrate the image asset service and ref validation into runtime wiring, document tools, and request pipeline so images live under plugin data and are constrained per session.

Build:
- Add an image-size JS dependency and extend the Node renderer schema/implementation to support structured image blocks referencing workspace images.

Documentation:
- Update README and static prompt documentation to describe the image asset workflow, /img commands, and the new image_llm_delay_seconds configuration option.

Tests:
- Add comprehensive unit and integration tests for the image asset service, /img command behavior, image buffering and timeouts, Word/PPT image rendering, document store image handling, and prompt/tool image ref validation.

</details>

</details>

</details>

</details>

</details>

</details>