### PR TITLE
fix: declare excel input file item schema

### DIFF
--- a/main.py
+++ b/main.py
@@ -369,7 +369,7 @@ class FileOperationPlugin(Star):
                 load_input_workbook、save_output_workbook、ensure_readable_sheet、
                 format_table_sheet、format_course_list_sheet、auto_format_workbook、
                 preserve_input_sheet_layout 等辅助函数。
-            input_files(array): 作为输入的 Excel 文件列表。
+            input_files(list[string]): 作为输入的 Excel 文件列表。
             output_name(string): 需要返回文件时的输出文件名。
         """
         effective_input_files = input_files

--- a/tests/test_office_assistant_before_llm_chat.py
+++ b/tests/test_office_assistant_before_llm_chat.py
@@ -37,6 +37,7 @@ import astrbot.api.message_components as Comp
 from astrbot.core.agent.tool import FunctionTool, ToolSet
 from astrbot.core.message.message_event_result import MessageEventResult
 from astrbot.core.platform.message_type import MessageType
+from astrbot.core.provider.register import llm_tools
 from astrbot.core.provider.entities import ProviderRequest
 from conftest import build_notice_once_callback as _build_notice_once_callback
 from tests._docx_test_helpers import _write_png
@@ -99,6 +100,15 @@ def _tool(name: str) -> FunctionTool:
         parameters={"type": "object", "properties": {}},
         handler=None,
     )
+
+
+def test_execute_excel_script_llm_tool_schema_declares_input_file_items():
+    tool = llm_tools.get_func("execute_excel_script")
+
+    assert tool is not None
+    input_files_schema = tool.parameters["properties"]["input_files"]
+    assert input_files_schema["type"] == "array"
+    assert input_files_schema["items"] == {"type": "string"}
 
 
 def _build_provider_request(


### PR DESCRIPTION
## Summary

修复 Gemini 在普通聊天请求阶段拒绝 execute_excel_script 工具 schema 的问题。

Gemini 要求 array 参数必须声明 items。此前 execute_excel_script.input_files 在 AstrBot 原生 @llm_tool docstring 里声明为 array，导致注册出来的工具 schema 缺少 items，从而在模型请求发出前报错：

parameters.properties[input_files].items: missing field

## Changes

将 execute_excel_script 的 input_files 类型声明从 array 改为 list[string]
让 AstrBot 注册出的工具 schema 包含 items: {"type": "string"}
增加原生 @llm_tool 注册路径的回归测试，避免只覆盖 document/workbook agent toolset 时漏掉这类问题

## Validation

```
python -m pytest tests/test_office_assistant_before_llm_chat.py::test_execute_excel_script_llm_tool_schema_declares_input_file_items tests/test_office_assistant_before_llm_chat.py::test_execute_excel_script_fills_single_uploaded_input_when_script_uses_input_files -q
ruff check .
git diff --check
```

## Notes

已在服务器热补丁验证，execute_excel_script.input_files 当前注册 schema 为 array of string。

## 由 Sourcery 提供的总结

确保 Excel 脚本执行工具在用于 LLM 工具注册时，正确声明其输入文件的模式（schema）。

Bug 修复：
- 修复 `execute_excel_script` 工具的模式定义，使 `input_files` 参数在注册时被声明为带有 `items` 定义的字符串数组。

测试：
- 添加回归测试，用于验证 `execute_excel_script.input_files` 在 LLM 工具模式中被暴露为字符串项的数组。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the Excel script execution tool correctly declares its input file schema for LLM tool registration.

Bug Fixes:
- Fix the execute_excel_script tool schema so the input_files parameter is registered as an array of strings with an items definition.

Tests:
- Add a regression test to verify execute_excel_script.input_files is exposed as an array of string items in the LLM tool schema.

</details>